### PR TITLE
Phase B2: Email Template end-to-end (v0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/src/braze/content_block.rs
+++ b/src/braze/content_block.rs
@@ -94,14 +94,14 @@ impl BrazeClient {
             .get(&["content_blocks", "info"])
             .query(&[("content_block_id", id)]);
         let wire: ContentBlockInfoResponse = self.send_json(req).await?;
-        match wire.classify_message() {
-            InfoMessageClass::Success => {}
-            InfoMessageClass::NotFound => {
+        match crate::braze::classify_info_message(wire.message.as_deref(), "no content block") {
+            crate::braze::InfoMessageClass::Success => {}
+            crate::braze::InfoMessageClass::NotFound => {
                 return Err(BrazeApiError::NotFound {
                     resource: format!("content_block id '{id}'"),
                 });
             }
-            InfoMessageClass::Unexpected(message) => {
+            crate::braze::InfoMessageClass::Unexpected(message) => {
                 return Err(BrazeApiError::UnexpectedApiMessage {
                     endpoint: "/content_blocks/info",
                     message,
@@ -194,41 +194,6 @@ struct ContentBlockInfoResponse {
     tags: Vec<String>,
     #[serde(default)]
     message: Option<String>,
-}
-
-/// Outcome of classifying the `message` field on a `/content_blocks/info`
-/// response. `NotFound` preserves the call-site branching contract; the
-/// `Unexpected` arm exists so an unknown message does not get silently
-/// folded into `NotFound` — see the doc comment on `get_content_block`.
-enum InfoMessageClass {
-    Success,
-    NotFound,
-    Unexpected(String),
-}
-
-impl ContentBlockInfoResponse {
-    fn classify_message(&self) -> InfoMessageClass {
-        let Some(raw) = self.message.as_deref() else {
-            return InfoMessageClass::Success;
-        };
-        let trimmed = raw.trim();
-        if trimmed.eq_ignore_ascii_case("success") {
-            return InfoMessageClass::Success;
-        }
-        let lower = trimmed.to_ascii_lowercase();
-        // Match the known not-found phrasings conservatively. Anything
-        // we don't recognise must NOT be treated as NotFound — that is
-        // the whole point of this classifier over the previous boolean
-        // check.
-        if lower.contains("not found")
-            || lower.contains("no content block")
-            || lower.contains("does not exist")
-        {
-            InfoMessageClass::NotFound
-        } else {
-            InfoMessageClass::Unexpected(raw.to_string())
-        }
-    }
 }
 
 /// Wire body shared by `/content_blocks/create` and `.../update`. Both

--- a/src/braze/content_block.rs
+++ b/src/braze/content_block.rs
@@ -6,7 +6,7 @@
 //! remote-only blocks are surfaced as orphans rather than `Removed` diffs.
 
 use crate::braze::error::BrazeApiError;
-use crate::braze::BrazeClient;
+use crate::braze::{classify_info_message, BrazeClient, InfoMessageClass};
 use crate::resource::{ContentBlock, ContentBlockState};
 use serde::{Deserialize, Serialize};
 
@@ -94,14 +94,14 @@ impl BrazeClient {
             .get(&["content_blocks", "info"])
             .query(&[("content_block_id", id)]);
         let wire: ContentBlockInfoResponse = self.send_json(req).await?;
-        match crate::braze::classify_info_message(wire.message.as_deref(), "no content block") {
-            crate::braze::InfoMessageClass::Success => {}
-            crate::braze::InfoMessageClass::NotFound => {
+        match classify_info_message(wire.message.as_deref(), "no content block") {
+            InfoMessageClass::Success => {}
+            InfoMessageClass::NotFound => {
                 return Err(BrazeApiError::NotFound {
                     resource: format!("content_block id '{id}'"),
                 });
             }
-            crate::braze::InfoMessageClass::Unexpected(message) => {
+            InfoMessageClass::Unexpected(message) => {
                 return Err(BrazeApiError::UnexpectedApiMessage {
                     endpoint: "/content_blocks/info",
                     message,

--- a/src/braze/email_template.rs
+++ b/src/braze/email_template.rs
@@ -82,14 +82,14 @@ impl BrazeClient {
             .get(&["templates", "email", "info"])
             .query(&[("email_template_id", id)]);
         let wire: EmailTemplateInfoResponse = self.send_json(req).await?;
-        match wire.classify_message() {
-            InfoMessageClass::Success => {}
-            InfoMessageClass::NotFound => {
+        match crate::braze::classify_info_message(wire.message.as_deref(), "no email template") {
+            crate::braze::InfoMessageClass::Success => {}
+            crate::braze::InfoMessageClass::NotFound => {
                 return Err(BrazeApiError::NotFound {
                     resource: format!("email_template id '{id}'"),
                 });
             }
-            InfoMessageClass::Unexpected(message) => {
+            crate::braze::InfoMessageClass::Unexpected(message) => {
                 return Err(BrazeApiError::UnexpectedApiMessage {
                     endpoint: "/templates/email/info",
                     message,
@@ -186,33 +186,6 @@ struct EmailTemplateInfoResponse {
     tags: Option<Vec<String>>,
     #[serde(default)]
     message: Option<String>,
-}
-
-enum InfoMessageClass {
-    Success,
-    NotFound,
-    Unexpected(String),
-}
-
-impl EmailTemplateInfoResponse {
-    fn classify_message(&self) -> InfoMessageClass {
-        let Some(raw) = self.message.as_deref() else {
-            return InfoMessageClass::Success;
-        };
-        let trimmed = raw.trim();
-        if trimmed.eq_ignore_ascii_case("success") {
-            return InfoMessageClass::Success;
-        }
-        let lower = trimmed.to_ascii_lowercase();
-        if lower.contains("not found")
-            || lower.contains("no email template")
-            || lower.contains("does not exist")
-        {
-            InfoMessageClass::NotFound
-        } else {
-            InfoMessageClass::Unexpected(raw.to_string())
-        }
-    }
 }
 
 /// Wire body shared by create and update. `description` is intentionally

--- a/src/braze/email_template.rs
+++ b/src/braze/email_template.rs
@@ -13,7 +13,7 @@
 //! - Pagination: `limit` (default 100, max 1000) + `offset`
 
 use crate::braze::error::BrazeApiError;
-use crate::braze::BrazeClient;
+use crate::braze::{classify_info_message, BrazeClient, InfoMessageClass};
 use crate::resource::EmailTemplate;
 use serde::{Deserialize, Serialize};
 
@@ -82,14 +82,14 @@ impl BrazeClient {
             .get(&["templates", "email", "info"])
             .query(&[("email_template_id", id)]);
         let wire: EmailTemplateInfoResponse = self.send_json(req).await?;
-        match crate::braze::classify_info_message(wire.message.as_deref(), "no email template") {
-            crate::braze::InfoMessageClass::Success => {}
-            crate::braze::InfoMessageClass::NotFound => {
+        match classify_info_message(wire.message.as_deref(), "no email template") {
+            InfoMessageClass::Success => {}
+            InfoMessageClass::NotFound => {
                 return Err(BrazeApiError::NotFound {
                     resource: format!("email_template id '{id}'"),
                 });
             }
-            crate::braze::InfoMessageClass::Unexpected(message) => {
+            InfoMessageClass::Unexpected(message) => {
                 return Err(BrazeApiError::UnexpectedApiMessage {
                     endpoint: "/templates/email/info",
                     message,

--- a/src/braze/email_template.rs
+++ b/src/braze/email_template.rs
@@ -1,0 +1,622 @@
+//! Email Template endpoints.
+//!
+//! Braze identifies email templates by `email_template_id` but uses
+//! `template_name` as the human-readable identifier. There is no DELETE
+//! endpoint, which is why remote-only templates are surfaced as orphans
+//! rather than `Removed` diffs — same pattern as Content Block (§11.6).
+//!
+//! API verification (2026-04-12):
+//! - Field name mapping: `template_name`↔`name`, `body`↔`body_html`,
+//!   `plaintext_body`↔`body_plaintext`
+//! - `description` is returned by /info but NOT settable via create/update
+//! - `from_address`/`from_display_name`/`reply_to` do NOT exist in the API
+//! - Pagination: `limit` (default 100, max 1000) + `offset`
+
+use crate::braze::error::BrazeApiError;
+use crate::braze::BrazeClient;
+use crate::resource::EmailTemplate;
+use serde::{Deserialize, Serialize};
+
+const LIST_LIMIT: u32 = 100;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmailTemplateSummary {
+    pub email_template_id: String,
+    pub name: String,
+}
+
+impl BrazeClient {
+    /// Returns one page of up to [`LIST_LIMIT`] summaries. Hard-errors
+    /// rather than silently truncating: see `PaginationNotImplemented`.
+    pub async fn list_email_templates(&self) -> Result<Vec<EmailTemplateSummary>, BrazeApiError> {
+        let req = self
+            .get(&["templates", "email", "list"])
+            .query(&[("limit", LIST_LIMIT.to_string())]);
+        let resp: EmailTemplateListResponse = self.send_json(req).await?;
+        let returned = resp.templates.len();
+
+        // Fail closed when the page is or might be truncated.
+        // Same pattern as content_block::list_content_blocks.
+        let truncation_detail: Option<String> = match resp.count {
+            Some(total) if total > returned => Some(format!("got {returned} of {total} results")),
+            None if returned >= LIST_LIMIT as usize => Some(format!(
+                "got a full page of {returned} result(s) with no total reported; \
+                 cannot verify whether more exist"
+            )),
+            _ => None,
+        };
+        if let Some(detail) = truncation_detail {
+            return Err(BrazeApiError::PaginationNotImplemented {
+                endpoint: "/templates/email/list",
+                detail,
+            });
+        }
+
+        // Duplicate names would collapse the name→id index in
+        // compute_email_template_plan.
+        let mut seen: std::collections::HashSet<&str> =
+            std::collections::HashSet::with_capacity(resp.templates.len());
+        for entry in &resp.templates {
+            if !seen.insert(entry.template_name.as_str()) {
+                return Err(BrazeApiError::DuplicateNameInListResponse {
+                    endpoint: "/templates/email/list",
+                    name: entry.template_name.clone(),
+                });
+            }
+        }
+
+        Ok(resp
+            .templates
+            .into_iter()
+            .map(|w| EmailTemplateSummary {
+                email_template_id: w.email_template_id,
+                name: w.template_name,
+            })
+            .collect())
+    }
+
+    /// Fetch full template details by id. Uses the same 200+message
+    /// classifier pattern as content_block::get_content_block.
+    pub async fn get_email_template(&self, id: &str) -> Result<EmailTemplate, BrazeApiError> {
+        let req = self
+            .get(&["templates", "email", "info"])
+            .query(&[("email_template_id", id)]);
+        let wire: EmailTemplateInfoResponse = self.send_json(req).await?;
+        match wire.classify_message() {
+            InfoMessageClass::Success => {}
+            InfoMessageClass::NotFound => {
+                return Err(BrazeApiError::NotFound {
+                    resource: format!("email_template id '{id}'"),
+                });
+            }
+            InfoMessageClass::Unexpected(message) => {
+                return Err(BrazeApiError::UnexpectedApiMessage {
+                    endpoint: "/templates/email/info",
+                    message,
+                });
+            }
+        }
+        Ok(EmailTemplate {
+            name: wire.template_name,
+            subject: wire.subject.unwrap_or_default(),
+            body_html: wire.body.unwrap_or_default(),
+            body_plaintext: wire.plaintext_body.unwrap_or_default(),
+            // description is read-only — returned by /info but not
+            // settable via create/update.
+            description: wire.description,
+            preheader: wire.preheader,
+            should_inline_css: wire.should_inline_css,
+            tags: wire.tags.unwrap_or_default(),
+        })
+    }
+
+    pub async fn create_email_template(&self, et: &EmailTemplate) -> Result<String, BrazeApiError> {
+        let body = EmailTemplateWriteBody {
+            email_template_id: None,
+            template_name: &et.name,
+            subject: &et.subject,
+            body: &et.body_html,
+            plaintext_body: Some(&et.body_plaintext),
+            preheader: et.preheader.as_deref(),
+            should_inline_css: et.should_inline_css,
+            tags: &et.tags,
+        };
+        let req = self.post(&["templates", "email", "create"]).json(&body);
+        let resp: EmailTemplateCreateResponse = self.send_json(req).await?;
+        Ok(resp.email_template_id)
+    }
+
+    /// Update an existing email template. `description` is intentionally
+    /// omitted — Braze /info returns it but create/update cannot set it.
+    pub async fn update_email_template(
+        &self,
+        id: &str,
+        et: &EmailTemplate,
+    ) -> Result<(), BrazeApiError> {
+        let body = EmailTemplateWriteBody {
+            email_template_id: Some(id),
+            template_name: &et.name,
+            subject: &et.subject,
+            body: &et.body_html,
+            plaintext_body: Some(&et.body_plaintext),
+            preheader: et.preheader.as_deref(),
+            should_inline_css: et.should_inline_css,
+            tags: &et.tags,
+        };
+        let req = self.post(&["templates", "email", "update"]).json(&body);
+        self.send_ok(req).await
+    }
+}
+
+// ===================================================================
+// Wire types
+// ===================================================================
+
+#[derive(Debug, Deserialize)]
+struct EmailTemplateListResponse {
+    #[serde(default)]
+    templates: Vec<EmailTemplateListEntry>,
+    #[serde(default)]
+    count: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmailTemplateListEntry {
+    email_template_id: String,
+    template_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmailTemplateInfoResponse {
+    #[serde(default)]
+    template_name: String,
+    #[serde(default)]
+    subject: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    plaintext_body: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    preheader: Option<String>,
+    #[serde(default)]
+    should_inline_css: Option<bool>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+enum InfoMessageClass {
+    Success,
+    NotFound,
+    Unexpected(String),
+}
+
+impl EmailTemplateInfoResponse {
+    fn classify_message(&self) -> InfoMessageClass {
+        let Some(raw) = self.message.as_deref() else {
+            return InfoMessageClass::Success;
+        };
+        let trimmed = raw.trim();
+        if trimmed.eq_ignore_ascii_case("success") {
+            return InfoMessageClass::Success;
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.contains("not found")
+            || lower.contains("no email template")
+            || lower.contains("does not exist")
+        {
+            InfoMessageClass::NotFound
+        } else {
+            InfoMessageClass::Unexpected(raw.to_string())
+        }
+    }
+}
+
+/// Wire body shared by create and update. `description` is intentionally
+/// absent — Braze /info returns it but create/update cannot set it.
+#[derive(Serialize)]
+struct EmailTemplateWriteBody<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    email_template_id: Option<&'a str>,
+    template_name: &'a str,
+    subject: &'a str,
+    body: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plaintext_body: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preheader: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    should_inline_css: Option<bool>,
+    tags: &'a [String],
+}
+
+#[derive(Debug, Deserialize)]
+struct EmailTemplateCreateResponse {
+    email_template_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::braze::test_client as make_client;
+    use serde_json::json;
+    use wiremock::matchers::{body_json, header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn list_happy_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/list"))
+            .and(header("authorization", "Bearer test-key"))
+            .and(query_param("limit", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 2,
+                "templates": [
+                    {"email_template_id": "id-1", "template_name": "welcome"},
+                    {"email_template_id": "id-2", "template_name": "password_reset"}
+                ],
+                "message": "success"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server);
+        let summaries = client.list_email_templates().await.unwrap();
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].email_template_id, "id-1");
+        assert_eq!(summaries[0].name, "welcome");
+    }
+
+    #[tokio::test]
+    async fn list_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"templates": []})))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        assert!(client.list_email_templates().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_ignores_unknown_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "templates": [{
+                    "email_template_id": "id-1",
+                    "template_name": "welcome",
+                    "updated_at": "2026-04-12T00:00:00Z",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "tags": ["onboarding"],
+                    "future_field": true
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let summaries = client.list_email_templates().await.unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].name, "welcome");
+    }
+
+    #[tokio::test]
+    async fn list_unauthorized() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/list"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("invalid"))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let err = client.list_email_templates().await.unwrap_err();
+        assert!(matches!(err, BrazeApiError::Unauthorized), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn info_happy_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/info"))
+            .and(query_param("email_template_id", "id-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "email_template_id": "id-1",
+                "template_name": "welcome",
+                "description": "Welcome email",
+                "subject": "Welcome to our service",
+                "body": "<p>Hello</p>",
+                "plaintext_body": "Hello",
+                "preheader": "Get started",
+                "should_inline_css": true,
+                "tags": ["onboarding", "email"],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-04-12T00:00:00Z",
+                "message": "success"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server);
+        let et = client.get_email_template("id-1").await.unwrap();
+        assert_eq!(et.name, "welcome");
+        assert_eq!(et.subject, "Welcome to our service");
+        assert_eq!(et.body_html, "<p>Hello</p>");
+        assert_eq!(et.body_plaintext, "Hello");
+        assert_eq!(et.description.as_deref(), Some("Welcome email"));
+        assert_eq!(et.preheader.as_deref(), Some("Get started"));
+        assert_eq!(et.should_inline_css, Some(true));
+        assert_eq!(et.tags, vec!["onboarding", "email"]);
+    }
+
+    #[tokio::test]
+    async fn info_missing_optional_fields_default() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "template_name": "minimal",
+                "message": "success"
+            })))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let et = client.get_email_template("id-x").await.unwrap();
+        assert_eq!(et.name, "minimal");
+        assert_eq!(et.subject, "");
+        assert_eq!(et.body_html, "");
+        assert_eq!(et.body_plaintext, "");
+        assert!(et.description.is_none());
+        assert!(et.preheader.is_none());
+        assert!(et.should_inline_css.is_none());
+        assert!(et.tags.is_empty());
+    }
+
+    #[tokio::test]
+    async fn info_not_found_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message": "No email template with id 'missing' found"
+            })))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let err = client.get_email_template("missing").await.unwrap_err();
+        match err {
+            BrazeApiError::NotFound { resource } => assert!(resource.contains("missing")),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn info_unexpected_message_surfaces_verbatim() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message": "Internal server hiccup, please retry"
+            })))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let err = client.get_email_template("some-id").await.unwrap_err();
+        match err {
+            BrazeApiError::UnexpectedApiMessage { endpoint, message } => {
+                assert_eq!(endpoint, "/templates/email/info");
+                assert!(message.contains("Internal server hiccup"));
+            }
+            other => panic!("expected UnexpectedApiMessage, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_sends_correct_body_and_returns_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/templates/email/create"))
+            .and(header("authorization", "Bearer test-key"))
+            .and(body_json(json!({
+                "template_name": "welcome",
+                "subject": "Welcome",
+                "body": "<p>Hi</p>",
+                "plaintext_body": "Hi",
+                "preheader": "Get started",
+                "should_inline_css": true,
+                "tags": ["onboarding"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "email_template_id": "new-id-123",
+                "message": "success"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server);
+        let et = EmailTemplate {
+            name: "welcome".into(),
+            subject: "Welcome".into(),
+            body_html: "<p>Hi</p>".into(),
+            body_plaintext: "Hi".into(),
+            description: Some("should not be sent".into()),
+            preheader: Some("Get started".into()),
+            should_inline_css: Some(true),
+            tags: vec!["onboarding".into()],
+        };
+        let id = client.create_email_template(&et).await.unwrap();
+        assert_eq!(id, "new-id-123");
+    }
+
+    #[tokio::test]
+    async fn create_minimal_omits_optional_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/templates/email/create"))
+            .and(body_json(json!({
+                "template_name": "minimal",
+                "subject": "x",
+                "body": "",
+                "plaintext_body": "",
+                "tags": []
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "email_template_id": "id-min"
+            })))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let et = EmailTemplate {
+            name: "minimal".into(),
+            subject: "x".into(),
+            body_html: String::new(),
+            body_plaintext: String::new(),
+            description: None,
+            preheader: None,
+            should_inline_css: None,
+            tags: vec![],
+        };
+        client.create_email_template(&et).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_sends_id_and_omits_description() {
+        // Pins that description is NOT sent — it's read-only.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/templates/email/update"))
+            .and(body_json(json!({
+                "email_template_id": "id-1",
+                "template_name": "welcome",
+                "subject": "Updated",
+                "body": "<p>New</p>",
+                "plaintext_body": "New",
+                "tags": []
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server);
+        let et = EmailTemplate {
+            name: "welcome".into(),
+            subject: "Updated".into(),
+            body_html: "<p>New</p>".into(),
+            body_plaintext: "New".into(),
+            description: Some("this should not appear in wire body".into()),
+            preheader: None,
+            should_inline_css: None,
+            tags: vec![],
+        };
+        client.update_email_template("id-1", &et).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_unauthorized_propagates() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/templates/email/update"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("invalid"))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let et = EmailTemplate {
+            name: "x".into(),
+            subject: "x".into(),
+            body_html: String::new(),
+            body_plaintext: String::new(),
+            description: None,
+            preheader: None,
+            should_inline_css: None,
+            tags: vec![],
+        };
+        let err = client.update_email_template("id", &et).await.unwrap_err();
+        assert!(matches!(err, BrazeApiError::Unauthorized), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn list_errors_when_count_exceeds_returned() {
+        let server = MockServer::start().await;
+        let entries: Vec<serde_json::Value> = (0..100)
+            .map(|i| {
+                json!({
+                    "email_template_id": format!("id-{i}"),
+                    "template_name": format!("tpl-{i}")
+                })
+            })
+            .collect();
+        Mock::given(method("GET"))
+            .and(path("/templates/email/list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 250,
+                "templates": entries,
+                "message": "success"
+            })))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let err = client.list_email_templates().await.unwrap_err();
+        match err {
+            BrazeApiError::PaginationNotImplemented { endpoint, detail } => {
+                assert_eq!(endpoint, "/templates/email/list");
+                assert!(detail.contains("100"), "detail: {detail}");
+                assert!(detail.contains("250"), "detail: {detail}");
+            }
+            other => panic!("expected PaginationNotImplemented, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_errors_on_full_page_with_no_count_field() {
+        let server = MockServer::start().await;
+        let entries: Vec<serde_json::Value> = (0..100)
+            .map(|i| {
+                json!({
+                    "email_template_id": format!("id-{i}"),
+                    "template_name": format!("tpl-{i}")
+                })
+            })
+            .collect();
+        Mock::given(method("GET"))
+            .and(path("/templates/email/list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "templates": entries })))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let err = client.list_email_templates().await.unwrap_err();
+        assert!(
+            matches!(err, BrazeApiError::PaginationNotImplemented { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_errors_on_duplicate_name() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates/email/list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 2,
+                "templates": [
+                    {"email_template_id": "id-a", "template_name": "dup"},
+                    {"email_template_id": "id-b", "template_name": "dup"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let err = client.list_email_templates().await.unwrap_err();
+        match err {
+            BrazeApiError::DuplicateNameInListResponse { endpoint, name } => {
+                assert_eq!(endpoint, "/templates/email/list");
+                assert_eq!(name, "dup");
+            }
+            other => panic!("expected DuplicateNameInListResponse, got {other:?}"),
+        }
+    }
+}

--- a/src/braze/email_template.rs
+++ b/src/braze/email_template.rs
@@ -116,7 +116,7 @@ impl BrazeClient {
             template_name: &et.name,
             subject: &et.subject,
             body: &et.body_html,
-            plaintext_body: Some(&et.body_plaintext),
+            plaintext_body: &et.body_plaintext,
             preheader: et.preheader.as_deref(),
             should_inline_css: et.should_inline_css,
             tags: &et.tags,
@@ -138,7 +138,7 @@ impl BrazeClient {
             template_name: &et.name,
             subject: &et.subject,
             body: &et.body_html,
-            plaintext_body: Some(&et.body_plaintext),
+            plaintext_body: &et.body_plaintext,
             preheader: et.preheader.as_deref(),
             should_inline_css: et.should_inline_css,
             tags: &et.tags,
@@ -197,8 +197,7 @@ struct EmailTemplateWriteBody<'a> {
     template_name: &'a str,
     subject: &'a str,
     body: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    plaintext_body: Option<&'a str>,
+    plaintext_body: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     preheader: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/braze/mod.rs
+++ b/src/braze/mod.rs
@@ -196,6 +196,40 @@ fn parse_retry_after(resp: &reqwest::Response) -> Option<Duration> {
         .map(Duration::from_secs)
 }
 
+/// Outcome of classifying the `message` field on a Braze `/info`
+/// response. Shared by content_block and email_template — the only
+/// difference is the resource-specific "not found" phrase.
+pub(crate) enum InfoMessageClass {
+    Success,
+    NotFound,
+    Unexpected(String),
+}
+
+/// Classify the `message` field returned by Braze `/info` endpoints.
+/// `resource_phrase` is a resource-specific not-found indicator
+/// (e.g. `"no content block"`, `"no email template"`).
+pub(crate) fn classify_info_message(
+    message: Option<&str>,
+    resource_phrase: &str,
+) -> InfoMessageClass {
+    let Some(raw) = message else {
+        return InfoMessageClass::Success;
+    };
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("success") {
+        return InfoMessageClass::Success;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.contains("not found")
+        || lower.contains(resource_phrase)
+        || lower.contains("does not exist")
+    {
+        InfoMessageClass::NotFound
+    } else {
+        InfoMessageClass::Unexpected(raw.to_string())
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn test_client(server: &wiremock::MockServer) -> BrazeClient {
     BrazeClient::new(

--- a/src/braze/mod.rs
+++ b/src/braze/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod catalog;
 pub mod content_block;
+pub mod email_template;
 pub mod error;
 pub mod rate_limit;
 

--- a/src/braze/mod.rs
+++ b/src/braze/mod.rs
@@ -212,6 +212,10 @@ pub(crate) fn classify_info_message(
     message: Option<&str>,
     resource_phrase: &str,
 ) -> InfoMessageClass {
+    debug_assert!(
+        resource_phrase == resource_phrase.to_ascii_lowercase(),
+        "resource_phrase must be lowercase (compared against lowercased message)"
+    );
     let Some(raw) = message else {
         return InfoMessageClass::Success;
     };

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -13,6 +13,7 @@ use crate::braze::BrazeClient;
 use crate::config::ResolvedConfig;
 use crate::diff::catalog::CatalogSchemaDiff;
 use crate::diff::content_block::{ContentBlockDiff, ContentBlockIdIndex};
+use crate::diff::email_template::{EmailTemplateDiff, EmailTemplateIdIndex};
 use crate::diff::orphan;
 use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::error::Error;
@@ -22,7 +23,9 @@ use anyhow::{anyhow, Context as _};
 use clap::Args;
 use std::path::Path;
 
-use super::diff::{compute_catalog_schema_diffs, compute_content_block_plan};
+use super::diff::{
+    compute_catalog_schema_diffs, compute_content_block_plan, compute_email_template_plan,
+};
 use super::{selected_kinds, warn_unimplemented};
 
 #[derive(Args, Debug)]
@@ -62,11 +65,13 @@ pub async fn run(
 ) -> anyhow::Result<()> {
     let catalogs_root = config_dir.join(&resolved.resources.catalog_schema.path);
     let content_blocks_root = config_dir.join(&resolved.resources.content_block.path);
+    let email_templates_root = config_dir.join(&resolved.resources.email_template.path);
     let client = BrazeClient::from_resolved(&resolved);
     let kinds = selected_kinds(args.resource, &resolved.resources);
 
     let mut summary = DiffSummary::default();
     let mut content_block_id_index: Option<ContentBlockIdIndex> = None;
+    let mut email_template_id_index: Option<EmailTemplateIdIndex> = None;
     for kind in kinds {
         match kind {
             ResourceKind::CatalogSchema => {
@@ -83,6 +88,17 @@ pub async fn run(
                         .context("computing content_block plan")?;
                 summary.diffs.extend(diffs);
                 content_block_id_index = Some(idx);
+            }
+            ResourceKind::EmailTemplate => {
+                let (diffs, idx) = compute_email_template_plan(
+                    &client,
+                    &email_templates_root,
+                    args.name.as_deref(),
+                )
+                .await
+                .context("computing email_template plan")?;
+                summary.diffs.extend(diffs);
+                email_template_id_index = Some(idx);
             }
             other => warn_unimplemented(other),
         }
@@ -130,6 +146,16 @@ pub async fn run(
                     &client,
                     d,
                     content_block_id_index.as_ref(),
+                    args.archive_orphans,
+                    today,
+                )
+                .await?;
+            }
+            ResourceDiff::EmailTemplate(d) => {
+                applied += apply_email_template(
+                    &client,
+                    d,
+                    email_template_id_index.as_ref(),
                     args.archive_orphans,
                     today,
                 )
@@ -305,4 +331,69 @@ async fn apply_catalog_schema(
         }
     }
     Ok(count)
+}
+
+async fn apply_email_template(
+    client: &BrazeClient,
+    d: &EmailTemplateDiff,
+    id_index: Option<&EmailTemplateIdIndex>,
+    archive_orphans: bool,
+    today: chrono::NaiveDate,
+) -> anyhow::Result<usize> {
+    if d.orphan {
+        if !archive_orphans {
+            return Ok(0);
+        }
+        let id_index = id_index.ok_or_else(|| {
+            anyhow!("internal: email_template id index missing for orphan apply path")
+        })?;
+        let id = id_index.get(&d.name).ok_or_else(|| {
+            anyhow!(
+                "internal: orphan '{}' missing from id index — list/diff drift",
+                d.name
+            )
+        })?;
+        let archived = orphan::archive_name(today, &d.name);
+        if archived == d.name {
+            return Ok(0);
+        }
+        let mut et = client
+            .get_email_template(id)
+            .await
+            .with_context(|| format!("fetching email template '{}' for archive rename", d.name))?;
+        et.name = archived;
+        tracing::info!(
+            email_template = %d.name,
+            new_name = %et.name,
+            "archiving orphan email template"
+        );
+        client.update_email_template(id, &et).await?;
+        return Ok(1);
+    }
+
+    match &d.op {
+        DiffOp::Added(et) => {
+            tracing::info!(email_template = %et.name, "creating email template");
+            let _ = client.create_email_template(et).await?;
+            Ok(1)
+        }
+        DiffOp::Modified { to, .. } => {
+            let id_index = id_index.ok_or_else(|| {
+                anyhow!("internal: email_template id index missing for modified apply path")
+            })?;
+            let id = id_index.get(&to.name).ok_or_else(|| {
+                anyhow!(
+                    "internal: modified email template '{}' missing from id index",
+                    to.name
+                )
+            })?;
+            tracing::info!(email_template = %to.name, "updating email template");
+            client.update_email_template(id, to).await?;
+            Ok(1)
+        }
+        DiffOp::Removed(_) => {
+            unreachable!("diff layer routes email template removals through orphan")
+        }
+        DiffOp::Unchanged => Ok(0),
+    }
 }

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -11,11 +11,14 @@ use crate::diff::catalog::diff_schema;
 use crate::diff::content_block::{
     diff as diff_content_block, ContentBlockDiff, ContentBlockIdIndex,
 };
+use crate::diff::email_template::{
+    diff as diff_email_template, EmailTemplateDiff, EmailTemplateIdIndex,
+};
 use crate::diff::{DiffSummary, ResourceDiff};
 use crate::error::Error;
 use crate::format::OutputFormat;
-use crate::fs::{catalog_io, content_block_io};
-use crate::resource::{Catalog, ContentBlock, ResourceKind};
+use crate::fs::{catalog_io, content_block_io, email_template_io};
+use crate::resource::{Catalog, ContentBlock, EmailTemplate, ResourceKind};
 use anyhow::Context as _;
 use clap::Args;
 use futures::stream::{StreamExt, TryStreamExt};
@@ -48,6 +51,7 @@ pub async fn run(
 ) -> anyhow::Result<()> {
     let catalogs_root = config_dir.join(&resolved.resources.catalog_schema.path);
     let content_blocks_root = config_dir.join(&resolved.resources.content_block.path);
+    let email_templates_root = config_dir.join(&resolved.resources.email_template.path);
     let client = BrazeClient::from_resolved(&resolved);
     let kinds = selected_kinds(args.resource, &resolved.resources);
 
@@ -66,6 +70,16 @@ pub async fn run(
                     compute_content_block_plan(&client, &content_blocks_root, args.name.as_deref())
                         .await
                         .context("computing content_block diff")?;
+                summary.diffs.extend(diffs);
+            }
+            ResourceKind::EmailTemplate => {
+                let (diffs, _idx) = compute_email_template_plan(
+                    &client,
+                    &email_templates_root,
+                    args.name.as_deref(),
+                )
+                .await
+                .context("computing email_template diff")?;
                 summary.diffs.extend(diffs);
             }
             other => {
@@ -209,6 +223,81 @@ pub(crate) async fn compute_content_block_plan(
         };
         if let Some(d) = diff_result {
             diffs.push(ResourceDiff::ContentBlock(d));
+        }
+    }
+
+    Ok((diffs, id_index))
+}
+
+/// Same pattern as `compute_content_block_plan` — list first, fan-out
+/// /info fetches for shared names, then diff.
+pub(crate) async fn compute_email_template_plan(
+    client: &BrazeClient,
+    email_templates_root: &Path,
+    name_filter: Option<&str>,
+) -> anyhow::Result<(Vec<ResourceDiff>, EmailTemplateIdIndex)> {
+    let mut local = email_template_io::load_all_email_templates(email_templates_root)?;
+    if let Some(name) = name_filter {
+        local.retain(|t| t.name == name);
+    }
+
+    let mut summaries = client.list_email_templates().await?;
+    if let Some(name) = name_filter {
+        summaries.retain(|s| s.name == name);
+    }
+
+    let id_index: EmailTemplateIdIndex = summaries
+        .into_iter()
+        .map(|s| (s.name, s.email_template_id))
+        .collect();
+
+    let local_by_name: BTreeMap<&str, &EmailTemplate> =
+        local.iter().map(|t| (t.name.as_str(), t)).collect();
+
+    let shared_names: Vec<&str> = id_index
+        .keys()
+        .map(String::as_str)
+        .filter(|n| local_by_name.contains_key(n))
+        .collect();
+    let fetched: BTreeMap<String, EmailTemplate> =
+        futures::stream::iter(shared_names.iter().map(|name| {
+            let id = id_index
+                .get(*name)
+                .expect("id_index built from the same summaries set");
+            async move {
+                client
+                    .get_email_template(id)
+                    .await
+                    .map(|et| (name.to_string(), et))
+                    .with_context(|| format!("fetching email template '{name}'"))
+            }
+        }))
+        .buffer_unordered(FETCH_CONCURRENCY)
+        .try_collect()
+        .await?;
+
+    let mut all_names: BTreeSet<&str> = BTreeSet::new();
+    all_names.extend(local_by_name.keys().copied());
+    all_names.extend(id_index.keys().map(String::as_str));
+
+    let mut diffs = Vec::new();
+    for name in all_names {
+        let local_et = local_by_name.get(name).copied();
+        let remote_et = fetched.get(name);
+        let remote_present = id_index.contains_key(name);
+        let diff_result = match (local_et, remote_et, remote_present) {
+            (Some(l), Some(r), true) => diff_email_template(Some(l), Some(r)),
+            (Some(l), None, false) => diff_email_template(Some(l), None),
+            (None, None, true) => Some(EmailTemplateDiff::orphan(name)),
+            _ => unreachable!(
+                "email_template diff invariant violated for '{name}': \
+                 local={} remote={} remote_present={remote_present}",
+                local_et.is_some(),
+                remote_et.is_some(),
+            ),
+        };
+        if let Some(d) = diff_result {
+            diffs.push(ResourceDiff::EmailTemplate(d));
         }
     }
 

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -3,7 +3,7 @@
 use crate::braze::error::BrazeApiError;
 use crate::braze::BrazeClient;
 use crate::config::ResolvedConfig;
-use crate::fs::{catalog_io, content_block_io};
+use crate::fs::{catalog_io, content_block_io, email_template_io};
 use crate::resource::ResourceKind;
 use anyhow::Context as _;
 use clap::Args;
@@ -32,6 +32,7 @@ pub async fn run(
 ) -> anyhow::Result<()> {
     let catalogs_root = config_dir.join(&resolved.resources.catalog_schema.path);
     let content_blocks_root = config_dir.join(&resolved.resources.content_block.path);
+    let email_templates_root = config_dir.join(&resolved.resources.email_template.path);
     let client = BrazeClient::from_resolved(&resolved);
     let kinds = selected_kinds(args.resource, &resolved.resources);
 
@@ -50,6 +51,14 @@ pub async fn run(
                     .await
                     .context("exporting content_block")?;
                 eprintln!("✓ content_block: exported {n} resource(s)");
+                total_written += n;
+            }
+            ResourceKind::EmailTemplate => {
+                let n =
+                    export_email_templates(&client, &email_templates_root, args.name.as_deref())
+                        .await
+                        .context("exporting email_template")?;
+                eprintln!("✓ email_template: exported {n} resource(s)");
                 total_written += n;
             }
             other => {
@@ -127,4 +136,44 @@ async fn export_content_blocks(
         content_block_io::save_content_block(content_blocks_root, cb)?;
     }
     Ok(blocks.len())
+}
+
+/// Same list-then-fetch pattern as content blocks.
+async fn export_email_templates(
+    client: &BrazeClient,
+    email_templates_root: &Path,
+    name_filter: Option<&str>,
+) -> anyhow::Result<usize> {
+    let summaries = client.list_email_templates().await?;
+    let targets: Vec<_> = match name_filter {
+        Some(name) => summaries.into_iter().filter(|s| s.name == name).collect(),
+        None => summaries,
+    };
+
+    if targets.is_empty() {
+        if let Some(name) = name_filter {
+            eprintln!("⚠ email_template: '{name}' not found in Braze");
+        }
+        return Ok(0);
+    }
+
+    let templates: Vec<crate::resource::EmailTemplate> =
+        futures::stream::iter(targets.iter().map(|s| {
+            let name = s.name.as_str();
+            let id = s.email_template_id.as_str();
+            async move {
+                client
+                    .get_email_template(id)
+                    .await
+                    .with_context(|| format!("fetching email template '{name}'"))
+            }
+        }))
+        .buffer_unordered(FETCH_CONCURRENCY)
+        .try_collect()
+        .await?;
+
+    for et in &templates {
+        email_template_io::save_email_template(email_templates_root, et)?;
+    }
+    Ok(templates.len())
 }

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -7,7 +7,7 @@
 
 use crate::config::ConfigFile;
 use crate::error::Error;
-use crate::fs::{catalog_io, content_block_io};
+use crate::fs::{catalog_io, content_block_io, email_template_io};
 use crate::resource::ResourceKind;
 use anyhow::anyhow;
 use clap::Args;
@@ -51,6 +51,10 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
                     cfg.naming.content_block_name_pattern.as_deref(),
                     &mut issues,
                 )?;
+            }
+            ResourceKind::EmailTemplate => {
+                let email_templates_root = config_dir.join(&cfg.resources.email_template.path);
+                validate_email_templates(&email_templates_root, &mut issues)?;
             }
             other => warn_unimplemented(other),
         }
@@ -222,6 +226,68 @@ fn validate_content_blocks(
                     ),
                 });
             }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_email_templates(
+    email_templates_root: &Path,
+    issues: &mut Vec<ValidationIssue>,
+) -> anyhow::Result<()> {
+    let read_dir = match std::fs::read_dir(email_templates_root) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(_) if email_templates_root.is_file() => {
+            issues.push(ValidationIssue {
+                path: email_templates_root.to_path_buf(),
+                message: "expected directory for the email_templates root".into(),
+            });
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    for entry in read_dir {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_dir() {
+            tracing::debug!(path = %path.display(), "skipping non-directory entry");
+            continue;
+        }
+        let template_yaml_path = path.join("template.yaml");
+        if !template_yaml_path.is_file() {
+            continue;
+        }
+        let dir_name = entry.file_name().to_string_lossy().into_owned();
+
+        let et = match email_template_io::read_email_template_dir(&path) {
+            Ok(et) => et,
+            Err(e) => {
+                issues.push(ValidationIssue {
+                    path: template_yaml_path.clone(),
+                    message: format!("parse error: {e}"),
+                });
+                continue;
+            }
+        };
+
+        if et.name != dir_name {
+            issues.push(ValidationIssue {
+                path: template_yaml_path.clone(),
+                message: format!(
+                    "email template name '{}' does not match its directory '{}'",
+                    et.name, dir_name
+                ),
+            });
+        }
+
+        if et.subject.is_empty() {
+            issues.push(ValidationIssue {
+                path: template_yaml_path.clone(),
+                message: format!("email template '{}' has an empty subject", et.name),
+            });
         }
     }
 

--- a/src/diff/content_block.rs
+++ b/src/diff/content_block.rs
@@ -10,7 +10,7 @@
 //! endpoint. Excluding `state` keeps the local file free to carry that
 //! metadata for human readers without producing false-positive diffs.
 
-use crate::diff::{compute_text_diff, tags_eq_unordered, DiffOp, TextDiffSummary};
+use crate::diff::{compute_text_diff, opt_str_eq, tags_eq_unordered, DiffOp, TextDiffSummary};
 use crate::resource::ContentBlock;
 use std::collections::BTreeMap;
 
@@ -102,26 +102,11 @@ pub fn diff(
 /// failure mode the `state` exclusion exists to prevent.
 fn syncable_eq(a: &ContentBlock, b: &ContentBlock) -> bool {
     a.name == b.name
-        && desc_eq(&a.description, &b.description)
+        && opt_str_eq(&a.description, &b.description)
         && a.content == b.content
         && tags_eq_unordered(&a.tags, &b.tags)
 }
 
-/// `None` and `Some("")` both mean "no description" for the purposes
-/// of diffing. Braze's `/info` omits the field entirely when a block
-/// has no description, so it always deserializes as `None`; a local
-/// file that carries `description: ""` (either because an operator
-/// typed an empty value or because YAML round-tripped a missing key
-/// that way) would otherwise diff as Modified forever, push the empty
-/// string on apply, come back as `None` again on the next fetch, and
-/// loop — the same infinite-drift failure mode as the `state`
-/// exclusion. Treating the two as equal here is the narrowest fix
-/// that preserves file fidelity (we deliberately do NOT normalize on
-/// load, so an intentional `description: ""` still round-trips to
-/// disk byte-for-byte).
-fn desc_eq(a: &Option<String>, b: &Option<String>) -> bool {
-    a.as_deref().unwrap_or("") == b.as_deref().unwrap_or("")
-}
 
 #[cfg(test)]
 mod tests {
@@ -247,7 +232,7 @@ mod tests {
 
     #[test]
     fn empty_local_description_equals_missing_remote_description() {
-        // Regression guard for the `desc_eq` fix. A local file with
+        // Regression guard for the `opt_str_eq` fix. A local file with
         // `description: ""` must diff equal against a remote /info
         // response that omits the field entirely (which deserializes
         // as `None`). Otherwise apply would push the empty string,
@@ -279,7 +264,7 @@ mod tests {
 
     #[test]
     fn real_description_difference_is_still_modified() {
-        // `desc_eq` must NOT collapse genuinely distinct descriptions.
+        // `opt_str_eq` must NOT collapse genuinely distinct descriptions.
         // Guards against a fix that accidentally unwrap-or-empties
         // both sides into the same non-empty string (which `==` would
         // otherwise catch, but belt and braces).

--- a/src/diff/content_block.rs
+++ b/src/diff/content_block.rs
@@ -107,7 +107,6 @@ fn syncable_eq(a: &ContentBlock, b: &ContentBlock) -> bool {
         && tags_eq_unordered(&a.tags, &b.tags)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/diff/content_block.rs
+++ b/src/diff/content_block.rs
@@ -10,9 +10,8 @@
 //! endpoint. Excluding `state` keeps the local file free to carry that
 //! metadata for human readers without producing false-positive diffs.
 
-use crate::diff::DiffOp;
+use crate::diff::{compute_text_diff, tags_eq_unordered, DiffOp, TextDiffSummary};
 use crate::resource::ContentBlock;
-use similar::{ChangeTag, TextDiff};
 use std::collections::BTreeMap;
 
 /// Name → Braze `content_block_id`. Built during diff, consumed by
@@ -27,12 +26,6 @@ pub struct ContentBlockDiff {
     pub text_diff: Option<TextDiffSummary>,
     /// True when present in Braze but missing from Git.
     pub orphan: bool,
-}
-
-#[derive(Debug, Clone)]
-pub struct TextDiffSummary {
-    pub additions: usize,
-    pub deletions: usize,
 }
 
 impl ContentBlockDiff {
@@ -128,38 +121,6 @@ fn syncable_eq(a: &ContentBlock, b: &ContentBlock) -> bool {
 /// disk byte-for-byte).
 fn desc_eq(a: &Option<String>, b: &Option<String>) -> bool {
     a.as_deref().unwrap_or("") == b.as_deref().unwrap_or("")
-}
-
-/// Multiset equality: same length + same elements after sort. Keeps
-/// duplicate-awareness (unlike a set) so `["a","a"]` vs `["a"]` still
-/// surfaces as a real change on the off chance Braze ever returns
-/// duplicated tags.
-fn tags_eq_unordered(a: &[String], b: &[String]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut a: Vec<&str> = a.iter().map(String::as_str).collect();
-    let mut b: Vec<&str> = b.iter().map(String::as_str).collect();
-    a.sort_unstable();
-    b.sort_unstable();
-    a == b
-}
-
-fn compute_text_diff(from: &str, to: &str) -> TextDiffSummary {
-    let diff = TextDiff::from_lines(from, to);
-    let mut additions = 0;
-    let mut deletions = 0;
-    for change in diff.iter_all_changes() {
-        match change.tag() {
-            ChangeTag::Insert => additions += 1,
-            ChangeTag::Delete => deletions += 1,
-            ChangeTag::Equal => {}
-        }
-    }
-    TextDiffSummary {
-        additions,
-        deletions,
-    }
 }
 
 #[cfg(test)]

--- a/src/diff/email_template.rs
+++ b/src/diff/email_template.rs
@@ -8,10 +8,8 @@
 //! as Modified forever — the same "infinite drift" mode the Content Block
 //! `state` exclusion prevents. See PHASE_B1_NOTES.md §3 / §6.
 
-use crate::diff::content_block::TextDiffSummary;
-use crate::diff::DiffOp;
+use crate::diff::{compute_text_diff, tags_eq_unordered, DiffOp, TextDiffSummary};
 use crate::resource::EmailTemplate;
-use similar::{ChangeTag, TextDiff};
 use std::collections::BTreeMap;
 
 /// Name → Braze `email_template_id`. Built during diff, consumed by
@@ -147,35 +145,6 @@ fn metadata_eq(a: &EmailTemplate, b: &EmailTemplate) -> bool {
 /// the field or return empty string.
 fn preheader_eq(a: &Option<String>, b: &Option<String>) -> bool {
     a.as_deref().unwrap_or("") == b.as_deref().unwrap_or("")
-}
-
-/// Multiset equality: same length + same elements after sort.
-fn tags_eq_unordered(a: &[String], b: &[String]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut a: Vec<&str> = a.iter().map(String::as_str).collect();
-    let mut b: Vec<&str> = b.iter().map(String::as_str).collect();
-    a.sort_unstable();
-    b.sort_unstable();
-    a == b
-}
-
-fn compute_text_diff(from: &str, to: &str) -> TextDiffSummary {
-    let diff = TextDiff::from_lines(from, to);
-    let mut additions = 0;
-    let mut deletions = 0;
-    for change in diff.iter_all_changes() {
-        match change.tag() {
-            ChangeTag::Insert => additions += 1,
-            ChangeTag::Delete => deletions += 1,
-            ChangeTag::Equal => {}
-        }
-    }
-    TextDiffSummary {
-        additions,
-        deletions,
-    }
 }
 
 #[cfg(test)]

--- a/src/diff/email_template.rs
+++ b/src/diff/email_template.rs
@@ -8,7 +8,7 @@
 //! as Modified forever — the same "infinite drift" mode the Content Block
 //! `state` exclusion prevents. See PHASE_B1_NOTES.md §3 / §6.
 
-use crate::diff::{compute_text_diff, tags_eq_unordered, DiffOp, TextDiffSummary};
+use crate::diff::{compute_text_diff, opt_str_eq, tags_eq_unordered, DiffOp, TextDiffSummary};
 use crate::resource::EmailTemplate;
 use std::collections::BTreeMap;
 
@@ -126,7 +126,7 @@ fn syncable_eq(a: &EmailTemplate, b: &EmailTemplate) -> bool {
         && a.subject == b.subject
         && a.body_html == b.body_html
         && a.body_plaintext == b.body_plaintext
-        && preheader_eq(&a.preheader, &b.preheader)
+        && opt_str_eq(&a.preheader, &b.preheader)
         && a.should_inline_css == b.should_inline_css
         && tags_eq_unordered(&a.tags, &b.tags)
     // description excluded (read-only, like ContentBlock state)
@@ -135,17 +135,11 @@ fn syncable_eq(a: &EmailTemplate, b: &EmailTemplate) -> bool {
 /// Metadata equality (everything except subject, body_html, body_plaintext,
 /// and description). Used to set the `metadata_changed` flag.
 fn metadata_eq(a: &EmailTemplate, b: &EmailTemplate) -> bool {
-    preheader_eq(&a.preheader, &b.preheader)
+    opt_str_eq(&a.preheader, &b.preheader)
         && a.should_inline_css == b.should_inline_css
         && tags_eq_unordered(&a.tags, &b.tags)
 }
 
-/// `None` and `Some("")` both mean "no preheader" for the purposes of
-/// diffing. Same pattern as Content Block `desc_eq` — Braze may omit
-/// the field or return empty string.
-fn preheader_eq(a: &Option<String>, b: &Option<String>) -> bool {
-    a.as_deref().unwrap_or("") == b.as_deref().unwrap_or("")
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/diff/email_template.rs
+++ b/src/diff/email_template.rs
@@ -140,7 +140,6 @@ fn metadata_eq(a: &EmailTemplate, b: &EmailTemplate) -> bool {
         && tags_eq_unordered(&a.tags, &b.tags)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/diff/email_template.rs
+++ b/src/diff/email_template.rs
@@ -1,18 +1,33 @@
-//! Email Template diff types.
+//! Email Template diff.
+//!
+//! ### Why `description` is excluded from the syncable comparison
+//!
+//! Braze's `/templates/email/info` returns `description` but the
+//! create and update endpoints cannot set it. Including it in
+//! `syncable_eq` would make any local file with `description: "..."` diff
+//! as Modified forever — the same "infinite drift" mode the Content Block
+//! `state` exclusion prevents. See PHASE_B1_NOTES.md §3 / §6.
 
 use crate::diff::content_block::TextDiffSummary;
 use crate::diff::DiffOp;
+use crate::resource::EmailTemplate;
+use similar::{ChangeTag, TextDiff};
+use std::collections::BTreeMap;
+
+/// Name → Braze `email_template_id`. Built during diff, consumed by
+/// apply to translate per-name plan entries into the id the update
+/// endpoint requires.
+pub type EmailTemplateIdIndex = BTreeMap<String, String>;
 
 #[derive(Debug, Clone)]
 pub struct EmailTemplateDiff {
     pub name: String,
-    // TODO(phase-b): change to DiffOp<EmailTemplate> for symmetry with
-    // CatalogSchemaDiff — natural to refactor when B2 implements this resource.
-    pub op: DiffOp<()>,
+    pub op: DiffOp<EmailTemplate>,
     pub subject_changed: bool,
     pub body_html_diff: Option<TextDiffSummary>,
     pub body_plaintext_diff: Option<TextDiffSummary>,
     pub metadata_changed: bool,
+    /// True when present in Braze but missing from Git.
     pub orphan: bool,
 }
 
@@ -28,5 +43,293 @@ impl EmailTemplateDiff {
 
     pub fn is_orphan(&self) -> bool {
         self.orphan
+    }
+
+    /// Canonical constructor for the remote-only / orphan shape. No
+    /// DELETE API → `op` stays `Unchanged`; callers branch on the
+    /// `orphan` flag instead.
+    pub fn orphan(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            op: DiffOp::Unchanged,
+            subject_changed: false,
+            body_html_diff: None,
+            body_plaintext_diff: None,
+            metadata_changed: false,
+            orphan: true,
+        }
+    }
+}
+
+/// Returns `None` only when both sides are absent. Local is desired
+/// state, remote is current Braze state.
+pub fn diff(
+    local: Option<&EmailTemplate>,
+    remote: Option<&EmailTemplate>,
+) -> Option<EmailTemplateDiff> {
+    match (local, remote) {
+        (None, None) => None,
+        (Some(l), None) => Some(EmailTemplateDiff {
+            name: l.name.clone(),
+            op: DiffOp::Added(l.clone()),
+            subject_changed: false,
+            body_html_diff: None,
+            body_plaintext_diff: None,
+            metadata_changed: false,
+            orphan: false,
+        }),
+        (None, Some(r)) => Some(EmailTemplateDiff::orphan(&r.name)),
+        (Some(l), Some(r)) => {
+            if syncable_eq(l, r) {
+                Some(EmailTemplateDiff {
+                    name: l.name.clone(),
+                    op: DiffOp::Unchanged,
+                    subject_changed: false,
+                    body_html_diff: None,
+                    body_plaintext_diff: None,
+                    metadata_changed: false,
+                    orphan: false,
+                })
+            } else {
+                let subject_changed = l.subject != r.subject;
+                let body_html_diff = if l.body_html != r.body_html {
+                    Some(compute_text_diff(&r.body_html, &l.body_html))
+                } else {
+                    None
+                };
+                let body_plaintext_diff = if l.body_plaintext != r.body_plaintext {
+                    Some(compute_text_diff(&r.body_plaintext, &l.body_plaintext))
+                } else {
+                    None
+                };
+                let metadata_changed = !metadata_eq(l, r);
+                Some(EmailTemplateDiff {
+                    name: l.name.clone(),
+                    op: DiffOp::Modified {
+                        from: r.clone(),
+                        to: l.clone(),
+                    },
+                    subject_changed,
+                    body_html_diff,
+                    body_plaintext_diff,
+                    metadata_changed,
+                    orphan: false,
+                })
+            }
+        }
+    }
+}
+
+/// Equality for the fields braze-sync can actually push to Braze.
+/// Excludes `description` — see the module docs. Tags are compared as a
+/// multiset because Braze's APIs don't document tag-order stability.
+fn syncable_eq(a: &EmailTemplate, b: &EmailTemplate) -> bool {
+    a.name == b.name
+        && a.subject == b.subject
+        && a.body_html == b.body_html
+        && a.body_plaintext == b.body_plaintext
+        && preheader_eq(&a.preheader, &b.preheader)
+        && a.should_inline_css == b.should_inline_css
+        && tags_eq_unordered(&a.tags, &b.tags)
+    // description excluded (read-only, like ContentBlock state)
+}
+
+/// Metadata equality (everything except subject, body_html, body_plaintext,
+/// and description). Used to set the `metadata_changed` flag.
+fn metadata_eq(a: &EmailTemplate, b: &EmailTemplate) -> bool {
+    preheader_eq(&a.preheader, &b.preheader)
+        && a.should_inline_css == b.should_inline_css
+        && tags_eq_unordered(&a.tags, &b.tags)
+}
+
+/// `None` and `Some("")` both mean "no preheader" for the purposes of
+/// diffing. Same pattern as Content Block `desc_eq` — Braze may omit
+/// the field or return empty string.
+fn preheader_eq(a: &Option<String>, b: &Option<String>) -> bool {
+    a.as_deref().unwrap_or("") == b.as_deref().unwrap_or("")
+}
+
+/// Multiset equality: same length + same elements after sort.
+fn tags_eq_unordered(a: &[String], b: &[String]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut a: Vec<&str> = a.iter().map(String::as_str).collect();
+    let mut b: Vec<&str> = b.iter().map(String::as_str).collect();
+    a.sort_unstable();
+    b.sort_unstable();
+    a == b
+}
+
+fn compute_text_diff(from: &str, to: &str) -> TextDiffSummary {
+    let diff = TextDiff::from_lines(from, to);
+    let mut additions = 0;
+    let mut deletions = 0;
+    for change in diff.iter_all_changes() {
+        match change.tag() {
+            ChangeTag::Insert => additions += 1,
+            ChangeTag::Delete => deletions += 1,
+            ChangeTag::Equal => {}
+        }
+    }
+    TextDiffSummary {
+        additions,
+        deletions,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn et(name: &str, html: &str) -> EmailTemplate {
+        EmailTemplate {
+            name: name.into(),
+            subject: format!("Subject {name}"),
+            body_html: html.into(),
+            body_plaintext: format!("plain {name}"),
+            description: Some(format!("{name} desc")),
+            preheader: Some("preview".into()),
+            should_inline_css: Some(true),
+            tags: vec!["tag".into()],
+        }
+    }
+
+    #[test]
+    fn both_absent_returns_none() {
+        assert!(diff(None, None).is_none());
+    }
+
+    #[test]
+    fn local_only_is_added() {
+        let l = et("welcome", "<p>Hi</p>");
+        let d = diff(Some(&l), None).unwrap();
+        assert!(matches!(d.op, DiffOp::Added(_)));
+        assert!(!d.orphan);
+        assert!(d.has_changes());
+    }
+
+    #[test]
+    fn remote_only_is_orphan_not_removed() {
+        let r = et("legacy", "<p>old</p>");
+        let d = diff(None, Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Unchanged));
+        assert!(d.orphan);
+        assert!(d.is_orphan());
+        assert!(d.has_changes());
+    }
+
+    #[test]
+    fn equal_templates_are_unchanged() {
+        let l = et("same", "<p>body</p>\n");
+        let r = et("same", "<p>body</p>\n");
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Unchanged));
+        assert!(!d.orphan);
+        assert!(!d.has_changes());
+    }
+
+    #[test]
+    fn subject_change_is_modified() {
+        let mut l = et("sub", "<p>body</p>\n");
+        let r = et("sub", "<p>body</p>\n");
+        l.subject = "New subject".into();
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Modified { .. }));
+        assert!(d.subject_changed);
+        assert!(d.body_html_diff.is_none());
+        assert!(d.body_plaintext_diff.is_none());
+    }
+
+    #[test]
+    fn body_html_change_produces_text_diff() {
+        let l = et("html", "line a\nline b\nline c\n");
+        let mut r = et("html", "line a\nold b\nline c\n");
+        r.body_html = "line a\nold b\nline c\n".into();
+        // sync the plaintext so only html differs
+        r.body_plaintext = l.body_plaintext.clone();
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Modified { .. }));
+        let td = d.body_html_diff.expect("html diff present");
+        assert_eq!(td.additions, 1);
+        assert_eq!(td.deletions, 1);
+        assert!(d.body_plaintext_diff.is_none());
+    }
+
+    #[test]
+    fn body_plaintext_change_produces_text_diff() {
+        let l = et("txt", "<p>same</p>");
+        let mut r = et("txt", "<p>same</p>");
+        r.body_plaintext = "different plain".into();
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Modified { .. }));
+        assert!(d.body_html_diff.is_none());
+        assert!(d.body_plaintext_diff.is_some());
+    }
+
+    #[test]
+    fn description_difference_alone_is_not_drift() {
+        let mut l = et("desc", "<p>body</p>");
+        let r = et("desc", "<p>body</p>");
+        l.description = Some("new desc".into());
+        // Make sure description is the ONLY difference
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Unchanged), "got {:?}", d.op);
+        assert!(!d.has_changes());
+    }
+
+    #[test]
+    fn tag_reorder_alone_is_not_drift() {
+        let mut l = et("tags", "<p>body</p>");
+        let mut r = et("tags", "<p>body</p>");
+        l.tags = vec!["alpha".into(), "beta".into(), "gamma".into()];
+        r.tags = vec!["gamma".into(), "alpha".into(), "beta".into()];
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Unchanged), "got {:?}", d.op);
+        assert!(!d.has_changes());
+    }
+
+    #[test]
+    fn tag_change_is_modified_with_metadata_flag() {
+        let mut l = et("tags2", "<p>body</p>");
+        let r = et("tags2", "<p>body</p>");
+        l.tags = vec!["a".into(), "b".into()];
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Modified { .. }));
+        assert!(d.metadata_changed);
+        assert!(!d.subject_changed);
+    }
+
+    #[test]
+    fn preheader_none_equals_empty() {
+        let mut l = et("pre", "<p>body</p>");
+        let mut r = et("pre", "<p>body</p>");
+        l.preheader = Some(String::new());
+        r.preheader = None;
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Unchanged), "got {:?}", d.op);
+        assert!(!d.has_changes());
+    }
+
+    #[test]
+    fn should_inline_css_change_is_metadata_modified() {
+        let mut l = et("css", "<p>body</p>");
+        let r = et("css", "<p>body</p>");
+        l.should_inline_css = Some(false);
+        let d = diff(Some(&l), Some(&r)).unwrap();
+        assert!(matches!(d.op, DiffOp::Modified { .. }));
+        assert!(d.metadata_changed);
+    }
+
+    #[test]
+    fn destructive_count_is_never_set_on_email_templates() {
+        let r = et("ghost", "<p>x</p>");
+        let orphan = diff(None, Some(&r)).unwrap();
+        assert!(!orphan.op.is_destructive());
+
+        let l2 = et("changed", "<p>new</p>");
+        let r2 = et("changed", "<p>old</p>");
+        let modified = diff(Some(&l2), Some(&r2)).unwrap();
+        assert!(!modified.op.is_destructive());
     }
 }

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -6,12 +6,48 @@
 //! match arms to be updated by the compiler.
 
 use crate::resource::ResourceKind;
+use similar::{ChangeTag, TextDiff};
 
 pub mod catalog;
 pub mod content_block;
 pub mod custom_attribute;
 pub mod email_template;
 pub mod orphan;
+
+#[derive(Debug, Clone)]
+pub struct TextDiffSummary {
+    pub additions: usize,
+    pub deletions: usize,
+}
+
+pub(crate) fn compute_text_diff(from: &str, to: &str) -> TextDiffSummary {
+    let diff = TextDiff::from_lines(from, to);
+    let mut additions = 0;
+    let mut deletions = 0;
+    for change in diff.iter_all_changes() {
+        match change.tag() {
+            ChangeTag::Insert => additions += 1,
+            ChangeTag::Delete => deletions += 1,
+            ChangeTag::Equal => {}
+        }
+    }
+    TextDiffSummary {
+        additions,
+        deletions,
+    }
+}
+
+/// Multiset equality: same elements after sort, ignoring order.
+pub(crate) fn tags_eq_unordered(a: &[String], b: &[String]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut a: Vec<&str> = a.iter().map(String::as_str).collect();
+    let mut b: Vec<&str> = b.iter().map(String::as_str).collect();
+    a.sort_unstable();
+    b.sort_unstable();
+    a == b
+}
 
 /// A diff operation on a single entity. Polymorphic over the entity type so
 /// the same vocabulary applies to whole resources, individual fields, etc.

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -37,6 +37,12 @@ pub(crate) fn compute_text_diff(from: &str, to: &str) -> TextDiffSummary {
     }
 }
 
+/// Treats `None` and `Some("")` as equal — Braze may omit a field or
+/// return an empty string interchangeably.
+pub(crate) fn opt_str_eq(a: &Option<String>, b: &Option<String>) -> bool {
+    a.as_deref().unwrap_or("") == b.as_deref().unwrap_or("")
+}
+
 /// Multiset equality: same elements after sort, ignoring order.
 pub(crate) fn tags_eq_unordered(a: &[String], b: &[String]) -> bool {
     if a.len() != b.len() {

--- a/src/format/fixtures.rs
+++ b/src/format/fixtures.rs
@@ -5,9 +5,9 @@
 
 use crate::diff::catalog::{diff_schema, CatalogItemsDiff};
 use crate::diff::content_block::{diff as diff_content_block, ContentBlockDiff};
-use crate::diff::TextDiffSummary;
 use crate::diff::custom_attribute::{CustomAttributeDiff, CustomAttributeOp};
 use crate::diff::email_template::EmailTemplateDiff;
+use crate::diff::TextDiffSummary;
 use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::resource::{Catalog, CatalogField, CatalogFieldType, ContentBlock, ContentBlockState};
 

--- a/src/format/fixtures.rs
+++ b/src/format/fixtures.rs
@@ -4,7 +4,8 @@
 //! corresponding TableFormatter / JsonFormatter snapshot is reproducible.
 
 use crate::diff::catalog::{diff_schema, CatalogItemsDiff};
-use crate::diff::content_block::{diff as diff_content_block, ContentBlockDiff, TextDiffSummary};
+use crate::diff::content_block::{diff as diff_content_block, ContentBlockDiff};
+use crate::diff::TextDiffSummary;
 use crate::diff::custom_attribute::{CustomAttributeDiff, CustomAttributeOp};
 use crate::diff::email_template::EmailTemplateDiff;
 use crate::diff::{DiffOp, DiffSummary, ResourceDiff};

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -12,7 +12,8 @@
 //! the boundary in [`From`] impls.
 
 use crate::diff::catalog::{CatalogItemsDiff, CatalogSchemaDiff};
-use crate::diff::content_block::{ContentBlockDiff, TextDiffSummary};
+use crate::diff::content_block::ContentBlockDiff;
+use crate::diff::TextDiffSummary;
 use crate::diff::custom_attribute::{CustomAttributeDiff, CustomAttributeOp};
 use crate::diff::email_template::EmailTemplateDiff;
 use crate::diff::{DiffOp, DiffSummary, ResourceDiff};

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -13,9 +13,9 @@
 
 use crate::diff::catalog::{CatalogItemsDiff, CatalogSchemaDiff};
 use crate::diff::content_block::ContentBlockDiff;
-use crate::diff::TextDiffSummary;
 use crate::diff::custom_attribute::{CustomAttributeDiff, CustomAttributeOp};
 use crate::diff::email_template::EmailTemplateDiff;
+use crate::diff::TextDiffSummary;
 use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::resource::CatalogField;
 use serde::Serialize;

--- a/src/fs/email_template_io.rs
+++ b/src/fs/email_template_io.rs
@@ -1,0 +1,413 @@
+//! Email Template file I/O.
+//!
+//! Each email template lives in its own directory under the templates root:
+//!
+//! ```text
+//! email_templates/
+//! └── welcome/
+//!     ├── template.yaml   # metadata (name, subject, preheader, tags, …)
+//!     ├── body.html       # HTML body (byte-faithful)
+//!     └── body.txt        # plaintext fallback (byte-faithful)
+//! ```
+//!
+//! The 3-file layout keeps body diffs reviewable in PRs (no YAML escaping)
+//! and follows the directory-per-resource pattern from IMPLEMENTATION.md §9.5.
+
+use crate::error::{Error, Result};
+use crate::fs::{validate_resource_name, write_atomic};
+use crate::resource::EmailTemplate;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+const TEMPLATE_YAML: &str = "template.yaml";
+const BODY_HTML: &str = "body.html";
+const BODY_TXT: &str = "body.txt";
+
+/// On-disk wire shape for `template.yaml`. Kept private so the file
+/// layout can change without affecting consumers of [`EmailTemplate`].
+#[derive(Debug, Serialize, Deserialize)]
+struct TemplateYaml {
+    name: String,
+    subject: String,
+    /// Read-only field from Braze /info. Not settable via create/update.
+    /// Excluded from syncable_eq (same pattern as ContentBlock `state`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    preheader: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    should_inline_css: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<String>,
+}
+
+/// Load every email template directory directly under `root`, sorted by name.
+/// Missing root is not an error. Each directory's name must match its
+/// `template.yaml` `name:` field — divergence is a hard parse error.
+pub fn load_all_email_templates(root: &Path) -> Result<Vec<EmailTemplate>> {
+    let read_dir = match std::fs::read_dir(root) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            if root.is_file() {
+                return Err(Error::InvalidFormat {
+                    path: root.to_path_buf(),
+                    message: "expected a directory for the email_templates root".into(),
+                });
+            }
+            return Err(e.into());
+        }
+    };
+
+    let mut templates = Vec::new();
+    for entry in read_dir {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_dir() {
+            tracing::debug!(path = %path.display(), "skipping non-directory entry");
+            continue;
+        }
+        let template_yaml_path = path.join(TEMPLATE_YAML);
+        if !template_yaml_path.is_file() {
+            tracing::debug!(path = %path.display(), "skipping directory without template.yaml");
+            continue;
+        }
+        let dir_name = entry.file_name().to_str().unwrap_or_default().to_string();
+        let et = read_email_template_dir(&path)?;
+        if et.name != dir_name {
+            return Err(Error::InvalidFormat {
+                path: template_yaml_path,
+                message: format!(
+                    "email template name '{}' does not match its directory '{}'",
+                    et.name, dir_name
+                ),
+            });
+        }
+        templates.push(et);
+    }
+
+    templates.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(templates)
+}
+
+/// Read a single email template directory. Does not validate that the
+/// directory name matches `name`; callers do that.
+pub fn read_email_template_dir(dir: &Path) -> Result<EmailTemplate> {
+    let yaml_path = dir.join(TEMPLATE_YAML);
+    let yaml_text = std::fs::read_to_string(&yaml_path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            Error::InvalidFormat {
+                path: yaml_path.clone(),
+                message: "template.yaml not found".into(),
+            }
+        } else {
+            e.into()
+        }
+    })?;
+    let meta: TemplateYaml = serde_norway::from_str(&yaml_text).map_err(|e| Error::YamlParse {
+        path: yaml_path.clone(),
+        source: e,
+    })?;
+
+    let html_path = dir.join(BODY_HTML);
+    let body_html = read_body_file(&html_path)?;
+
+    let txt_path = dir.join(BODY_TXT);
+    let body_plaintext = read_body_file(&txt_path)?;
+
+    Ok(EmailTemplate {
+        name: meta.name,
+        subject: meta.subject,
+        body_html,
+        body_plaintext,
+        description: meta.description,
+        preheader: meta.preheader,
+        should_inline_css: meta.should_inline_css,
+        tags: meta.tags,
+    })
+}
+
+/// Read a body file. Missing file → empty string (§6.4: empty is valid).
+/// Byte-faithful — no trailing newline normalization.
+fn read_body_file(path: &Path) -> Result<String> {
+    match std::fs::read_to_string(path) {
+        Ok(s) => Ok(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Write `et` to `<root>/<et.name>/{template.yaml, body.html, body.txt}`.
+/// Names containing path separators or `..` are rejected.
+pub fn save_email_template(root: &Path, et: &EmailTemplate) -> Result<()> {
+    validate_resource_name("email template", &et.name)?;
+    let dir = root.join(&et.name);
+
+    let meta = TemplateYaml {
+        name: et.name.clone(),
+        subject: et.subject.clone(),
+        // `description` is only emitted when present. A fresh export from
+        // Braze /info will carry it; operator-authored files without one
+        // omit the field entirely rather than writing `description: ""`.
+        description: et.description.clone(),
+        preheader: et.preheader.clone(),
+        should_inline_css: et.should_inline_css,
+        tags: et.tags.clone(),
+    };
+    let yaml_text = format!(
+        "# Generated by braze-sync.\n{}",
+        serde_norway::to_string(&meta).map_err(|e| Error::InvalidFormat {
+            path: dir.join(TEMPLATE_YAML),
+            message: format!("failed to serialize template.yaml: {e}"),
+        })?
+    );
+
+    write_atomic(&dir.join(TEMPLATE_YAML), yaml_text.as_bytes())?;
+    // Body files are written byte-exact (B1 invariant #2).
+    write_atomic(&dir.join(BODY_HTML), et.body_html.as_bytes())?;
+    write_atomic(&dir.join(BODY_TXT), et.body_plaintext.as_bytes())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn et(name: &str, html: &str) -> EmailTemplate {
+        EmailTemplate {
+            name: name.into(),
+            subject: format!("Subject for {name}"),
+            body_html: html.into(),
+            body_plaintext: format!("plain: {name}"),
+            description: Some(format!("desc for {name}")),
+            preheader: Some("preview".into()),
+            should_inline_css: Some(true),
+            tags: vec!["t1".into()],
+        }
+    }
+
+    #[test]
+    fn round_trip_single_template() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = et("welcome", "<p>Hello</p>\n");
+        save_email_template(dir.path(), &original).unwrap();
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0], original);
+    }
+
+    #[test]
+    fn save_creates_nested_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("braze").join("email_templates");
+        save_email_template(&nested, &et("nested", "x")).unwrap();
+        assert!(nested.join("nested").join("template.yaml").is_file());
+        assert!(nested.join("nested").join("body.html").is_file());
+        assert!(nested.join("nested").join("body.txt").is_file());
+    }
+
+    #[test]
+    fn load_sorts_alphabetically() {
+        let dir = tempfile::tempdir().unwrap();
+        save_email_template(dir.path(), &et("zebra", "z")).unwrap();
+        save_email_template(dir.path(), &et("apple", "a")).unwrap();
+        save_email_template(dir.path(), &et("mango", "m")).unwrap();
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(
+            loaded.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            vec!["apple", "mango", "zebra"]
+        );
+    }
+
+    #[test]
+    fn missing_root_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let nonexistent = dir.path().join("not_here");
+        let loaded = load_all_email_templates(&nonexistent).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn empty_root_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn root_pointing_at_a_file_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("not_a_dir");
+        std::fs::write(&file_path, "x").unwrap();
+        let err = load_all_email_templates(&file_path).unwrap_err();
+        assert!(matches!(err, Error::InvalidFormat { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn dir_without_template_yaml_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("empty_dir")).unwrap();
+        save_email_template(dir.path(), &et("real", "body")).unwrap();
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "real");
+    }
+
+    #[test]
+    fn name_mismatch_with_dir_name_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let wrong_dir = dir.path().join("on_disk_name");
+        std::fs::create_dir_all(&wrong_dir).unwrap();
+        std::fs::write(
+            wrong_dir.join("template.yaml"),
+            "name: in_yaml_name\nsubject: x\n",
+        )
+        .unwrap();
+        std::fs::write(wrong_dir.join("body.html"), "").unwrap();
+        std::fs::write(wrong_dir.join("body.txt"), "").unwrap();
+        let err = load_all_email_templates(dir.path()).unwrap_err();
+        match err {
+            Error::InvalidFormat { message, .. } => {
+                assert!(message.contains("on_disk_name"));
+                assert!(message.contains("in_yaml_name"));
+            }
+            other => panic!("expected InvalidFormat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_yaml_field_is_ignored_for_forward_compat() {
+        let dir = tempfile::tempdir().unwrap();
+        let tpl_dir = dir.path().join("future");
+        std::fs::create_dir_all(&tpl_dir).unwrap();
+        std::fs::write(
+            tpl_dir.join("template.yaml"),
+            "name: future\nsubject: s\nfuture_v2_field: surprise\n",
+        )
+        .unwrap();
+        std::fs::write(tpl_dir.join("body.html"), "<p>hi</p>").unwrap();
+        std::fs::write(tpl_dir.join("body.txt"), "hi").unwrap();
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "future");
+    }
+
+    #[test]
+    fn save_rejects_path_traversal_in_name() {
+        let dir = tempfile::tempdir().unwrap();
+        for bad in ["../evil", "..", ".", "", "a/b", "a\\b"] {
+            let bad_et = EmailTemplate {
+                name: bad.into(),
+                subject: "x".into(),
+                body_html: String::new(),
+                body_plaintext: String::new(),
+                description: None,
+                preheader: None,
+                should_inline_css: None,
+                tags: vec![],
+            };
+            let err = save_email_template(dir.path(), &bad_et).unwrap_err();
+            assert!(
+                matches!(err, Error::InvalidFormat { .. }),
+                "name {bad:?} should be rejected; got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn save_overwrites_existing_template() {
+        let dir = tempfile::tempdir().unwrap();
+        save_email_template(dir.path(), &et("ovr", "v1\n")).unwrap();
+        save_email_template(dir.path(), &et("ovr", "v2\n")).unwrap();
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].body_html, "v2\n");
+    }
+
+    #[test]
+    fn body_without_trailing_newline_round_trips_byte_exact() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = EmailTemplate {
+            name: "no_eol".into(),
+            subject: "x".into(),
+            body_html: "<p>Hello</p>".into(),
+            body_plaintext: "Hello".into(),
+            description: None,
+            preheader: None,
+            should_inline_css: None,
+            tags: vec![],
+        };
+        save_email_template(dir.path(), &original).unwrap();
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(loaded[0].body_html, "<p>Hello</p>");
+        assert_eq!(loaded[0].body_plaintext, "Hello");
+        assert_eq!(loaded[0], original);
+    }
+
+    #[test]
+    fn empty_body_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let empty = EmailTemplate {
+            name: "blank".into(),
+            subject: "x".into(),
+            body_html: String::new(),
+            body_plaintext: String::new(),
+            description: None,
+            preheader: None,
+            should_inline_css: None,
+            tags: vec![],
+        };
+        save_email_template(dir.path(), &empty).unwrap();
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(loaded[0], empty);
+    }
+
+    #[test]
+    fn missing_body_files_default_to_empty_string() {
+        let dir = tempfile::tempdir().unwrap();
+        let tpl_dir = dir.path().join("minimal");
+        std::fs::create_dir_all(&tpl_dir).unwrap();
+        std::fs::write(tpl_dir.join("template.yaml"), "name: minimal\nsubject: s\n").unwrap();
+        // No body.html or body.txt files
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].body_html, "");
+        assert_eq!(loaded[0].body_plaintext, "");
+    }
+
+    #[test]
+    fn template_yaml_has_header_comment() {
+        let dir = tempfile::tempdir().unwrap();
+        save_email_template(dir.path(), &et("commented", "<p>hi</p>")).unwrap();
+        let text =
+            std::fs::read_to_string(dir.path().join("commented").join("template.yaml")).unwrap();
+        assert!(
+            text.starts_with("# Generated by braze-sync."),
+            "expected header comment; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn description_none_omits_field_from_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let no_desc = EmailTemplate {
+            name: "nodesc".into(),
+            subject: "x".into(),
+            body_html: String::new(),
+            body_plaintext: String::new(),
+            description: None,
+            preheader: None,
+            should_inline_css: None,
+            tags: vec![],
+        };
+        save_email_template(dir.path(), &no_desc).unwrap();
+        let text =
+            std::fs::read_to_string(dir.path().join("nodesc").join("template.yaml")).unwrap();
+        assert!(
+            !text.contains("description"),
+            "None description should not be serialized; got:\n{text}"
+        );
+        let loaded = load_all_email_templates(dir.path()).unwrap();
+        assert_eq!(loaded[0], no_desc);
+    }
+}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod catalog_io;
 pub mod content_block_io;
+pub mod email_template_io;
 pub mod frontmatter;
 
 use crate::error::{Error, Result};

--- a/src/resource/email_template.rs
+++ b/src/resource/email_template.rs
@@ -3,6 +3,13 @@
 //! `body_plaintext` is always present (`String`, not `Option<String>`); the
 //! empty string is the legitimate value for HTML-only templates. This is a
 //! deliberate decision recorded in §17.
+//!
+//! API verification (2026-04-12):
+//! - `from_address`, `from_display_name`, `reply_to` do NOT exist in Braze API
+//! - `description` is returned by /info but NOT settable via create/update (read-only)
+//! - `should_inline_css` is supported by create/update/info
+//! - Braze field name mapping: `template_name`→`name`, `body`→`body_html`,
+//!   `plaintext_body`→`body_plaintext`
 
 use serde::{Deserialize, Serialize};
 
@@ -15,14 +22,15 @@ pub struct EmailTemplate {
     /// Plaintext fallback. Empty string allowed; field always present.
     #[serde(default)]
     pub body_plaintext: String,
+    /// Returned by Braze /info but not settable via create/update.
+    /// Excluded from syncable_eq (same pattern as ContentBlock `state`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub from_address: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub from_display_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reply_to: Option<String>,
+    pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preheader: Option<String>,
+    /// CSS inline processing toggle. Supported by create/update/info.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub should_inline_css: Option<bool>,
     #[serde(default)]
     pub tags: Vec<String>,
 }
@@ -38,10 +46,9 @@ mod tests {
             subject: "Welcome".into(),
             body_html: "<p>hi</p>".into(),
             body_plaintext: "hi".into(),
-            from_address: Some("noreply@example.com".into()),
-            from_display_name: Some("Example".into()),
-            reply_to: None,
+            description: Some("Welcome email".into()),
             preheader: Some("Get started".into()),
+            should_inline_css: Some(true),
             tags: vec!["onboarding".into()],
         };
         let yaml = serde_norway::to_string(&t).unwrap();
@@ -56,10 +63,9 @@ mod tests {
             subject: "x".into(),
             body_html: "<p>x</p>".into(),
             body_plaintext: String::new(),
-            from_address: None,
-            from_display_name: None,
-            reply_to: None,
+            description: None,
             preheader: None,
+            should_inline_css: None,
             tags: vec![],
         };
         let yaml = serde_norway::to_string(&t).unwrap();

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -15,7 +15,9 @@
 mod common;
 
 use assert_cmd::Command;
-use common::{write_config, write_local_content_block, write_local_schema};
+use common::{
+    write_config, write_local_content_block, write_local_email_template, write_local_schema,
+};
 use serde_json::json;
 use wiremock::matchers::{body_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -680,6 +682,190 @@ async fn content_block_archive_orphans_skips_already_archived_blocks() {
                 "apply",
                 "--resource",
                 "content_block",
+                "--confirm",
+                "--archive-orphans",
+            ])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
+// =====================================================================
+// Email Template (v0.3.0)
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn email_template_dry_run_makes_no_write_calls() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"templates": []})))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/templates/email/create"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_email_template(tmp.path(), "fresh", "Welcome", "<p>Hi</p>", "Hi");
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "email_template"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn email_template_confirm_create_posts_to_create_endpoint() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"templates": []})))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/templates/email/create"))
+        .and(body_json(json!({
+            "template_name": "fresh",
+            "subject": "Welcome",
+            "body": "<p>Hi</p>",
+            "plaintext_body": "Hi",
+            "tags": []
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "email_template_id": "new-id"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_email_template(tmp.path(), "fresh", "Welcome", "<p>Hi</p>", "Hi");
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "email_template", "--confirm"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn email_template_confirm_update_posts_to_update_endpoint() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": [{"email_template_id": "id-w", "template_name": "welcome"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/info"))
+        .and(query_param("email_template_id", "id-w"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "template_name": "welcome",
+            "subject": "Old subject",
+            "body": "<p>Old</p>",
+            "plaintext_body": "Old",
+            "tags": [],
+            "message": "success"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/templates/email/update"))
+        .and(body_json(json!({
+            "email_template_id": "id-w",
+            "template_name": "welcome",
+            "subject": "New subject",
+            "body": "<p>New</p>",
+            "plaintext_body": "New",
+            "tags": []
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_email_template(tmp.path(), "welcome", "New subject", "<p>New</p>", "New");
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "email_template", "--confirm"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn email_template_archive_orphans_renames_via_update() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": [{"email_template_id": "id-old", "template_name": "old_promo"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/info"))
+        .and(query_param("email_template_id", "id-old"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "template_name": "old_promo",
+            "subject": "Old",
+            "body": "<p>Old</p>",
+            "plaintext_body": "Old",
+            "tags": [],
+            "message": "success"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/templates/email/update"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "email_template",
                 "--confirm",
                 "--archive-orphans",
             ])

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -9,7 +9,9 @@
 mod common;
 
 use assert_cmd::Command;
-use common::{write_config, write_local_content_block, write_local_schema};
+use common::{
+    write_config, write_local_content_block, write_local_email_template, write_local_schema,
+};
 use serde_json::json;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -385,4 +387,119 @@ async fn diff_with_json_format_emits_valid_v1_json() {
     assert_eq!(v["diffs"][0]["kind"], "catalog_schema");
     assert_eq!(v["diffs"][0]["name"], "stable");
     assert_eq!(v["diffs"][0]["op"], "unchanged");
+}
+
+// =====================================================================
+// Email Template (v0.3.0)
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_email_template_added_when_remote_missing() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"templates": []})))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_email_template(tmp.path(), "fresh", "Welcome", "<p>Hi</p>", "Hi");
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "email_template"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Email Template: fresh"), "stdout: {stdout}");
+    assert!(stdout.contains("+ new email template"), "stdout: {stdout}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_email_template_orphan_when_local_missing() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": [
+                {"email_template_id": "id-old", "template_name": "old_campaign"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    // No local email templates written
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "email_template"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("orphaned"), "stdout: {stdout}");
+    assert!(stdout.contains("1 changed"), "stdout: {stdout}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_email_template_no_drift_when_identical() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": [{"email_template_id": "id-w", "template_name": "welcome"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "template_name": "welcome",
+            "subject": "Hi",
+            "body": "<p>Hi</p>",
+            "plaintext_body": "Hi",
+            "tags": [],
+            "message": "success"
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_email_template(tmp.path(), "welcome", "Hi", "<p>Hi</p>", "Hi");
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "email_template"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("no drift"), "stdout: {stdout}");
+    assert!(stdout.contains("0 changed"), "stdout: {stdout}");
 }

--- a/tests/cli_export.rs
+++ b/tests/cli_export.rs
@@ -312,3 +312,64 @@ async fn export_content_block_with_name_filter_only_fetches_matching_info() {
         .join("content_blocks/shared_header.liquid")
         .exists());
 }
+
+// =====================================================================
+// Email Template (v0.3.0)
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn export_email_templates_writes_directory_layout() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": [
+                {"email_template_id": "id-welcome", "template_name": "welcome"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "template_name": "welcome",
+            "subject": "Welcome to our service",
+            "body": "<p>Hello</p>",
+            "plaintext_body": "Hello",
+            "description": "Welcome email",
+            "preheader": "Get started",
+            "tags": ["onboarding"],
+            "message": "success"
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    let tmp_path = tmp.path().to_path_buf();
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["export", "--resource", "email_template"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let et_dir = tmp_path.join("email_templates/welcome");
+    assert!(et_dir.join("template.yaml").exists());
+    assert!(et_dir.join("body.html").exists());
+    assert!(et_dir.join("body.txt").exists());
+
+    let yaml = fs::read_to_string(et_dir.join("template.yaml")).unwrap();
+    assert!(yaml.contains("name: welcome"));
+    assert!(yaml.contains("subject: Welcome to our service"));
+    let html = fs::read_to_string(et_dir.join("body.html")).unwrap();
+    assert_eq!(html, "<p>Hello</p>");
+    let txt = fs::read_to_string(et_dir.join("body.txt")).unwrap();
+    assert_eq!(txt, "Hello");
+}

--- a/tests/cli_validate.rs
+++ b/tests/cli_validate.rs
@@ -11,7 +11,7 @@ mod common;
 use assert_cmd::Command;
 use common::{
     write_config_for_validate as write_config, write_content_block_raw, write_local_content_block,
-    write_schema_raw,
+    write_local_email_template, write_schema_raw,
 };
 
 #[test]
@@ -235,4 +235,59 @@ fn validate_reports_content_block_naming_pattern_violation() {
         stderr.contains("content_block_name_pattern"),
         "stderr: {stderr}"
     );
+}
+
+// =====================================================================
+// Email Template (v0.3.0)
+// =====================================================================
+
+#[test]
+fn validate_passes_for_well_formed_email_template() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = write_config(dir.path(), None, None);
+    write_local_email_template(dir.path(), "welcome", "Hello", "<p>Hi</p>", "Hi");
+
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .args(["validate", "--resource", "email_template"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn validate_reports_email_template_name_dir_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = write_config(dir.path(), None, None);
+    let et_dir = dir.path().join("email_templates").join("on_disk");
+    std::fs::create_dir_all(&et_dir).unwrap();
+    std::fs::write(et_dir.join("template.yaml"), "name: in_yaml\nsubject: x\n").unwrap();
+    std::fs::write(et_dir.join("body.html"), "").unwrap();
+    std::fs::write(et_dir.join("body.txt"), "").unwrap();
+
+    let output = Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .args(["validate", "--resource", "email_template"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("on_disk"), "stderr: {stderr}");
+    assert!(stderr.contains("in_yaml"), "stderr: {stderr}");
+}
+
+#[test]
+fn validate_email_template_does_not_require_braze_api_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = write_config(dir.path(), None, None);
+    write_local_email_template(dir.path(), "no_key", "Hello", "<p>x</p>", "x");
+
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .args(["validate", "--resource", "email_template"])
+        .assert()
+        .success();
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -84,3 +84,19 @@ pub fn write_content_block_raw(dir: &Path, name: &str, content: &str) {
     fs::create_dir_all(&cb_dir).unwrap();
     fs::write(cb_dir.join(format!("{name}.liquid")), content).unwrap();
 }
+
+/// Write a local email template directory under `<dir>/email_templates/<name>/`.
+pub fn write_local_email_template(
+    dir: &Path,
+    name: &str,
+    subject: &str,
+    body_html: &str,
+    body_txt: &str,
+) {
+    let et_dir = dir.join("email_templates").join(name);
+    fs::create_dir_all(&et_dir).unwrap();
+    let yaml = format!("name: {name}\nsubject: {subject}\n");
+    fs::write(et_dir.join("template.yaml"), yaml).unwrap();
+    fs::write(et_dir.join("body.html"), body_html).unwrap();
+    fs::write(et_dir.join("body.txt"), body_txt).unwrap();
+}


### PR DESCRIPTION
## Summary

- Full Email Template support: 3-file directory layout (`template.yaml` + `body.html` + `body.txt`), Braze API client (list/get/create/update), per-part diff engine, orphan tracking, and all 4 CLI commands (export/diff/apply/validate)
- API verification (2026-04-12) corrected struct design: removed `from_address`/`from_display_name`/`reply_to` (not in Braze API), added `description` (read-only) and `should_inline_css`
- Follows all B1 invariants: fail-closed pagination, byte-faithful body round-trip, `description` excluded from syncable_eq, tags multiset comparison, duplicate name guard, UTC archive timestamps

## Changes

| Area | Files | What |
|:---|:---|:---|
| FS I/O | `src/fs/email_template_io.rs` (new) | 3-file layout read/save, dir-name check, path-traversal guard |
| Braze API | `src/braze/email_template.rs` (new) | 4 endpoints with field name mapping (`template_name`↔`name`, `body`↔`body_html`, `plaintext_body`↔`body_plaintext`) |
| Diff | `src/diff/email_template.rs` | Full rewrite: `DiffOp<EmailTemplate>`, per-part diff, `syncable_eq` with invariants |
| Domain type | `src/resource/email_template.rs` | Struct aligned with API reality |
| CLI | `src/cli/{export,diff,apply,validate}.rs` | EmailTemplate arms wired |
| Tests | unit + integration | 223 → 278 tests (+55) |
| Version | `Cargo.toml` | `0.2.1` → `0.3.0` |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] 278 tests all passing (228 unit + 50 integration)
- [x] Email Template export writes 3-file directory layout
- [x] Email Template diff detects added/modified/orphan/unchanged
- [x] Email Template apply creates/updates/archives correctly
- [x] Email Template validate checks name-dir mismatch
- [x] Dry-run makes zero write calls
- [x] `--archive-orphans` renames via update endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full email template support across CLI: export, diff, apply, validate, and list; export writes per-template directories with metadata, HTML and plaintext bodies.
  * Local filesystem load/save for email templates; diffs now show fine-grained changes and mark orphaned remote templates.

* **Bug Fixes**
  * Stronger API-response validation surfaced for pagination, duplicate names, and not-found responses.

* **Chores**
  * Crate version bumped to 0.3.0

* **Tests**
  * New integration and unit tests covering email-template flows and IO.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->