### PR TITLE
docs: recommend cargo install --locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,19 @@ brew install uny/tap/braze-sync
 **cargo install** (requires Rust toolchain):
 
 ```bash
-cargo install braze-sync
+cargo install braze-sync --locked
 ```
+
+`--locked` is recommended. Without it, `cargo install` ignores the
+published `Cargo.lock` and resolves transitive dependencies to the
+newest semver-compatible versions, some of which bump their MSRV
+beyond this crate's (currently 1.86) and fail to build on older
+toolchains.
 
 **Build from source:**
 
 ```bash
-cargo install --path .
+cargo install --path . --locked
 ```
 
 ## Quick start


### PR DESCRIPTION
## Summary

- `cargo install braze-sync` without `--locked` ignores the published `Cargo.lock` and resolves transitive deps to the newest semver-compatible versions. Some (e.g. `constant_time_eq 0.4.3`) bump their MSRV above this crate's declared 1.86, so installs fail on older toolchains with a rustc-version error.
- Updates both `cargo install braze-sync` and `cargo install --path .` examples in the README to include `--locked`, with a short note explaining why.

Triggered by a real install failure reported against v0.7.0.

## Test plan

- [x] README examples now include `--locked`
- [ ] After merge, users can verify with `cargo install braze-sync --locked`