### PR TITLE
Fix homebrew job bot commit author and new-file detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,14 +252,19 @@ jobs:
         working-directory: tap
         env:
           VERSION: ${{ github.ref_name }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-token.outputs.user-id }}
         run: |
           set -euo pipefail
-          git config user.name "uny-release-bot[bot]"
-          git config user.email "uny-release-bot[bot]@users.noreply.github.com"
-          if git diff --quiet Formula/braze-sync.rb; then
+          git config user.name "${APP_SLUG}[bot]"
+          # Numeric user-id is required for GitHub to attribute the
+          # commit to the App's bot user (and mark it Verified); it
+          # also survives an App rename.
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add Formula/braze-sync.rb
+          if git diff --cached --quiet; then
             echo "Formula already up to date; nothing to commit."
             exit 0
           fi
-          git add Formula/braze-sync.rb
           git commit -m "braze-sync ${VERSION}"
           git push


### PR DESCRIPTION
## Summary

Addresses both CodeRabbit findings on #12, after that PR was merged and the v0.7.0 Release job was stopped pre-publish.

- **Major**: Use the `app-slug` and `user-id` outputs from `actions/create-github-app-token` to build the committer identity. The previous hard-coded `uny-release-bot[bot]@users.noreply.github.com` lacks the numeric user-id prefix, so GitHub does not attribute the commit to the App's bot user and does not mark it Verified. The correct form is `<user-id>+<app-slug>[bot]@users.noreply.github.com`. Using the action outputs also survives an App rename.
- **Nitpick**: Stage the Formula *before* the change-detection check. `git diff --quiet <path>` against an untracked file exits 0, which would silently skip a first-ever (or post-rename) commit. `git add` followed by `git diff --cached --quiet` handles both new and modified files uniformly.

## Context

The direct push on main (`7bb0ab0`) that addressed only the first finding has been reverted (`79f4a5d`) so that the fix lands cleanly via PR.

## Test plan

- [x] `actionlint` clean (no issues beyond the environment)
- [ ] Post-merge: re-tag `v0.7.0` (or `v0.7.1`) and verify the `homebrew` job produces a commit on `uny/homebrew-tap` authored by `uny-release-bot[bot]` with the Verified badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)