### PR TITLE
ci(audit): fix failing cargo-audit job

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,16 @@
+# `cargo audit` configuration. Consumed by `rustsec/audit-check` in CI
+# (and by `cargo audit` locally). Keep the ignore list small and
+# justify every entry — ignores silently mask future real findings.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2026-0097: `rand` is unsound when a custom `log` logger
+    # calls `rand::rng()` from inside its log hook, while `ThreadRng`
+    # is attempting to reseed. We do not install any `log` logger
+    # (we use `tracing`) and never call `rand::rng()` from logging
+    # code paths, so this advisory does not apply to this binary.
+    # The advisory fires on rand 0.8.5 and 0.9.2, both pulled in
+    # transitively (governor / wiremock dev-dep). Re-check once those
+    # crates upgrade to rand >= 0.9.3 and drop this entry.
+    "RUSTSEC-2026-0097",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
 
   audit:
     runs-on: ubuntu-latest
+    # `rustsec/audit-check` posts findings via the GitHub Checks API, which
+    # requires `checks: write`. Without this the job fails with
+    # "Resource not accessible by integration" even when the advisory scan
+    # itself succeeds. `contents: read` is kept explicit so the default
+    # permission set does not widen unexpectedly.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "similar",
  "tempfile",
  "thiserror",
@@ -1054,16 +1054,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1687,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,21 +1709,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -2082,6 +2070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,12 +2111,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,10 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+# `serde_norway` is the actively-maintained serde_yaml fork recommended by
+# RUSTSEC-2025-0067 / RUSTSEC-2025-0068 after `serde_yml` / `libyml` were
+# archived as unsound. API-compatible with the original `serde_yaml`.
+serde_norway = "0.9"
 
 # Errors
 thiserror = "2"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,10 +46,11 @@ impl ConfigFile {
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
         let bytes = std::fs::read_to_string(path)?;
-        let cfg: ConfigFile = serde_yml::from_str(&bytes).map_err(|source| Error::YamlParse {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        let cfg: ConfigFile =
+            serde_norway::from_str(&bytes).map_err(|source| Error::YamlParse {
+                path: path.to_path_buf(),
+                source,
+            })?;
         cfg.validate_static()?;
         Ok(cfg)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     YamlParse {
         path: PathBuf,
         #[source]
-        source: serde_yml::Error,
+        source: serde_norway::Error,
     },
 
     #[error("CSV parse error in {path}: {source}")]

--- a/src/fs/catalog_io.rs
+++ b/src/fs/catalog_io.rs
@@ -94,7 +94,7 @@ pub fn load_all_schemas(catalogs_root: &Path) -> Result<Vec<Catalog>> {
 /// ignored, in line with IMPLEMENTATION.md §2.5.
 pub fn read_schema_file(path: &Path) -> Result<Catalog> {
     let bytes = std::fs::read_to_string(path)?;
-    let cat: Catalog = serde_yml::from_str(&bytes).map_err(|source| Error::YamlParse {
+    let cat: Catalog = serde_norway::from_str(&bytes).map_err(|source| Error::YamlParse {
         path: path.to_path_buf(),
         source,
     })?;
@@ -115,7 +115,7 @@ pub fn save_schema(catalogs_root: &Path, catalog: &Catalog) -> Result<()> {
     let path = dir.join(SCHEMA_FILE_NAME);
 
     let normalized = catalog.normalized();
-    let yaml = serde_yml::to_string(&normalized).map_err(|e| Error::InvalidFormat {
+    let yaml = serde_norway::to_string(&normalized).map_err(|e| Error::InvalidFormat {
         path: path.clone(),
         message: format!("yaml serialization failed: {e}"),
     })?;

--- a/src/fs/frontmatter.rs
+++ b/src/fs/frontmatter.rs
@@ -33,7 +33,7 @@ where
         message: "missing closing `---` frontmatter fence".into(),
     })?;
 
-    let parsed: T = serde_yml::from_str(yaml).map_err(|source| Error::YamlParse {
+    let parsed: T = serde_norway::from_str(yaml).map_err(|source| Error::YamlParse {
         path: path.to_path_buf(),
         source,
     })?;
@@ -44,7 +44,7 @@ where
 /// inverse of [`parse`]. Always emits LF line endings and ensures the
 /// frontmatter section ends with a newline before the closing fence.
 pub fn render<T: Serialize>(path: &Path, frontmatter: &T, body: &str) -> Result<String> {
-    let yaml = serde_yml::to_string(frontmatter).map_err(|e| Error::InvalidFormat {
+    let yaml = serde_norway::to_string(frontmatter).map_err(|e| Error::InvalidFormat {
         path: path.to_path_buf(),
         message: format!("frontmatter serialization failed: {e}"),
     })?;

--- a/src/resource/catalog.rs
+++ b/src/resource/catalog.rs
@@ -115,14 +115,14 @@ mod tests {
                 },
             ],
         };
-        let yaml = serde_yml::to_string(&cat).unwrap();
-        let parsed: Catalog = serde_yml::from_str(&yaml).unwrap();
+        let yaml = serde_norway::to_string(&cat).unwrap();
+        let parsed: Catalog = serde_norway::from_str(&yaml).unwrap();
         assert_eq!(cat, parsed);
     }
 
     #[test]
     fn catalog_field_type_serializes_snake_case() {
-        let yaml = serde_yml::to_string(&CatalogFieldType::Boolean).unwrap();
+        let yaml = serde_norway::to_string(&CatalogFieldType::Boolean).unwrap();
         assert_eq!(yaml.trim(), "boolean");
     }
 
@@ -132,7 +132,7 @@ mod tests {
         // know about, the catalog should still parse — the unknown type
         // round-trips as "unknown" rather than crashing the entire export.
         let yaml = "name: future\nfields:\n  - name: x\n    type: hyperlink\n";
-        let cat: Catalog = serde_yml::from_str(yaml).unwrap();
+        let cat: Catalog = serde_norway::from_str(yaml).unwrap();
         assert_eq!(cat.fields[0].field_type, CatalogFieldType::Unknown);
         assert_eq!(cat.fields[0].field_type.as_str(), "unknown");
     }
@@ -151,7 +151,7 @@ fields:
   - name: score
     type: number
 ";
-        let cat: Catalog = serde_yml::from_str(yaml).unwrap();
+        let cat: Catalog = serde_norway::from_str(yaml).unwrap();
         assert_eq!(cat.fields.len(), 3);
         assert_eq!(cat.fields[0].field_type, CatalogFieldType::String);
         assert_eq!(cat.fields[1].field_type, CatalogFieldType::Unknown);
@@ -165,7 +165,7 @@ fields:
             description: None,
             fields: vec![],
         };
-        let yaml = serde_yml::to_string(&cat).unwrap();
+        let yaml = serde_norway::to_string(&cat).unwrap();
         assert!(!yaml.contains("description"));
     }
 

--- a/src/resource/content_block.rs
+++ b/src/resource/content_block.rs
@@ -38,14 +38,14 @@ mod tests {
             tags: vec!["pr".into()],
             state: ContentBlockState::Active,
         };
-        let yaml = serde_yml::to_string(&cb).unwrap();
-        let parsed: ContentBlock = serde_yml::from_str(&yaml).unwrap();
+        let yaml = serde_norway::to_string(&cb).unwrap();
+        let parsed: ContentBlock = serde_norway::from_str(&yaml).unwrap();
         assert_eq!(cb, parsed);
     }
 
     #[test]
     fn state_serializes_snake_case() {
-        let s = serde_yml::to_string(&ContentBlockState::Draft).unwrap();
+        let s = serde_norway::to_string(&ContentBlockState::Draft).unwrap();
         assert_eq!(s.trim(), "draft");
     }
 }

--- a/src/resource/custom_attribute.rs
+++ b/src/resource/custom_attribute.rs
@@ -71,15 +71,15 @@ mod tests {
                 },
             ],
         };
-        let yaml = serde_yml::to_string(&r).unwrap();
-        let parsed: CustomAttributeRegistry = serde_yml::from_str(&yaml).unwrap();
+        let yaml = serde_norway::to_string(&r).unwrap();
+        let parsed: CustomAttributeRegistry = serde_norway::from_str(&yaml).unwrap();
         assert_eq!(r, parsed);
     }
 
     #[test]
     fn deprecated_defaults_to_false() {
         let yaml = "name: foo\ntype: string\n";
-        let attr: CustomAttribute = serde_yml::from_str(yaml).unwrap();
+        let attr: CustomAttribute = serde_norway::from_str(yaml).unwrap();
         assert!(!attr.deprecated);
     }
 

--- a/src/resource/email_template.rs
+++ b/src/resource/email_template.rs
@@ -44,8 +44,8 @@ mod tests {
             preheader: Some("Get started".into()),
             tags: vec!["onboarding".into()],
         };
-        let yaml = serde_yml::to_string(&t).unwrap();
-        let parsed: EmailTemplate = serde_yml::from_str(&yaml).unwrap();
+        let yaml = serde_norway::to_string(&t).unwrap();
+        let parsed: EmailTemplate = serde_norway::from_str(&yaml).unwrap();
         assert_eq!(t, parsed);
     }
 
@@ -62,8 +62,8 @@ mod tests {
             preheader: None,
             tags: vec![],
         };
-        let yaml = serde_yml::to_string(&t).unwrap();
-        let parsed: EmailTemplate = serde_yml::from_str(&yaml).unwrap();
+        let yaml = serde_norway::to_string(&t).unwrap();
+        let parsed: EmailTemplate = serde_norway::from_str(&yaml).unwrap();
         assert_eq!(parsed.body_plaintext, "");
     }
 }


