### PR TITLE
Phase C1: init command (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to braze-sync are recorded here. The format loosely
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
+§0.2 the v0.x line is crates.io-published but tolerates breaking
+changes; v1.0 freezes the public surface (CLI flags, config schema,
+file formats, JSON output, exit codes) for the full v1.x line.
+
+## [Unreleased]
+
+## [0.6.0] — 2026-04-17
+
+### Added
+
+- `braze-sync init` — scaffolds a new workspace with a commented
+  `braze-sync.config.yaml`, resource directories (`catalogs/`,
+  `content_blocks/`, `email_templates/`, `custom_attributes/`), and
+  `.gitignore` entries for `.env` files. Idempotent on directories and
+  `.gitignore`; requires `--force` to overwrite an existing config.
+- `braze-sync init --from-existing` — scaffolds then immediately runs
+  `export` against the configured environment, populating the layout
+  with current Braze state in a single command. Keeps an already-edited
+  config rather than overwriting it, so it can be run after the
+  operator has pointed the endpoint at their instance.
+
+## [0.5.0] — Phase B4
+
+Custom Attribute end-to-end (registry mode: read + diff + deprecation
+toggle only; create is intentionally unsupported — see
+IMPLEMENTATION.md §2.2).
+
+## [0.4.0] — Phase B3
+
+Catalog Items end-to-end with CSV streaming and blake3 content-hash
+diffs.
+
+## [0.3.0] — Phase B2
+
+Email Template end-to-end with per-part diffs (subject / body_html /
+body_plaintext / metadata) and orphan tracking (Braze has no DELETE).
+
+## [0.2.1]
+
+Catalog list pagination fail-closed; crates.io auto-publish CI.
+
+## [0.2.0] — Phase B1
+
+Content Block end-to-end with orphan tracking and `--archive-orphans`.
+
+## [0.1.0] — Phase A
+
+Catalog Schema end-to-end across all four core commands: `export`,
+`diff`, `apply`, `validate`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -8,20 +8,19 @@ synchronize it to Braze with the same workflow you'd use for
 detection in CI, and an `--allow-destructive` gate that has to be
 crossed explicitly before anything is dropped.
 
-## Status: v0.2.0 (Catalog Schema + Content Block)
+## Status: v0.6.0 (all 5 resources + init)
 
-v0.2.0 ships **Catalog Schema** and **Content Block** end-to-end:
+All five v1.0 resource kinds are implemented end-to-end: **Catalog
+Schema**, **Catalog Items**, **Content Block**, **Email Template**, and
+**Custom Attribute** (registry mode).
 
 | Command | What it does |
 |:---|:---|
+| `braze-sync init` | Scaffolds a new workspace (config, directories, `.gitignore`) |
 | `braze-sync export` | Pulls current Braze state into local files |
 | `braze-sync diff` | Shows drift between local files and Braze |
 | `braze-sync apply` | Applies local intent to Braze (dry-run by default) |
 | `braze-sync validate` | Local-only structural and naming checks (no API call) |
-
-Three other resource kinds (Email Template, Catalog Items, Custom
-Attribute) are visible in `--resource` and emit a "not yet implemented
-(Phase B)" warning. They fill in across v0.3.0 → v0.5.0.
 
 ### Content Block specifics
 
@@ -61,33 +60,37 @@ cargo install --path .
 
 ## Quick start
 
-1. Set your Braze API key in an environment variable:
+1. Scaffold a new workspace (config, directories, `.gitignore`):
+
+   ```bash
+   braze-sync init
+   ```
+
+   This writes a commented `braze-sync.config.yaml` (pointing at the
+   EU default endpoint — edit if your instance is elsewhere) plus
+   empty `catalogs/`, `content_blocks/`, `email_templates/`, and
+   `custom_attributes/` directories. Safe to re-run: existing configs
+   are kept unless `--force` is passed.
+
+2. Set your Braze API key in an environment variable:
 
    ```bash
    export BRAZE_DEV_API_KEY="your-key-here"
    ```
 
-2. Create `braze-sync.config.yaml`:
-
-   ```yaml
-   version: 1
-   default_environment: dev
-   environments:
-     dev:
-       api_endpoint: https://rest.fra-02.braze.eu
-       api_key_env: BRAZE_DEV_API_KEY
-   ```
-
-3. Pull the current state from Braze:
+3. Pull the current Braze state into the scaffolded layout:
 
    ```bash
    braze-sync export
    ```
 
-   This writes `catalogs/<name>/schema.yaml` for every Catalog Schema in
-   your workspace.
+   Or do steps 1 and 3 in one shot:
 
-4. Edit a schema (e.g. add a field) and check the drift:
+   ```bash
+   braze-sync init --from-existing
+   ```
+
+4. Edit a resource (e.g. add a catalog field) and check the drift:
 
    ```bash
    braze-sync diff
@@ -128,15 +131,11 @@ API keys never live in the config file. The config only references the
 held in `secrecy::SecretString` from the moment it leaves the OS so
 that `tracing` / `Debug` / panic messages cannot leak it.
 
-## v0.2.0 limitations
+## Limitations
 
 These will be lifted across the v0.x → v1.0 milestones:
 
-- **Catalog Schema and Content Block only.** Email Template, Catalog
-  Items, and Custom Attribute land in v0.3 → v0.5. They appear in
-  `--resource` so the CLI surface stays stable, but selecting one in
-  v0.2.0 just emits a "not yet implemented (Phase B)" warning.
-- **No catalog create / delete.** v0.2.0 manages fields on existing
+- **No catalog create / delete.** v0.6.0 manages fields on existing
   catalogs. To create a brand-new catalog, create it in the Braze
   dashboard first, then run `braze-sync export`.
 - **No field type changes.** Changing a field's type from `string` to

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use super::diff::resolve_catalog_names;
 use super::{selected_kinds, FETCH_CONCURRENCY};
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Default)]
 pub struct ExportArgs {
     /// Limit export to a specific resource kind. Omit to export every
     /// enabled resource kind in turn.

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,26 +1,8 @@
 //! `braze-sync init` — scaffold a new braze-sync workspace.
 //!
-//! Writes:
-//! - `braze-sync.config.yaml` at the `--config` path (with commented
-//!   guidance so the user can edit in place).
-//! - Resource directories (`catalogs/`, `content_blocks/`,
-//!   `email_templates/`, `custom_attributes/`) as siblings of the config
-//!   file, matching the default paths in [`ResourcesConfig`].
-//! - `.gitignore` entries for `.env` and `.env.*` (appended if absent;
-//!   never deduped through rewrite).
-//!
-//! Runs **before** config loading in [`crate::cli::run`], so a missing
-//! config file is the normal case rather than exit code 3.
-//!
-//! `--force` is the only gate on overwriting an existing config file.
-//! Directories and `.gitignore` are always idempotent: creating an
-//! existing directory is a no-op, and `.gitignore` entries are added
-//! only if not already present.
-//!
-//! With `--from-existing`, init additionally loads the scaffolded (or
-//! pre-existing) config, resolves the environment, and runs the same
-//! code path as `braze-sync export` with no filter — so the operator
-//! ends up with a fully populated layout in one command.
+//! `.gitignore` entries are appended (not rewritten) so any operator
+//! edits to that file survive. `--force` only gates the config file;
+//! directories and `.gitignore` are always idempotent.
 
 use crate::config::ConfigFile;
 use anyhow::{bail, Context as _};
@@ -63,7 +45,7 @@ pub async fn run(
         (false, false) => OnExisting::Fail,
     };
     let config_written = write_config_file(config_path, on_existing)?;
-    let dirs_created = scaffold_resource_dirs(&config_dir)?;
+    scaffold_resource_dirs(&config_dir)?;
     let gitignore_updated = update_gitignore(&config_dir)?;
 
     eprintln!(
@@ -75,10 +57,7 @@ pub async fn run(
             "exists, kept"
         }
     );
-    eprintln!(
-        "✓ directories: {dirs_created} created, {} kept",
-        SUBDIRS.len() - dirs_created
-    );
+    eprintln!("✓ directories: ensured");
     eprintln!(
         "✓ .gitignore: {}",
         if gitignore_updated {
@@ -102,15 +81,10 @@ pub async fn run(
     Ok(())
 }
 
-/// Policy for what to do when the config file already exists.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OnExisting {
-    /// Operator asked for `--force`: clobber the existing file.
     Overwrite,
-    /// Operator asked for `--from-existing`: assume the file is
-    /// intentionally pre-edited (endpoint/env vars) and keep it.
     Keep,
-    /// Neither flag: refuse and tell the operator to pass `--force`.
     Fail,
 }
 
@@ -135,9 +109,9 @@ fn write_config_file(config_path: &Path, on_existing: OnExisting) -> anyhow::Res
     Ok(true)
 }
 
-/// Default resource subdirectories matching `ResourcesConfig` defaults.
-/// An operator who edits the config to point elsewhere is expected to
-/// create those directories themselves.
+/// Matches the resource paths in `CONFIG_TEMPLATE` (and thus
+/// `ResourcesConfig` defaults). An operator who edits the config to
+/// point elsewhere is expected to create those directories themselves.
 const SUBDIRS: [&str; 4] = [
     "catalogs",
     "content_blocks",
@@ -145,19 +119,13 @@ const SUBDIRS: [&str; 4] = [
     "custom_attributes",
 ];
 
-/// Creates the resource directories as siblings of the config file.
-/// Returns the number newly created (for the summary line).
-fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<usize> {
-    let mut created = 0;
+fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<()> {
     for sub in SUBDIRS {
         let dir = config_dir.join(sub);
-        if !dir.exists() {
-            fs::create_dir_all(&dir)
-                .with_context(|| format!("creating directory {}", dir.display()))?;
-            created += 1;
-        }
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("creating directory {}", dir.display()))?;
     }
-    Ok(created)
+    Ok(())
 }
 
 /// Ensures `.gitignore` contains lines for `.env` and `.env.*`. Appends
@@ -218,9 +186,6 @@ async fn run_from_existing(
     super::export::run(&export_args, resolved, config_dir).await
 }
 
-/// Commented config template — mirrors IMPLEMENTATION.md §10. Kept in
-/// the binary so `init` works offline and so the comments stay in sync
-/// with the deserializer.
 pub(crate) const CONFIG_TEMPLATE: &str = r#"# braze-sync configuration (v1 schema, frozen at v1.0).
 # Reference: https://github.com/uny/braze-sync#configuration
 
@@ -338,8 +303,7 @@ mod tests {
     #[test]
     fn scaffold_creates_all_four_dirs() {
         let tmp = tempfile::tempdir().unwrap();
-        let created = scaffold_resource_dirs(tmp.path()).unwrap();
-        assert_eq!(created, 4);
+        scaffold_resource_dirs(tmp.path()).unwrap();
         for sub in SUBDIRS {
             assert!(tmp.path().join(sub).is_dir(), "{sub} should exist");
         }
@@ -349,8 +313,7 @@ mod tests {
     fn scaffold_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
         scaffold_resource_dirs(tmp.path()).unwrap();
-        let created = scaffold_resource_dirs(tmp.path()).unwrap();
-        assert_eq!(created, 0, "second run creates nothing");
+        scaffold_resource_dirs(tmp.path()).expect("second run should succeed");
     }
 
     #[test]

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -88,9 +88,6 @@ enum OnExisting {
     Fail,
 }
 
-/// Write the scaffolded config. Returns `true` if a new file was
-/// written, `false` if an existing one was kept. See [`OnExisting`]
-/// for the policy applied when the file already exists.
 fn write_config_file(config_path: &Path, on_existing: OnExisting) -> anyhow::Result<bool> {
     if config_path.exists() {
         match on_existing {
@@ -119,6 +116,8 @@ const SUBDIRS: [&str; 4] = [
     "custom_attributes",
 ];
 
+const GITIGNORE_ENTRIES: [&str; 2] = [".env", ".env.*"];
+
 fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<()> {
     for sub in SUBDIRS {
         let dir = config_dir.join(sub);
@@ -128,13 +127,10 @@ fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Ensures `.gitignore` contains lines for `.env` and `.env.*`. Appends
-/// missing entries under a clearly-labeled braze-sync section so the
-/// operator can tell where they came from. Returns `true` if any entry
-/// was added.
+/// Missing entries are appended under a labeled section so the operator
+/// can tell where they came from; existing file content is preserved.
 fn update_gitignore(config_dir: &Path) -> anyhow::Result<bool> {
     let path = config_dir.join(".gitignore");
-    const ENTRIES: [&str; 2] = [".env", ".env.*"];
 
     let existing = match fs::read_to_string(&path) {
         Ok(s) => s,
@@ -145,7 +141,11 @@ fn update_gitignore(config_dir: &Path) -> anyhow::Result<bool> {
     };
 
     let has_line = |needle: &str| existing.lines().any(|l| l.trim() == needle);
-    let missing: Vec<&str> = ENTRIES.iter().copied().filter(|e| !has_line(e)).collect();
+    let missing: Vec<&str> = GITIGNORE_ENTRIES
+        .iter()
+        .copied()
+        .filter(|e| !has_line(e))
+        .collect();
     if missing.is_empty() {
         return Ok(false);
     }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,8 +1,4 @@
 //! `braze-sync init` — scaffold a new braze-sync workspace.
-//!
-//! `.gitignore` entries are appended (not rewritten) so any operator
-//! edits to that file survive. `--force` only gates the config file;
-//! directories and `.gitignore` are always idempotent.
 
 use crate::config::ConfigFile;
 use anyhow::{bail, Context as _};
@@ -106,9 +102,6 @@ fn write_config_file(config_path: &Path, on_existing: OnExisting) -> anyhow::Res
     Ok(true)
 }
 
-/// Matches the resource paths in `CONFIG_TEMPLATE` (and thus
-/// `ResourcesConfig` defaults). An operator who edits the config to
-/// point elsewhere is expected to create those directories themselves.
 const SUBDIRS: [&str; 4] = [
     "catalogs",
     "content_blocks",
@@ -127,8 +120,6 @@ fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Missing entries are appended under a labeled section so the operator
-/// can tell where they came from; existing file content is preserved.
 fn update_gitignore(config_dir: &Path) -> anyhow::Result<bool> {
     let path = config_dir.join(".gitignore");
 
@@ -179,15 +170,10 @@ async fn run_from_existing(
         .resolve(env_override)
         .context("resolving environment for --from-existing")?;
 
-    let export_args = super::export::ExportArgs {
-        resource: None,
-        name: None,
-    };
-    super::export::run(&export_args, resolved, config_dir).await
+    super::export::run(&super::export::ExportArgs::default(), resolved, config_dir).await
 }
 
-pub(crate) const CONFIG_TEMPLATE: &str = r#"# braze-sync configuration (v1 schema, frozen at v1.0).
-# Reference: https://github.com/uny/braze-sync#configuration
+const CONFIG_TEMPLATE: &str = r#"# braze-sync configuration (v1 schema, frozen at v1.0).
 
 version: 1
 
@@ -241,14 +227,10 @@ mod tests {
 
     #[test]
     fn config_template_parses_as_valid_config() {
-        // Guard against drift: if the template ever disagrees with the
-        // deserializer, init would produce a config that the rest of
-        // braze-sync refuses to load. That's a bug we want to catch at
-        // build time, not at user `export` time.
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("braze-sync.config.yaml");
         fs::write(&path, CONFIG_TEMPLATE).unwrap();
-        let cfg = ConfigFile::load(&path).expect("template must load cleanly");
+        let cfg = ConfigFile::load(&path).unwrap();
         assert_eq!(cfg.version, 1);
         assert_eq!(cfg.default_environment, "dev");
         assert!(cfg.environments.contains_key("dev"));
@@ -270,7 +252,7 @@ mod tests {
         let first = update_gitignore(tmp.path()).unwrap();
         assert!(first);
         let second = update_gitignore(tmp.path()).unwrap();
-        assert!(!second, "second run should be a no-op");
+        assert!(!second);
     }
 
     #[test]
@@ -280,7 +262,7 @@ mod tests {
         fs::write(&path, "target/\ndist/\n").unwrap();
         update_gitignore(tmp.path()).unwrap();
         let content = fs::read_to_string(&path).unwrap();
-        assert!(content.contains("target/"), "existing entry must survive");
+        assert!(content.contains("target/"));
         assert!(content.contains("dist/"));
         assert!(content.contains(".env"));
     }
@@ -294,7 +276,7 @@ mod tests {
         assert!(updated);
         let content = fs::read_to_string(&path).unwrap();
         let count = content.lines().filter(|l| l.trim() == ".env").count();
-        assert_eq!(count, 1, "should not duplicate .env");
+        assert_eq!(count, 1);
         assert!(content.contains(".env.*"));
     }
 
@@ -303,7 +285,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         scaffold_resource_dirs(tmp.path()).unwrap();
         for sub in SUBDIRS {
-            assert!(tmp.path().join(sub).is_dir(), "{sub} should exist");
+            assert!(tmp.path().join(sub).is_dir());
         }
     }
 
@@ -311,7 +293,7 @@ mod tests {
     fn scaffold_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
         scaffold_resource_dirs(tmp.path()).unwrap();
-        scaffold_resource_dirs(tmp.path()).expect("second run should succeed");
+        scaffold_resource_dirs(tmp.path()).unwrap();
     }
 
     #[test]
@@ -342,7 +324,7 @@ mod tests {
         let path = tmp.path().join("braze-sync.config.yaml");
         fs::write(&path, "# operator-tuned\nversion: 1\n").unwrap();
         let written = write_config_file(&path, OnExisting::Keep).unwrap();
-        assert!(!written, "existing config should be kept");
+        assert!(!written);
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("operator-tuned"));
     }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,0 +1,431 @@
+//! `braze-sync init` — scaffold a new braze-sync workspace.
+//!
+//! Writes:
+//! - `braze-sync.config.yaml` at the `--config` path (with commented
+//!   guidance so the user can edit in place).
+//! - Resource directories (`catalogs/`, `content_blocks/`,
+//!   `email_templates/`, `custom_attributes/`) as siblings of the config
+//!   file, matching the default paths in [`ResourcesConfig`].
+//! - `.gitignore` entries for `.env` and `.env.*` (appended if absent;
+//!   never deduped through rewrite).
+//!
+//! Runs **before** config loading in [`crate::cli::run`], so a missing
+//! config file is the normal case rather than exit code 3.
+//!
+//! `--force` is the only gate on overwriting an existing config file.
+//! Directories and `.gitignore` are always idempotent: creating an
+//! existing directory is a no-op, and `.gitignore` entries are added
+//! only if not already present.
+//!
+//! With `--from-existing`, init additionally loads the scaffolded (or
+//! pre-existing) config, resolves the environment, and runs the same
+//! code path as `braze-sync export` with no filter — so the operator
+//! ends up with a fully populated layout in one command.
+
+use crate::config::ConfigFile;
+use anyhow::{bail, Context as _};
+use clap::Args;
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+#[derive(Args, Debug)]
+pub struct InitArgs {
+    /// Overwrite an existing `braze-sync.config.yaml`. Directories and
+    /// `.gitignore` are updated idempotently regardless.
+    #[arg(long)]
+    pub force: bool,
+
+    /// After scaffolding, pull the current state from Braze into the new
+    /// layout. Requires the API key env var from the scaffolded config
+    /// (by default `BRAZE_DEV_API_KEY`) to be set.
+    #[arg(long)]
+    pub from_existing: bool,
+}
+
+pub async fn run(
+    args: &InitArgs,
+    config_path: &Path,
+    env_override: Option<&str>,
+) -> anyhow::Result<()> {
+    let config_dir = config_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    fs::create_dir_all(&config_dir)
+        .with_context(|| format!("creating config directory {}", config_dir.display()))?;
+
+    // With `--from-existing`, an already-present config is assumed to
+    // be intentional (the operator configured endpoint/env vars before
+    // running init) — we keep it unless `--force` says otherwise.
+    // Without `--from-existing`, the presence of a config means the
+    // operator either already initialized or hand-wrote one; refusing
+    // without `--force` avoids silent clobber.
+    let config_written = write_config_file(config_path, args.force, args.from_existing)?;
+    let dirs_created = scaffold_resource_dirs(&config_dir)?;
+    let gitignore_updated = update_gitignore(&config_dir)?;
+
+    // Report what happened so the operator sees whether any step was a
+    // no-op. `init` being idempotent is a feature — we want it to be safe
+    // to re-run — but silent no-ops would hide misconfiguration.
+    eprintln!(
+        "✓ config:     {} ({})",
+        config_path.display(),
+        if config_written {
+            "written"
+        } else {
+            "exists, kept"
+        }
+    );
+    eprintln!(
+        "✓ directories: {dirs_created} created, {} kept",
+        4 - dirs_created
+    );
+    eprintln!(
+        "✓ .gitignore: {}",
+        if gitignore_updated {
+            "updated"
+        } else {
+            "already has entries"
+        }
+    );
+
+    if args.from_existing {
+        eprintln!("→ --from-existing: loading config and pulling Braze state…");
+        run_from_existing(config_path, &config_dir, env_override).await?;
+    } else {
+        eprintln!();
+        eprintln!("Next steps:");
+        eprintln!("  1. export BRAZE_DEV_API_KEY=<your key>");
+        eprintln!("  2. braze-sync export            # pull current Braze state");
+        eprintln!("  3. braze-sync diff              # preview drift");
+    }
+
+    Ok(())
+}
+
+/// Write the scaffolded config. Returns `true` if a new file was
+/// written, `false` if an existing one was kept.
+///
+/// Policy:
+/// - Config missing → always write.
+/// - Config exists + `force` → overwrite (with a warning).
+/// - Config exists + `allow_keep` (i.e. `--from-existing`) → keep it.
+/// - Config exists, neither flag → hard error instructing the operator
+///   to pass `--force`.
+fn write_config_file(config_path: &Path, force: bool, allow_keep: bool) -> anyhow::Result<bool> {
+    if config_path.exists() {
+        if force {
+            eprintln!("⚠ {} exists; overwriting (--force)", config_path.display());
+            // fall through to write
+        } else if allow_keep {
+            return Ok(false);
+        } else {
+            bail!(
+                "{} already exists; pass --force to overwrite",
+                config_path.display()
+            );
+        }
+    }
+    fs::write(config_path, CONFIG_TEMPLATE)
+        .with_context(|| format!("writing config to {}", config_path.display()))?;
+    Ok(true)
+}
+
+/// Creates the four resource directories as siblings of the config file.
+/// Returns the count of directories that didn't already exist — purely
+/// for the summary message.
+fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<usize> {
+    // These match the default `ResourcesConfig` paths; any operator who
+    // edits the config to point elsewhere is expected to create those
+    // directories themselves.
+    const SUBDIRS: [&str; 4] = [
+        "catalogs",
+        "content_blocks",
+        "email_templates",
+        "custom_attributes",
+    ];
+    let mut created = 0;
+    for sub in SUBDIRS {
+        let dir = config_dir.join(sub);
+        if !dir.exists() {
+            fs::create_dir_all(&dir)
+                .with_context(|| format!("creating directory {}", dir.display()))?;
+            created += 1;
+        }
+    }
+    Ok(created)
+}
+
+/// Ensures `.gitignore` contains lines for `.env` and `.env.*`. Appends
+/// missing entries under a clearly-labeled braze-sync section so the
+/// operator can tell where they came from. Returns `true` if any entry
+/// was added.
+fn update_gitignore(config_dir: &Path) -> anyhow::Result<bool> {
+    let path = config_dir.join(".gitignore");
+    const ENTRIES: [&str; 2] = [".env", ".env.*"];
+
+    let existing = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(e).with_context(|| format!("reading {}", path.display()));
+        }
+    };
+
+    let has_line = |needle: &str| existing.lines().any(|l| l.trim() == needle);
+    let missing: Vec<&str> = ENTRIES.iter().copied().filter(|e| !has_line(e)).collect();
+    if missing.is_empty() {
+        return Ok(false);
+    }
+
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("opening {} for append", path.display()))?;
+
+    // Insert a leading newline only if the existing file doesn't already
+    // end with one, so we don't glue our section onto the last existing
+    // entry.
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        f.write_all(b"\n")?;
+    }
+    if !existing.is_empty() {
+        f.write_all(b"\n# braze-sync\n")?;
+    } else {
+        f.write_all(b"# braze-sync\n")?;
+    }
+    for entry in missing {
+        writeln!(f, "{entry}")?;
+    }
+    Ok(true)
+}
+
+async fn run_from_existing(
+    config_path: &Path,
+    config_dir: &Path,
+    env_override: Option<&str>,
+) -> anyhow::Result<()> {
+    // Reload dotenv now that the user may have edited the just-written
+    // config or dropped a .env. The initial call in cli::run already
+    // happened, but re-running it is cheap and harmless.
+    if let Err(e) = crate::config::load_dotenv() {
+        tracing::warn!("dotenv: {e}");
+    }
+
+    let cfg = ConfigFile::load(config_path)
+        .with_context(|| format!("reloading config from {}", config_path.display()))?;
+    let resolved = cfg
+        .resolve(env_override)
+        .context("resolving environment for --from-existing")?;
+
+    // Delegate to the same code path as `braze-sync export` (no filter
+    // — pull everything that's enabled in the config).
+    let export_args = super::export::ExportArgs {
+        resource: None,
+        name: None,
+    };
+    super::export::run(&export_args, resolved, config_dir).await
+}
+
+/// Commented config template — mirrors IMPLEMENTATION.md §10. Kept in
+/// the binary so `init` works offline and so the comments stay in sync
+/// with the deserializer.
+pub(crate) const CONFIG_TEMPLATE: &str = r#"# braze-sync configuration (v1 schema, frozen at v1.0).
+# Reference: https://github.com/uny/braze-sync#configuration
+
+version: 1
+
+# Environment picked when --env is not passed.
+default_environment: dev
+
+defaults:
+  # Requests/minute cap applied via governor. Lower if you hit 429s.
+  rate_limit_per_minute: 40
+
+environments:
+  dev:
+    # Braze REST endpoint for your instance. See:
+    # https://www.braze.com/docs/api/basics/#endpoints
+    api_endpoint: https://rest.fra-02.braze.eu
+    # Name of the env var holding the API key — NEVER put the key itself
+    # in this file.
+    api_key_env: BRAZE_DEV_API_KEY
+  # prod:
+  #   api_endpoint: https://rest.fra-02.braze.eu
+  #   api_key_env: BRAZE_PROD_API_KEY
+  #   rate_limit_per_minute: 30
+
+resources:
+  catalog_schema:
+    enabled: true
+    path: catalogs/
+  catalog_items:
+    enabled: true
+    parallel_batches: 4
+  content_block:
+    enabled: true
+    path: content_blocks/
+  email_template:
+    enabled: true
+    path: email_templates/
+  custom_attribute:
+    enabled: true
+    path: custom_attributes/registry.yaml
+
+# Optional name validators enforced by `braze-sync validate`.
+# naming:
+#   catalog_name_pattern: "^[a-z][a-z0-9_]*$"
+#   content_block_name_pattern: "^[a-zA-Z0-9_]+$"
+#   custom_attribute_name_pattern: "^[a-z][a-z0-9_]*$"
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_template_parses_as_valid_config() {
+        // Guard against drift: if the template ever disagrees with the
+        // deserializer, init would produce a config that the rest of
+        // braze-sync refuses to load. That's a bug we want to catch at
+        // build time, not at user `export` time.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("braze-sync.config.yaml");
+        fs::write(&path, CONFIG_TEMPLATE).unwrap();
+        let cfg = ConfigFile::load(&path).expect("template must load cleanly");
+        assert_eq!(cfg.version, 1);
+        assert_eq!(cfg.default_environment, "dev");
+        assert!(cfg.environments.contains_key("dev"));
+    }
+
+    #[test]
+    fn gitignore_entries_added_on_fresh_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let updated = update_gitignore(tmp.path()).unwrap();
+        assert!(updated);
+        let content = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+        assert!(content.contains(".env"));
+        assert!(content.contains(".env.*"));
+    }
+
+    #[test]
+    fn gitignore_idempotent_on_second_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = update_gitignore(tmp.path()).unwrap();
+        assert!(first);
+        let second = update_gitignore(tmp.path()).unwrap();
+        assert!(!second, "second run should be a no-op");
+    }
+
+    #[test]
+    fn gitignore_preserves_existing_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".gitignore");
+        fs::write(&path, "target/\ndist/\n").unwrap();
+        update_gitignore(tmp.path()).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("target/"), "existing entry must survive");
+        assert!(content.contains("dist/"));
+        assert!(content.contains(".env"));
+    }
+
+    #[test]
+    fn gitignore_skips_already_present_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".gitignore");
+        fs::write(&path, ".env\n").unwrap();
+        let updated = update_gitignore(tmp.path()).unwrap();
+        // `.env.*` is still missing, so we expect an update.
+        assert!(updated);
+        let content = fs::read_to_string(&path).unwrap();
+        // `.env` should still appear exactly once.
+        let count = content.lines().filter(|l| l.trim() == ".env").count();
+        assert_eq!(count, 1, "should not duplicate .env");
+        assert!(content.contains(".env.*"));
+    }
+
+    #[test]
+    fn scaffold_creates_all_four_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let n = scaffold_resource_dirs(tmp.path()).unwrap();
+        assert_eq!(n, 4);
+        for sub in [
+            "catalogs",
+            "content_blocks",
+            "email_templates",
+            "custom_attributes",
+        ] {
+            assert!(tmp.path().join(sub).is_dir(), "{sub} should exist");
+        }
+    }
+
+    #[test]
+    fn scaffold_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        scaffold_resource_dirs(tmp.path()).unwrap();
+        let second = scaffold_resource_dirs(tmp.path()).unwrap();
+        assert_eq!(second, 0, "second run creates nothing");
+    }
+
+    #[test]
+    fn write_config_refuses_to_overwrite_without_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("braze-sync.config.yaml");
+        fs::write(&path, "version: 1\n# user edits\n").unwrap();
+        let err = write_config_file(&path, false, false).unwrap_err();
+        assert!(err.to_string().contains("--force"));
+        // Original content preserved.
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("user edits"));
+    }
+
+    #[test]
+    fn write_config_overwrites_with_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("braze-sync.config.yaml");
+        fs::write(&path, "# old\n").unwrap();
+        let written = write_config_file(&path, true, false).unwrap();
+        assert!(written);
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("braze-sync configuration"));
+    }
+
+    #[test]
+    fn write_config_keeps_existing_with_allow_keep() {
+        // --from-existing path: existing config is kept, not overwritten.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("braze-sync.config.yaml");
+        fs::write(&path, "# operator-tuned\nversion: 1\n").unwrap();
+        let written = write_config_file(&path, false, true).unwrap();
+        assert!(!written, "existing config should be kept");
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("operator-tuned"));
+    }
+
+    #[test]
+    fn write_config_writes_fresh_when_allow_keep_and_no_existing() {
+        // --from-existing in an empty dir still needs to scaffold the config.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("braze-sync.config.yaml");
+        let written = write_config_file(&path, false, true).unwrap();
+        assert!(written);
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn write_config_force_overrides_allow_keep() {
+        // If the operator explicitly says --force, overwrite even if
+        // --from-existing would otherwise keep the file.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("braze-sync.config.yaml");
+        fs::write(&path, "# old\n").unwrap();
+        let written = write_config_file(&path, true, true).unwrap();
+        assert!(written);
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("braze-sync configuration"));
+    }
+}

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -57,19 +57,15 @@ pub async fn run(
     fs::create_dir_all(&config_dir)
         .with_context(|| format!("creating config directory {}", config_dir.display()))?;
 
-    // With `--from-existing`, an already-present config is assumed to
-    // be intentional (the operator configured endpoint/env vars before
-    // running init) — we keep it unless `--force` says otherwise.
-    // Without `--from-existing`, the presence of a config means the
-    // operator either already initialized or hand-wrote one; refusing
-    // without `--force` avoids silent clobber.
-    let config_written = write_config_file(config_path, args.force, args.from_existing)?;
-    let dirs_created = scaffold_resource_dirs(&config_dir)?;
+    let on_existing = match (args.force, args.from_existing) {
+        (true, _) => OnExisting::Overwrite,
+        (false, true) => OnExisting::Keep,
+        (false, false) => OnExisting::Fail,
+    };
+    let config_written = write_config_file(config_path, on_existing)?;
+    let (dirs_created, dirs_total) = scaffold_resource_dirs(&config_dir)?;
     let gitignore_updated = update_gitignore(&config_dir)?;
 
-    // Report what happened so the operator sees whether any step was a
-    // no-op. `init` being idempotent is a feature — we want it to be safe
-    // to re-run — but silent no-ops would hide misconfiguration.
     eprintln!(
         "✓ config:     {} ({})",
         config_path.display(),
@@ -81,7 +77,7 @@ pub async fn run(
     );
     eprintln!(
         "✓ directories: {dirs_created} created, {} kept",
-        4 - dirs_created
+        dirs_total - dirs_created
     );
     eprintln!(
         "✓ .gitignore: {}",
@@ -93,7 +89,7 @@ pub async fn run(
     );
 
     if args.from_existing {
-        eprintln!("→ --from-existing: loading config and pulling Braze state…");
+        eprintln!("✓ --from-existing: loading config and pulling Braze state…");
         run_from_existing(config_path, &config_dir, env_override).await?;
     } else {
         eprintln!();
@@ -106,27 +102,32 @@ pub async fn run(
     Ok(())
 }
 
+/// Policy for what to do when the config file already exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OnExisting {
+    /// Operator asked for `--force`: clobber the existing file.
+    Overwrite,
+    /// Operator asked for `--from-existing`: assume the file is
+    /// intentionally pre-edited (endpoint/env vars) and keep it.
+    Keep,
+    /// Neither flag: refuse and tell the operator to pass `--force`.
+    Fail,
+}
+
 /// Write the scaffolded config. Returns `true` if a new file was
-/// written, `false` if an existing one was kept.
-///
-/// Policy:
-/// - Config missing → always write.
-/// - Config exists + `force` → overwrite (with a warning).
-/// - Config exists + `allow_keep` (i.e. `--from-existing`) → keep it.
-/// - Config exists, neither flag → hard error instructing the operator
-///   to pass `--force`.
-fn write_config_file(config_path: &Path, force: bool, allow_keep: bool) -> anyhow::Result<bool> {
+/// written, `false` if an existing one was kept. See [`OnExisting`]
+/// for the policy applied when the file already exists.
+fn write_config_file(config_path: &Path, on_existing: OnExisting) -> anyhow::Result<bool> {
     if config_path.exists() {
-        if force {
-            eprintln!("⚠ {} exists; overwriting (--force)", config_path.display());
-            // fall through to write
-        } else if allow_keep {
-            return Ok(false);
-        } else {
-            bail!(
+        match on_existing {
+            OnExisting::Overwrite => {
+                eprintln!("⚠ {} exists; overwriting (--force)", config_path.display());
+            }
+            OnExisting::Keep => return Ok(false),
+            OnExisting::Fail => bail!(
                 "{} already exists; pass --force to overwrite",
                 config_path.display()
-            );
+            ),
         }
     }
     fs::write(config_path, CONFIG_TEMPLATE)
@@ -134,19 +135,20 @@ fn write_config_file(config_path: &Path, force: bool, allow_keep: bool) -> anyho
     Ok(true)
 }
 
-/// Creates the four resource directories as siblings of the config file.
-/// Returns the count of directories that didn't already exist — purely
-/// for the summary message.
-fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<usize> {
-    // These match the default `ResourcesConfig` paths; any operator who
-    // edits the config to point elsewhere is expected to create those
-    // directories themselves.
-    const SUBDIRS: [&str; 4] = [
-        "catalogs",
-        "content_blocks",
-        "email_templates",
-        "custom_attributes",
-    ];
+/// Default resource subdirectories matching `ResourcesConfig` defaults.
+/// An operator who edits the config to point elsewhere is expected to
+/// create those directories themselves.
+const SUBDIRS: [&str; 4] = [
+    "catalogs",
+    "content_blocks",
+    "email_templates",
+    "custom_attributes",
+];
+
+/// Creates the resource directories as siblings of the config file.
+/// Returns `(created, total)` — the counts are purely for the summary
+/// message.
+fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<(usize, usize)> {
     let mut created = 0;
     for sub in SUBDIRS {
         let dir = config_dir.join(sub);
@@ -156,7 +158,7 @@ fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<usize> {
             created += 1;
         }
     }
-    Ok(created)
+    Ok((created, SUBDIRS.len()))
 }
 
 /// Ensures `.gitignore` contains lines for `.env` and `.env.*`. Appends
@@ -187,17 +189,12 @@ fn update_gitignore(config_dir: &Path) -> anyhow::Result<bool> {
         .open(&path)
         .with_context(|| format!("opening {} for append", path.display()))?;
 
-    // Insert a leading newline only if the existing file doesn't already
-    // end with one, so we don't glue our section onto the last existing
-    // entry.
-    if !existing.is_empty() && !existing.ends_with('\n') {
-        f.write_all(b"\n")?;
-    }
-    if !existing.is_empty() {
-        f.write_all(b"\n# braze-sync\n")?;
-    } else {
-        f.write_all(b"# braze-sync\n")?;
-    }
+    let prefix = match (existing.is_empty(), existing.ends_with('\n')) {
+        (true, _) => "# braze-sync\n",
+        (false, true) => "\n# braze-sync\n",
+        (false, false) => "\n\n# braze-sync\n",
+    };
+    f.write_all(prefix.as_bytes())?;
     for entry in missing {
         writeln!(f, "{entry}")?;
     }
@@ -209,21 +206,12 @@ async fn run_from_existing(
     config_dir: &Path,
     env_override: Option<&str>,
 ) -> anyhow::Result<()> {
-    // Reload dotenv now that the user may have edited the just-written
-    // config or dropped a .env. The initial call in cli::run already
-    // happened, but re-running it is cheap and harmless.
-    if let Err(e) = crate::config::load_dotenv() {
-        tracing::warn!("dotenv: {e}");
-    }
-
     let cfg = ConfigFile::load(config_path)
         .with_context(|| format!("reloading config from {}", config_path.display()))?;
     let resolved = cfg
         .resolve(env_override)
         .context("resolving environment for --from-existing")?;
 
-    // Delegate to the same code path as `braze-sync export` (no filter
-    // — pull everything that's enabled in the config).
     let export_args = super::export::ExportArgs {
         resource: None,
         name: None,
@@ -351,14 +339,10 @@ mod tests {
     #[test]
     fn scaffold_creates_all_four_dirs() {
         let tmp = tempfile::tempdir().unwrap();
-        let n = scaffold_resource_dirs(tmp.path()).unwrap();
-        assert_eq!(n, 4);
-        for sub in [
-            "catalogs",
-            "content_blocks",
-            "email_templates",
-            "custom_attributes",
-        ] {
+        let (created, total) = scaffold_resource_dirs(tmp.path()).unwrap();
+        assert_eq!(created, 4);
+        assert_eq!(total, 4);
+        for sub in SUBDIRS {
             assert!(tmp.path().join(sub).is_dir(), "{sub} should exist");
         }
     }
@@ -367,8 +351,8 @@ mod tests {
     fn scaffold_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
         scaffold_resource_dirs(tmp.path()).unwrap();
-        let second = scaffold_resource_dirs(tmp.path()).unwrap();
-        assert_eq!(second, 0, "second run creates nothing");
+        let (created, _) = scaffold_resource_dirs(tmp.path()).unwrap();
+        assert_eq!(created, 0, "second run creates nothing");
     }
 
     #[test]
@@ -376,9 +360,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("braze-sync.config.yaml");
         fs::write(&path, "version: 1\n# user edits\n").unwrap();
-        let err = write_config_file(&path, false, false).unwrap_err();
+        let err = write_config_file(&path, OnExisting::Fail).unwrap_err();
         assert!(err.to_string().contains("--force"));
-        // Original content preserved.
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("user edits"));
     }
@@ -388,44 +371,29 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("braze-sync.config.yaml");
         fs::write(&path, "# old\n").unwrap();
-        let written = write_config_file(&path, true, false).unwrap();
+        let written = write_config_file(&path, OnExisting::Overwrite).unwrap();
         assert!(written);
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("braze-sync configuration"));
     }
 
     #[test]
-    fn write_config_keeps_existing_with_allow_keep() {
-        // --from-existing path: existing config is kept, not overwritten.
+    fn write_config_keeps_existing_on_keep() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("braze-sync.config.yaml");
         fs::write(&path, "# operator-tuned\nversion: 1\n").unwrap();
-        let written = write_config_file(&path, false, true).unwrap();
+        let written = write_config_file(&path, OnExisting::Keep).unwrap();
         assert!(!written, "existing config should be kept");
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("operator-tuned"));
     }
 
     #[test]
-    fn write_config_writes_fresh_when_allow_keep_and_no_existing() {
-        // --from-existing in an empty dir still needs to scaffold the config.
+    fn write_config_writes_fresh_on_keep_when_no_existing() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("braze-sync.config.yaml");
-        let written = write_config_file(&path, false, true).unwrap();
+        let written = write_config_file(&path, OnExisting::Keep).unwrap();
         assert!(written);
         assert!(path.exists());
-    }
-
-    #[test]
-    fn write_config_force_overrides_allow_keep() {
-        // If the operator explicitly says --force, overwrite even if
-        // --from-existing would otherwise keep the file.
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("braze-sync.config.yaml");
-        fs::write(&path, "# old\n").unwrap();
-        let written = write_config_file(&path, true, true).unwrap();
-        assert!(written);
-        let content = fs::read_to_string(&path).unwrap();
-        assert!(content.contains("braze-sync configuration"));
     }
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 pub struct InitArgs {
     /// Overwrite an existing `braze-sync.config.yaml`. Directories and
     /// `.gitignore` are updated idempotently regardless.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "from_existing")]
     pub force: bool,
 
     /// After scaffolding, pull the current state from Braze into the new
@@ -35,6 +35,8 @@ pub async fn run(
     fs::create_dir_all(&config_dir)
         .with_context(|| format!("creating config directory {}", config_dir.display()))?;
 
+    // --force and --from-existing are mutually exclusive (clap-enforced)
+    // to prevent silently discarding operator edits.
     let on_existing = match (args.force, args.from_existing) {
         (true, _) => OnExisting::Overwrite,
         (false, true) => OnExisting::Keep,
@@ -64,6 +66,14 @@ pub async fn run(
     );
 
     if args.from_existing {
+        if config_written {
+            eprintln!(
+                "⚠ --from-existing is using the freshly-scaffolded config — \
+                 the template's default endpoint will be hit. \
+                 Edit {} first if your Braze instance is elsewhere.",
+                config_path.display()
+            );
+        }
         eprintln!("✓ --from-existing: loading config and pulling Braze state…");
         run_from_existing(config_path, &config_dir, env_override).await?;
     } else {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -174,7 +174,7 @@ async fn run_from_existing(
     env_override: Option<&str>,
 ) -> anyhow::Result<()> {
     let cfg = ConfigFile::load(config_path)
-        .with_context(|| format!("reloading config from {}", config_path.display()))?;
+        .with_context(|| format!("loading config from {}", config_path.display()))?;
     let resolved = cfg
         .resolve(env_override)
         .context("resolving environment for --from-existing")?;
@@ -291,10 +291,8 @@ mod tests {
         let path = tmp.path().join(".gitignore");
         fs::write(&path, ".env\n").unwrap();
         let updated = update_gitignore(tmp.path()).unwrap();
-        // `.env.*` is still missing, so we expect an update.
         assert!(updated);
         let content = fs::read_to_string(&path).unwrap();
-        // `.env` should still appear exactly once.
         let count = content.lines().filter(|l| l.trim() == ".env").count();
         assert_eq!(count, 1, "should not duplicate .env");
         assert!(content.contains(".env.*"));

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -63,7 +63,7 @@ pub async fn run(
         (false, false) => OnExisting::Fail,
     };
     let config_written = write_config_file(config_path, on_existing)?;
-    let (dirs_created, dirs_total) = scaffold_resource_dirs(&config_dir)?;
+    let dirs_created = scaffold_resource_dirs(&config_dir)?;
     let gitignore_updated = update_gitignore(&config_dir)?;
 
     eprintln!(
@@ -77,7 +77,7 @@ pub async fn run(
     );
     eprintln!(
         "✓ directories: {dirs_created} created, {} kept",
-        dirs_total - dirs_created
+        SUBDIRS.len() - dirs_created
     );
     eprintln!(
         "✓ .gitignore: {}",
@@ -146,9 +146,8 @@ const SUBDIRS: [&str; 4] = [
 ];
 
 /// Creates the resource directories as siblings of the config file.
-/// Returns `(created, total)` — the counts are purely for the summary
-/// message.
-fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<(usize, usize)> {
+/// Returns the number newly created (for the summary line).
+fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<usize> {
     let mut created = 0;
     for sub in SUBDIRS {
         let dir = config_dir.join(sub);
@@ -158,7 +157,7 @@ fn scaffold_resource_dirs(config_dir: &Path) -> anyhow::Result<(usize, usize)> {
             created += 1;
         }
     }
-    Ok((created, SUBDIRS.len()))
+    Ok(created)
 }
 
 /// Ensures `.gitignore` contains lines for `.env` and `.env.*`. Appends
@@ -339,9 +338,8 @@ mod tests {
     #[test]
     fn scaffold_creates_all_four_dirs() {
         let tmp = tempfile::tempdir().unwrap();
-        let (created, total) = scaffold_resource_dirs(tmp.path()).unwrap();
+        let created = scaffold_resource_dirs(tmp.path()).unwrap();
         assert_eq!(created, 4);
-        assert_eq!(total, 4);
         for sub in SUBDIRS {
             assert!(tmp.path().join(sub).is_dir(), "{sub} should exist");
         }
@@ -351,7 +349,7 @@ mod tests {
     fn scaffold_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
         scaffold_resource_dirs(tmp.path()).unwrap();
-        let (created, _) = scaffold_resource_dirs(tmp.path()).unwrap();
+        let created = scaffold_resource_dirs(tmp.path()).unwrap();
         assert_eq!(created, 0, "second run creates nothing");
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,7 @@
 pub mod apply;
 pub mod diff;
 pub mod export;
+pub mod init;
 pub mod validate;
 
 /// Maximum concurrent in-flight Braze GET requests for fan-out fetches.
@@ -73,6 +74,8 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
+    /// Scaffold a new braze-sync workspace (config, directories, .gitignore)
+    Init(init::InitArgs),
     /// Pull state from Braze into local files
     Export(export::ExportArgs),
     /// Show drift between local files and Braze
@@ -105,6 +108,14 @@ pub async fn run() -> i32 {
         // dotenv failures are non-fatal — config resolution will surface
         // any actually missing vars with a clearer error.
         tracing::warn!("dotenv: {e}");
+    }
+
+    // `init` runs BEFORE config load: its whole job is to create the
+    // config, so refusing on a missing file would be a catch-22. It
+    // also handles its own env resolution internally when `--from-existing`
+    // is set, so it bypasses both stages below.
+    if let Command::Init(args) = &cli.command {
+        return finish(init::run(args, &cli.config, cli.env.as_deref()).await);
     }
 
     // Stage 1: parse + structurally validate the config file. No env
@@ -178,6 +189,9 @@ async fn dispatch(cli: &Cli, resolved: ResolvedConfig, config_dir: &Path) -> any
         }
         Command::Validate(_) => {
             unreachable!("validate is dispatched in cli::run before env resolution")
+        }
+        Command::Init(_) => {
+            unreachable!("init is dispatched in cli::run before config load")
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -110,8 +110,7 @@ pub async fn run() -> i32 {
         tracing::warn!("dotenv: {e}");
     }
 
-    // `init` runs before config load (its job is to create the config)
-    // and handles its own env resolution for `--from-existing`.
+    // init runs before config load — its job is to create the config.
     if let Command::Init(args) = &cli.command {
         return finish(init::run(args, &cli.config, cli.env.as_deref()).await);
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -110,10 +110,8 @@ pub async fn run() -> i32 {
         tracing::warn!("dotenv: {e}");
     }
 
-    // `init` runs BEFORE config load: its whole job is to create the
-    // config, so refusing on a missing file would be a catch-22. It
-    // also handles its own env resolution internally when `--from-existing`
-    // is set, so it bypasses both stages below.
+    // `init` runs before config load (its job is to create the config)
+    // and handles its own env resolution for `--from-existing`.
     if let Command::Init(args) = &cli.command {
         return finish(init::run(args, &cli.config, cli.env.as_deref()).await);
     }

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -5,8 +5,6 @@
 //! `--from-existing` test additionally stands up a wiremock server so
 //! the export phase has something to pull.
 
-mod common;
-
 use assert_cmd::Command;
 use serde_json::json;
 use std::fs;

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -54,6 +54,19 @@ fn init_refuses_to_overwrite_config_without_force() {
 }
 
 #[test]
+fn init_rejects_force_with_from_existing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("braze-sync.config.yaml");
+
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .args(["init", "--force", "--from-existing"])
+        .assert()
+        .failure();
+}
+
+#[test]
 fn init_force_overwrites_existing_config() {
     let tmp = tempfile::tempdir().unwrap();
     let config_path = tmp.path().join("braze-sync.config.yaml");

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -112,9 +112,6 @@ fn init_is_idempotent_for_directories_and_gitignore() {
 
 #[test]
 fn init_creates_parent_directories_for_nested_config_path() {
-    // `braze-sync init --config braze/braze-sync.config.yaml` should
-    // create the `braze/` directory too — this is the nested-workspace
-    // pattern from IMPLEMENTATION.md §9.1.
     let tmp = tempfile::tempdir().unwrap();
     let config_path = tmp.path().join("braze").join("braze-sync.config.yaml");
 
@@ -209,11 +206,8 @@ environments:
     .await
     .unwrap();
 
-    // Scaffolding still ran alongside export, so directories and
-    // .gitignore must exist.
     assert!(tmp_path.join("catalogs").is_dir());
     assert!(tmp_path.join(".gitignore").exists());
-    // Export produced the one catalog schema we mocked.
     assert!(
         tmp_path.join("catalogs/cardiology/schema.yaml").exists(),
         "export should have written cardiology schema"

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -85,7 +85,6 @@ fn init_is_idempotent_for_directories_and_gitignore() {
     let tmp = tempfile::tempdir().unwrap();
     let config_path = tmp.path().join("braze-sync.config.yaml");
 
-    // First run creates everything.
     Command::cargo_bin("braze-sync")
         .unwrap()
         .args(["--config", config_path.to_str().unwrap()])
@@ -95,8 +94,8 @@ fn init_is_idempotent_for_directories_and_gitignore() {
 
     let gitignore_after_first = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
 
-    // Second run (with --force since the config now exists) must not
-    // duplicate gitignore entries or fail on existing directories.
+    // --force on the second run because the config now exists; directories
+    // and .gitignore must remain idempotent regardless.
     Command::cargo_bin("braze-sync")
         .unwrap()
         .args(["--config", config_path.to_str().unwrap()])
@@ -181,9 +180,9 @@ async fn init_from_existing_pulls_state_into_scaffold() {
     let tmp = tempfile::tempdir().unwrap();
     let config_path = tmp.path().join("braze-sync.config.yaml");
 
-    // Pre-write a config that points at wiremock so --from-existing has
-    // a reachable endpoint. `init --force` keeps directories/gitignore
-    // consistent without clobbering our test-specific endpoint.
+    // Pre-write a config pointing at wiremock; `init --from-existing`
+    // uses OnExisting::Keep so this endpoint survives instead of being
+    // replaced by the default template's production URL.
     let yaml = format!(
         "version: 1
 default_environment: test
@@ -203,9 +202,6 @@ environments:
             .unwrap()
             .env("BRAZE_DEV_API_KEY", "test-key")
             .args(["--config", config_path_cmd.to_str().unwrap()])
-            // --from-existing keeps the pre-written config (which points
-            // at the mock server). Without this we'd get the default
-            // template, which points at production Braze.
             .args(["init", "--from-existing"])
             .assert()
             .success();

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -94,8 +94,6 @@ fn init_is_idempotent_for_directories_and_gitignore() {
 
     let gitignore_after_first = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
 
-    // --force on the second run because the config now exists; directories
-    // and .gitignore must remain idempotent regardless.
     Command::cargo_bin("braze-sync")
         .unwrap()
         .args(["--config", config_path.to_str().unwrap()])

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -1,0 +1,227 @@
+//! Integration tests for `braze-sync init`.
+//!
+//! `init` scaffolds before config loading, so these tests run against
+//! an empty temp directory and assert on the resulting filesystem. The
+//! `--from-existing` test additionally stands up a wiremock server so
+//! the export phase has something to pull.
+
+mod common;
+
+use assert_cmd::Command;
+use serde_json::json;
+use std::fs;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[test]
+fn init_in_empty_dir_creates_full_scaffold() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("braze-sync.config.yaml");
+
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .arg("init")
+        .assert()
+        .success();
+
+    assert!(config_path.exists(), "config file should be written");
+    for sub in [
+        "catalogs",
+        "content_blocks",
+        "email_templates",
+        "custom_attributes",
+    ] {
+        assert!(tmp.path().join(sub).is_dir(), "{sub} dir should be created");
+    }
+    let gitignore = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+    assert!(gitignore.contains(".env"));
+    assert!(gitignore.contains(".env.*"));
+
+    // The scaffolded config must be loadable by the same binary.
+    let config_yaml = fs::read_to_string(&config_path).unwrap();
+    assert!(config_yaml.contains("version: 1"));
+    assert!(config_yaml.contains("api_key_env: BRAZE_DEV_API_KEY"));
+}
+
+#[test]
+fn init_refuses_to_overwrite_config_without_force() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("braze-sync.config.yaml");
+    fs::write(&config_path, "# hand-tuned\nversion: 1\n").unwrap();
+
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .arg("init")
+        .assert()
+        .failure();
+
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert!(
+        content.contains("hand-tuned"),
+        "existing config must be preserved"
+    );
+}
+
+#[test]
+fn init_force_overwrites_existing_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("braze-sync.config.yaml");
+    fs::write(&config_path, "# old\n").unwrap();
+
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .args(["init", "--force"])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert!(content.contains("braze-sync configuration"));
+    assert!(!content.contains("# old"));
+}
+
+#[test]
+fn init_is_idempotent_for_directories_and_gitignore() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("braze-sync.config.yaml");
+
+    // First run creates everything.
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .arg("init")
+        .assert()
+        .success();
+
+    let gitignore_after_first = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+
+    // Second run (with --force since the config now exists) must not
+    // duplicate gitignore entries or fail on existing directories.
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .args(["init", "--force"])
+        .assert()
+        .success();
+
+    let gitignore_after_second = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+    assert_eq!(
+        gitignore_after_first, gitignore_after_second,
+        ".gitignore should be idempotent across runs"
+    );
+}
+
+#[test]
+fn init_creates_parent_directories_for_nested_config_path() {
+    // `braze-sync init --config braze/braze-sync.config.yaml` should
+    // create the `braze/` directory too — this is the nested-workspace
+    // pattern from IMPLEMENTATION.md §9.1.
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("braze").join("braze-sync.config.yaml");
+
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .arg("init")
+        .assert()
+        .success();
+
+    assert!(config_path.exists());
+    assert!(tmp.path().join("braze/catalogs").is_dir());
+    assert!(tmp.path().join("braze/.gitignore").exists());
+}
+
+/// `--from-existing` wires init → export. Smoke-test with a single
+/// resource kind's worth of Braze mocks; the export path itself is
+/// covered in detail by tests/cli_export.rs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn init_from_existing_pulls_state_into_scaffold() {
+    let server = MockServer::start().await;
+    // Empty-ish responses for every resource list endpoint so export
+    // can run without triggering 404s.
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "catalogs": [
+                {"name": "cardiology", "fields": [{"name": "id", "type": "string"}]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs/cardiology/items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/custom_attributes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 0,
+            "custom_attributes": []
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("braze-sync.config.yaml");
+
+    // Pre-write a config that points at wiremock so --from-existing has
+    // a reachable endpoint. `init --force` keeps directories/gitignore
+    // consistent without clobbering our test-specific endpoint.
+    let yaml = format!(
+        "version: 1
+default_environment: test
+environments:
+  test:
+    api_endpoint: {}
+    api_key_env: BRAZE_DEV_API_KEY
+",
+        server.uri()
+    );
+    fs::write(&config_path, yaml).unwrap();
+
+    let tmp_path = tmp.path().to_path_buf();
+    let config_path_cmd = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_DEV_API_KEY", "test-key")
+            .args(["--config", config_path_cmd.to_str().unwrap()])
+            // --from-existing keeps the pre-written config (which points
+            // at the mock server). Without this we'd get the default
+            // template, which points at production Braze.
+            .args(["init", "--from-existing"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    // Scaffolding still ran alongside export, so directories and
+    // .gitignore must exist.
+    assert!(tmp_path.join("catalogs").is_dir());
+    assert!(tmp_path.join(".gitignore").exists());
+    // Export produced the one catalog schema we mocked.
+    assert!(
+        tmp_path.join("catalogs/cardiology/schema.yaml").exists(),
+        "export should have written cardiology schema"
+    );
+}

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -1,9 +1,4 @@
 //! Integration tests for `braze-sync init`.
-//!
-//! `init` scaffolds before config loading, so these tests run against
-//! an empty temp directory and assert on the resulting filesystem. The
-//! `--from-existing` test additionally stands up a wiremock server so
-//! the export phase has something to pull.
 
 use assert_cmd::Command;
 use serde_json::json;
@@ -23,20 +18,19 @@ fn init_in_empty_dir_creates_full_scaffold() {
         .assert()
         .success();
 
-    assert!(config_path.exists(), "config file should be written");
+    assert!(config_path.exists());
     for sub in [
         "catalogs",
         "content_blocks",
         "email_templates",
         "custom_attributes",
     ] {
-        assert!(tmp.path().join(sub).is_dir(), "{sub} dir should be created");
+        assert!(tmp.path().join(sub).is_dir(), "{sub}");
     }
     let gitignore = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
     assert!(gitignore.contains(".env"));
     assert!(gitignore.contains(".env.*"));
 
-    // The scaffolded config must be loadable by the same binary.
     let config_yaml = fs::read_to_string(&config_path).unwrap();
     assert!(config_yaml.contains("version: 1"));
     assert!(config_yaml.contains("api_key_env: BRAZE_DEV_API_KEY"));
@@ -56,10 +50,7 @@ fn init_refuses_to_overwrite_config_without_force() {
         .failure();
 
     let content = fs::read_to_string(&config_path).unwrap();
-    assert!(
-        content.contains("hand-tuned"),
-        "existing config must be preserved"
-    );
+    assert!(content.contains("hand-tuned"));
 }
 
 #[test]
@@ -102,10 +93,7 @@ fn init_is_idempotent_for_directories_and_gitignore() {
         .success();
 
     let gitignore_after_second = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
-    assert_eq!(
-        gitignore_after_first, gitignore_after_second,
-        ".gitignore should be idempotent across runs"
-    );
+    assert_eq!(gitignore_after_first, gitignore_after_second);
 }
 
 #[test]
@@ -125,14 +113,9 @@ fn init_creates_parent_directories_for_nested_config_path() {
     assert!(tmp.path().join("braze/.gitignore").exists());
 }
 
-/// `--from-existing` wires init → export. Smoke-test with a single
-/// resource kind's worth of Braze mocks; the export path itself is
-/// covered in detail by tests/cli_export.rs.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn init_from_existing_pulls_state_into_scaffold() {
     let server = MockServer::start().await;
-    // Empty-ish responses for every resource list endpoint so export
-    // can run without triggering 404s.
     Mock::given(method("GET"))
         .and(path("/catalogs"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -175,9 +158,8 @@ async fn init_from_existing_pulls_state_into_scaffold() {
     let tmp = tempfile::tempdir().unwrap();
     let config_path = tmp.path().join("braze-sync.config.yaml");
 
-    // Pre-write a config pointing at wiremock; `init --from-existing`
-    // uses OnExisting::Keep so this endpoint survives instead of being
-    // replaced by the default template's production URL.
+    // `init --from-existing` keeps the existing config, so pre-writing one
+    // pointing at wiremock survives the scaffold step.
     let yaml = format!(
         "version: 1
 default_environment: test
@@ -206,8 +188,5 @@ environments:
 
     assert!(tmp_path.join("catalogs").is_dir());
     assert!(tmp_path.join(".gitignore").exists());
-    assert!(
-        tmp_path.join("catalogs/cardiology/schema.yaml").exists(),
-        "export should have written cardiology schema"
-    );
+    assert!(tmp_path.join("catalogs/cardiology/schema.yaml").exists());
 }


### PR DESCRIPTION
## Summary

- `braze-sync init` scaffolds a new workspace: commented `braze-sync.config.yaml`, the four resource directories (`catalogs/`, `content_blocks/`, `email_templates/`, `custom_attributes/`), and `.env` / `.env.*` entries in `.gitignore`.
- `braze-sync init --from-existing` runs the same export path as `braze-sync export` (no filter) right after scaffolding, so operators can go from empty directory to a fully populated layout in one command. Keeps an already-edited config rather than clobbering it.
- Dispatches before config load (mirroring how `validate` bypasses env resolution) so a missing config is the normal case, not exit code 3.
- `--force` is the only gate on overwriting an existing config; directories and `.gitignore` are always idempotent.

Bumps version to **v0.6.0** and adds a `CHANGELOG.md` consolidating v0.1.0 → v0.6.0.

Completes the first item of Phase C (Hardening) per `docs/local/IMPLEMENTATION.md` §13.

## Test plan

- [x] `cargo test` — 391 tests pass (9 new unit + 6 new integration for init)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke: `braze-sync init` in empty `/tmp` dir creates expected layout
- [x] Manual smoke: re-running without `--force` errors cleanly, preserves existing config
- [x] Manual smoke: `--force` overwrites; gitignore stays idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace scaffolding via `braze-sync init` (creates config, resource dirs, updates .gitignore) with idempotent behavior
  * Added `--force` (overwrite) and `--from-existing` (scaffold then import) options
  * Bumped version to v0.6.0

* **Documentation**
  * Updated README with new init workflow and v0.6.0 feature list
  * Added CHANGELOG documenting release history

* **Tests**
  * Added integration tests covering init behaviors and import-from-existing flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->