### PR TITLE
Pin config hard-errors for removed keys and document v0.8.0 scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ## [Unreleased]
 
+### Breaking changes (targeted for v0.8.0)
+
+- **Removed `catalog_items` support.** braze-sync now exclusively
+  manages Braze configuration (schemas, content blocks, email
+  templates, custom attribute registry). Catalog items are runtime
+  data and are out of scope — see
+  [`docs/scope-boundaries.md`](docs/scope-boundaries.md).
+- **Removed the client-side rate limiter.** The `governor` dependency
+  is gone; braze-sync now reacts to 429 + `Retry-After` instead of
+  pre-throttling. The 429 retry loop uses a time budget + exponential
+  backoff with full jitter, and honors `Retry-After` as integer
+  seconds or HTTP-date.
+- **Config hard-errors on removed keys.** Configs that still carry
+  `defaults.rate_limit_per_minute`, `environments.<env>.rate_limit_per_minute`,
+  or a `resources.catalog_items:` section will fail to load.
+
+### Migration
+
+**If you were syncing catalog items:** use the Braze REST API
+(`/catalogs/{name}/items`) directly from your data pipeline, Cloud
+Functions, or a dedicated ETL job. Remove the `catalog_items:` section
+from `braze-sync.config.yaml`. Any `catalogs/*/items.csv` files on
+disk are no longer read or written — delete them.
+
+**If your config specified `rate_limit_per_minute`:** delete the key.
+braze-sync no longer throttles proactively; Braze's own 429 signal is
+the only pacing mechanism.
+
+### Added (unreleased)
+
+- `custom_attribute` now uses the Braze-verified wire schema
+  (`attributes`/`name`/`status`) and follows RFC 5988 `Link: rel="next"`
+  pagination through every page. Fixes `exported 0 attribute(s)` on
+  workspaces where attributes carried suffixed type strings like
+  `"String (Automatically Detected)"` or `status: "Blocklisted"`.
+- `content_blocks/list` and `templates/email/list` now use offset
+  pagination with `limit=1000` (Braze max). Workspaces with over 100
+  entries no longer hard-error.
+- `CustomAttributeType::Object` / `ObjectArray` domain variants for
+  the `Object` and `Object Array` types that Braze returns in practice.
+
 ## [0.7.0] — 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,11 +8,20 @@ synchronize it to Braze with the same workflow you'd use for
 detection in CI, and an `--allow-destructive` gate that has to be
 crossed explicitly before anything is dropped.
 
-## Status: v0.6.0 (all 5 resources + init)
+## Status: v0.8.0-prep (4 resources + init)
 
-All five v1.0 resource kinds are implemented end-to-end: **Catalog
-Schema**, **Catalog Items**, **Content Block**, **Email Template**, and
-**Custom Attribute** (registry mode).
+braze-sync manages Braze **configuration** as code. The four managed
+resource kinds are:
+
+- **Catalog Schema** (field definitions, types, constraints)
+- **Content Block** (reusable Liquid fragments)
+- **Email Template** (HTML/Liquid templates)
+- **Custom Attribute** registry (definition-level; deprecation toggle)
+
+**Out of scope**: runtime data like catalog **items**, user attribute
+values, events, and campaigns. Those have their own systems of record;
+use the Braze REST API or data pipelines directly. See
+[docs/scope-boundaries.md](docs/scope-boundaries.md).
 
 | Command | What it does |
 |:---|:---|