### PR DESCRIPTION
## Summary

Fix the `audit` job on `main` that has been red since Phase B1 landed
(runs [24280628439](https://github.com/uny/braze-sync/actions/runs/24280628439),
[24292493070](https://github.com/uny/braze-sync/actions/runs/24292493070)).
Two independent problems stacked on the same job:

- **Unsound / unmaintained deps.** `serde_yml` 0.0.12 and its `libyml`
  backend were archived upstream and flagged by RUSTSEC-2025-0067 and
  RUSTSEC-2025-0068. Replace with `serde_norway` 0.9, the maintained
  `serde_yaml` fork the advisories recommend. Its backend
  (`unsafe-libyaml-norway`) is also maintained, so this doesn't just
  trade one archived dep for another. `serde_norway` is
  source-compatible with the original `serde_yaml`, so the change is a
  pure namespace replacement across 7 files.
- **CI permission bug.** `rustsec/audit-check` posts findings via the
  GitHub Checks API, which needs `checks: write`. Without it the job
  fails with `Resource not accessible by integration` regardless of
  what the advisory scan actually found. Grant `checks: write` (and
  pin `contents: read` so the permission set does not widen by
  default).
- **rand 0.8.5 / 0.9.2 RUSTSEC-2026-0097.** Transitive, not applicable
  to this binary (the unsoundness path requires a custom `log` logger
  calling `rand::rng()` inside its log hook; we use `tracing` and
  never invoke rand from logging code). Added to `.cargo/audit.toml`
  ignore list with written rationale and a reminder to drop the entry
  once governor / wiremock upgrade to rand >= 0.9.3.

## Test plan

- [x] `cargo test --all-features` — 223 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo audit --deny warnings` (locally with cargo-audit 0.22.1,
      RustSec DB 1043 advisories) — exit 0
- [ ] CI `audit` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Replaced YAML serialization library across the codebase to improve maintenance and compatibility.
  * Enhanced CI security audit workflow with explicit permissions to publish results via GitHub Checks API.
  * Added security advisory configuration to audit tooling in CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->