--- a/docs/scope-boundaries.md
+++ b/docs/scope-boundaries.md
@@ -1,0 +1,70 @@
+# Scope boundaries
+
+braze-sync manages Braze **configuration** as code. It explicitly does
+**not** manage runtime data. This page records the line and the
+reasoning so that future feature requests have a shared frame of
+reference.
+
+## In scope
+
+Configuration — things that look like schema, templates, or
+declarative settings, and that a team would review in a pull request.
+
+| Resource | What braze-sync owns |
+|:---|:---|
+| **Catalog Schema** | Field definitions, types, constraints |
+| **Content Block** | Reusable Liquid fragments |
+| **Email Template** | HTML/Liquid templates, subject, metadata |
+| **Custom Attribute** registry | Attribute name/type/deprecation — the *definition* only |
+
+All four are low-cardinality (tens to low hundreds of entries per
+workspace), human-authored, and worth code review on change.
+
+## Out of scope
+
+Runtime data — things that change as users interact with the product,
+are written by application code, or live at volumes that make Git
+review nonsensical.
+
+| Runtime data | Why not braze-sync | Where it lives instead |
+|:---|:---|:---|
+| **Catalog items** (rows) | High volume (10k–100k+); sourced from analytics / product DBs; changes daily | Braze REST `/catalogs/{name}/items` from data pipelines, Cloud Functions, ETL jobs |
+| **Custom Attribute values** | Written per-user by the app | `/users/track` from application code |
+| **Events** | Emitted per-action | `/users/track` events array |
+| **Campaigns / Canvases** | Produced in the Braze dashboard; include runtime analytics | Braze dashboard (no API-first workflow is realistic today) |
+
+If a data source changes faster than a human can review PRs, it does
+not belong in braze-sync.
+
+## Why the split matters
+
+1. **Review signal-to-noise.** A PR that adds a new `catalog_schema`
+   field is meaningful; a PR that updates 50,000 rows of a product
+   catalog is not.
+2. **Tool correctness.** braze-sync's diff/apply model assumes the
+   full set of managed resources fits in memory and can be compared
+   hash-for-hash. Runtime data violates that assumption.
+3. **Operational split.** Configuration is a release-gated change
+   (merge → deploy). Runtime data is a background stream. Mixing the
+   two in one tool couples their cadences.
+
+## Was catalog_items ever in scope?
+
+It was wired up in v0.4–v0.7 as an experiment and removed in **v0.8.0**
+for the reasons above. If you were relying on it:
+
+- **Reads** (`export`): hit `GET /catalogs/{name}/items` directly; the
+  response is paginated with `next_cursor` in the body.
+- **Writes** (`apply`): Braze enforces max 50 items per
+  POST/DELETE; batch accordingly. `braze-sync.config.yaml` with a
+  leftover `catalog_items:` section will hard-error at load time
+  (intentional — see the v0.8.0 CHANGELOG entry for migration steps).
+
+## See also
+
+- [`docs/configuration.md`](configuration.md) — YAML reference for the
+  four managed resources
+- [`docs/registry-mode.md`](registry-mode.md) — why Custom Attributes
+  are registry-only (not row-level CRUD)
+- [`CHANGELOG.md`](../CHANGELOG.md) — v0.8.0 breaking changes and
+  migration steps

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -279,6 +279,42 @@ resources:
     }
 
     #[test]
+    fn rejects_legacy_defaults_rate_limit_per_minute() {
+        // v0.8.0: client-side rate limiter was removed. Leftover
+        // `rate_limit_per_minute` keys must hard-error so users notice
+        // they need to delete them, rather than silently ignoring.
+        let yaml = r#"
+version: 1
+default_environment: dev
+defaults:
+  rate_limit_per_minute: 40
+environments:
+  dev:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_DEV_API_KEY
+"#;
+        let f = write_config(yaml);
+        let err = ConfigFile::load(f.path()).unwrap_err();
+        assert!(matches!(err, Error::YamlParse { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn rejects_legacy_environment_rate_limit_per_minute() {
+        let yaml = r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_DEV_API_KEY
+    rate_limit_per_minute: 30
+"#;
+        let f = write_config(yaml);
+        let err = ConfigFile::load(f.path()).unwrap_err();
+        assert!(matches!(err, Error::YamlParse { .. }), "got: {err:?}");
+    }
+
+    #[test]
     fn rejects_non_http_endpoint_scheme() {
         let yaml = r#"
 version: 1


### PR DESCRIPTION
## Summary

- Regression tests pinning the hard-error behavior for legacy \`defaults.rate_limit_per_minute\` and \`environments.<env>.rate_limit_per_minute\` keys
- New \`docs/scope-boundaries.md\` — the canonical "configuration vs runtime data" line, with migration pointers
- CHANGELOG: the Unreleased section now enumerates every v0.8.0 breaking change plus migration steps
- README: updated status line and mission statement (four resources, not five)

## Why

#15 and #16 already removed the code. \`deny_unknown_fields\` on the relevant serde structs means old configs already fail at load. This PR ships the *documentation* for that break and pins the behavior against future regressions.

## Test plan

- [x] \`cargo test\` workspace green (288 lib tests + all integration)
- [x] \`cargo clippy --all-targets\` clean
- [x] New config tests: \`rejects_legacy_defaults_rate_limit_per_minute\`, \`rejects_legacy_environment_rate_limit_per_minute\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)