### PR TITLE
Add exclude_patterns to every resource config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,12 +84,17 @@ Toggles and paths for each v1.0 resource kind. Every sub-block is
 optional — omitted entries fall back to the defaults shown below. To
 skip a resource entirely in a workspace, set `enabled: false`.
 
+Every resource sub-block also accepts an optional
+`exclude_patterns: [<regex>, …]` list; see
+[§ exclude_patterns](#exclude_patterns) below.
+
 #### `catalog_schema`
 
 | Field | Type | Default |
 |:---|:---|:---|
 | `enabled` | bool | `true` |
 | `path` | path | `catalogs/` |
+| `exclude_patterns` | list of regex strings | `[]` |
 
 Directory holding one `<catalog>/schema.yaml` per catalog.
 
@@ -99,6 +104,7 @@ Directory holding one `<catalog>/schema.yaml` per catalog.
 |:---|:---|:---|
 | `enabled` | bool | `true` |
 | `path` | path | `content_blocks/` |
+| `exclude_patterns` | list of regex strings | `[]` |
 
 Directory of `<name>.liquid` files.
 
@@ -108,6 +114,7 @@ Directory of `<name>.liquid` files.
 |:---|:---|:---|
 | `enabled` | bool | `true` |
 | `path` | path | `email_templates/` |
+| `exclude_patterns` | list of regex strings | `[]` |
 
 Directory holding one `<template>/` subdirectory per email template, each
 containing `template.yaml`, `body.html`, and `body.txt`.
@@ -118,8 +125,40 @@ containing `template.yaml`, `body.html`, and `body.txt`.
 |:---|:---|:---|
 | `enabled` | bool | `true` |
 | `path` | path | `custom_attributes/registry.yaml` |
+| `exclude_patterns` | list of regex strings | `[]` |
 
 A single-file registry — see [registry-mode.md](registry-mode.md).
+
+### `exclude_patterns`
+
+`exclude_patterns` is a list of regular expressions — when a resource's
+`name` matches any pattern, it is treated as **managed out of band**
+and is skipped by every command:
+
+- `export` does not write it to disk
+- `diff` / `apply` ignore it on both sides (so a locally-excluded
+  resource will not surface as "missing from Braze" or "orphaned")
+- `validate` skips its structural and naming-pattern checks
+
+This is the recommended way to cohabit with Braze reserved attributes
+(`_unset`), developer debugging leftovers (`hoge`, `hack`, `test_*`),
+or legacy camelCase duplicates that a dashboard operator introduced
+and cannot be renamed without disrupting downstream pipelines.
+
+Syntax is the [`regex-lite`](https://docs.rs/regex-lite) dialect (same
+subset as `naming.*_name_pattern`). Bad regexes hard-error at config
+load time — not at first use — so a typo in a pattern does not
+silently become "matches nothing".
+
+```yaml
+custom_attribute:
+  enabled: true
+  path: custom_attributes/registry.yaml
+  exclude_patterns:
+    - "^_"              # Braze reserved attributes like _unset
+    - "^(hoge|hack)$"   # developer leftovers
+    - "^test_"          # anything prefixed test_
+```
 
 ### `naming` (optional)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,14 @@ subset as `naming.*_name_pattern`). Bad regexes hard-error at config
 load time — not at first use — so a typo in a pattern does not
 silently become "matches nothing".
 
+> **Anchoring:** patterns are substring-matched, so `hoge` will also
+> match `foo_hoge_bar`. Anchor with `^…$` when you want exact-name
+> equality (see the example below).
+
+If `--name <n>` is passed on the command line and `<n>` matches an
+exclude pattern, the CLI prints a warning and skips the kind for that
+invocation. Excludes always win over `--name`.
+
 ```yaml
 custom_attribute:
   enabled: true

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -28,7 +28,7 @@ use super::diff::{
     compute_catalog_schema_diffs, compute_content_block_plan, compute_custom_attribute_diffs,
     compute_email_template_plan,
 };
-use super::selected_kinds;
+use super::{selected_kinds, warn_if_name_excluded};
 
 #[derive(Args, Debug)]
 pub struct ApplyArgs {
@@ -76,6 +76,9 @@ pub async fn run(
     let mut content_block_id_index: Option<ContentBlockIdIndex> = None;
     let mut email_template_id_index: Option<EmailTemplateIdIndex> = None;
     for kind in kinds {
+        if warn_if_name_excluded(kind, args.name.as_deref(), resolved.excludes_for(kind)) {
+            continue;
+        }
         match kind {
             ResourceKind::CatalogSchema => {
                 let diffs = compute_catalog_schema_diffs(

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -78,25 +78,46 @@ pub async fn run(
     for kind in kinds {
         match kind {
             ResourceKind::CatalogSchema => {
-                let diffs =
-                    compute_catalog_schema_diffs(&client, &catalogs_root, args.name.as_deref())
-                        .await
-                        .context("computing catalog_schema plan")?;
+                let excludes = crate::config::compile_exclude_patterns(
+                    &resolved.resources.catalog_schema.exclude_patterns,
+                    "catalog_schema",
+                )?;
+                let diffs = compute_catalog_schema_diffs(
+                    &client,
+                    &catalogs_root,
+                    args.name.as_deref(),
+                    &excludes,
+                )
+                .await
+                .context("computing catalog_schema plan")?;
                 summary.diffs.extend(diffs);
             }
             ResourceKind::ContentBlock => {
-                let (diffs, idx) =
-                    compute_content_block_plan(&client, &content_blocks_root, args.name.as_deref())
-                        .await
-                        .context("computing content_block plan")?;
+                let excludes = crate::config::compile_exclude_patterns(
+                    &resolved.resources.content_block.exclude_patterns,
+                    "content_block",
+                )?;
+                let (diffs, idx) = compute_content_block_plan(
+                    &client,
+                    &content_blocks_root,
+                    args.name.as_deref(),
+                    &excludes,
+                )
+                .await
+                .context("computing content_block plan")?;
                 summary.diffs.extend(diffs);
                 content_block_id_index = Some(idx);
             }
             ResourceKind::EmailTemplate => {
+                let excludes = crate::config::compile_exclude_patterns(
+                    &resolved.resources.email_template.exclude_patterns,
+                    "email_template",
+                )?;
                 let (diffs, idx) = compute_email_template_plan(
                     &client,
                     &email_templates_root,
                     args.name.as_deref(),
+                    &excludes,
                 )
                 .await
                 .context("computing email_template plan")?;
@@ -104,10 +125,15 @@ pub async fn run(
                 email_template_id_index = Some(idx);
             }
             ResourceKind::CustomAttribute => {
+                let excludes = crate::config::compile_exclude_patterns(
+                    &resolved.resources.custom_attribute.exclude_patterns,
+                    "custom_attribute",
+                )?;
                 let diffs = compute_custom_attribute_diffs(
                     &client,
                     &custom_attributes_path,
                     args.name.as_deref(),
+                    &excludes,
                 )
                 .await
                 .context("computing custom_attribute plan")?;

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -78,30 +78,22 @@ pub async fn run(
     for kind in kinds {
         match kind {
             ResourceKind::CatalogSchema => {
-                let excludes = crate::config::compile_exclude_patterns(
-                    &resolved.resources.catalog_schema.exclude_patterns,
-                    "catalog_schema",
-                )?;
                 let diffs = compute_catalog_schema_diffs(
                     &client,
                     &catalogs_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::CatalogSchema),
                 )
                 .await
                 .context("computing catalog_schema plan")?;
                 summary.diffs.extend(diffs);
             }
             ResourceKind::ContentBlock => {
-                let excludes = crate::config::compile_exclude_patterns(
-                    &resolved.resources.content_block.exclude_patterns,
-                    "content_block",
-                )?;
                 let (diffs, idx) = compute_content_block_plan(
                     &client,
                     &content_blocks_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::ContentBlock),
                 )
                 .await
                 .context("computing content_block plan")?;
@@ -109,15 +101,11 @@ pub async fn run(
                 content_block_id_index = Some(idx);
             }
             ResourceKind::EmailTemplate => {
-                let excludes = crate::config::compile_exclude_patterns(
-                    &resolved.resources.email_template.exclude_patterns,
-                    "email_template",
-                )?;
                 let (diffs, idx) = compute_email_template_plan(
                     &client,
                     &email_templates_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::EmailTemplate),
                 )
                 .await
                 .context("computing email_template plan")?;
@@ -125,15 +113,11 @@ pub async fn run(
                 email_template_id_index = Some(idx);
             }
             ResourceKind::CustomAttribute => {
-                let excludes = crate::config::compile_exclude_patterns(
-                    &resolved.resources.custom_attribute.exclude_patterns,
-                    "custom_attribute",
-                )?;
                 let diffs = compute_custom_attribute_diffs(
                     &client,
                     &custom_attributes_path,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::CustomAttribute),
                 )
                 .await
                 .context("computing custom_attribute plan")?;

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -6,7 +6,7 @@
 
 use crate::braze::error::BrazeApiError;
 use crate::braze::BrazeClient;
-use crate::config::{compile_exclude_patterns, is_excluded, ResolvedConfig};
+use crate::config::{is_excluded, ResolvedConfig};
 use crate::diff::catalog::diff_schema;
 use crate::diff::content_block::{
     diff as diff_content_block, ContentBlockDiff, ContentBlockIdIndex,
@@ -23,6 +23,7 @@ use crate::resource::{Catalog, ContentBlock, EmailTemplate, ResourceKind};
 use anyhow::Context as _;
 use clap::Args;
 use futures::stream::{StreamExt, TryStreamExt};
+use regex_lite::Regex;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
@@ -61,60 +62,44 @@ pub async fn run(
     for kind in kinds {
         match kind {
             ResourceKind::CatalogSchema => {
-                let excludes = compile_exclude_patterns(
-                    &resolved.resources.catalog_schema.exclude_patterns,
-                    "catalog_schema",
-                )?;
                 let diffs = compute_catalog_schema_diffs(
                     &client,
                     &catalogs_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::CatalogSchema),
                 )
                 .await
                 .context("computing catalog_schema diff")?;
                 summary.diffs.extend(diffs);
             }
             ResourceKind::ContentBlock => {
-                let excludes = compile_exclude_patterns(
-                    &resolved.resources.content_block.exclude_patterns,
-                    "content_block",
-                )?;
                 let (diffs, _idx) = compute_content_block_plan(
                     &client,
                     &content_blocks_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::ContentBlock),
                 )
                 .await
                 .context("computing content_block diff")?;
                 summary.diffs.extend(diffs);
             }
             ResourceKind::EmailTemplate => {
-                let excludes = compile_exclude_patterns(
-                    &resolved.resources.email_template.exclude_patterns,
-                    "email_template",
-                )?;
                 let (diffs, _idx) = compute_email_template_plan(
                     &client,
                     &email_templates_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::EmailTemplate),
                 )
                 .await
                 .context("computing email_template diff")?;
                 summary.diffs.extend(diffs);
             }
             ResourceKind::CustomAttribute => {
-                let excludes = compile_exclude_patterns(
-                    &resolved.resources.custom_attribute.exclude_patterns,
-                    "custom_attribute",
-                )?;
                 let diffs = compute_custom_attribute_diffs(
                     &client,
                     &custom_attributes_path,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::CustomAttribute),
                 )
                 .await
                 .context("computing custom_attribute diff")?;
@@ -142,7 +127,7 @@ pub(crate) async fn compute_catalog_schema_diffs(
     client: &BrazeClient,
     catalogs_root: &Path,
     name_filter: Option<&str>,
-    excludes: &[regex_lite::Regex],
+    excludes: &[Regex],
 ) -> anyhow::Result<Vec<ResourceDiff>> {
     let mut local = catalog_io::load_all_schemas(catalogs_root)?;
     if let Some(name) = name_filter {
@@ -190,7 +175,7 @@ pub(crate) async fn compute_content_block_plan(
     client: &BrazeClient,
     content_blocks_root: &Path,
     name_filter: Option<&str>,
-    excludes: &[regex_lite::Regex],
+    excludes: &[Regex],
 ) -> anyhow::Result<(Vec<ResourceDiff>, ContentBlockIdIndex)> {
     let mut local = content_block_io::load_all_content_blocks(content_blocks_root)?;
     if let Some(name) = name_filter {
@@ -276,7 +261,7 @@ pub(crate) async fn compute_email_template_plan(
     client: &BrazeClient,
     email_templates_root: &Path,
     name_filter: Option<&str>,
-    excludes: &[regex_lite::Regex],
+    excludes: &[Regex],
 ) -> anyhow::Result<(Vec<ResourceDiff>, EmailTemplateIdIndex)> {
     let mut local = email_template_io::load_all_email_templates(email_templates_root)?;
     if let Some(name) = name_filter {
@@ -358,7 +343,7 @@ pub(crate) async fn compute_custom_attribute_diffs(
     client: &BrazeClient,
     registry_path: &Path,
     name_filter: Option<&str>,
-    excludes: &[regex_lite::Regex],
+    excludes: &[Regex],
 ) -> anyhow::Result<Vec<ResourceDiff>> {
     let mut local = custom_attribute_io::load_registry(registry_path)?;
     let mut remote = client.list_custom_attributes().await?;

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -6,7 +6,7 @@
 
 use crate::braze::error::BrazeApiError;
 use crate::braze::BrazeClient;
-use crate::config::ResolvedConfig;
+use crate::config::{compile_exclude_patterns, is_excluded, ResolvedConfig};
 use crate::diff::catalog::diff_schema;
 use crate::diff::content_block::{
     diff as diff_content_block, ContentBlockDiff, ContentBlockIdIndex,
@@ -61,34 +61,60 @@ pub async fn run(
     for kind in kinds {
         match kind {
             ResourceKind::CatalogSchema => {
-                let diffs =
-                    compute_catalog_schema_diffs(&client, &catalogs_root, args.name.as_deref())
-                        .await
-                        .context("computing catalog_schema diff")?;
+                let excludes = compile_exclude_patterns(
+                    &resolved.resources.catalog_schema.exclude_patterns,
+                    "catalog_schema",
+                )?;
+                let diffs = compute_catalog_schema_diffs(
+                    &client,
+                    &catalogs_root,
+                    args.name.as_deref(),
+                    &excludes,
+                )
+                .await
+                .context("computing catalog_schema diff")?;
                 summary.diffs.extend(diffs);
             }
             ResourceKind::ContentBlock => {
-                let (diffs, _idx) =
-                    compute_content_block_plan(&client, &content_blocks_root, args.name.as_deref())
-                        .await
-                        .context("computing content_block diff")?;
+                let excludes = compile_exclude_patterns(
+                    &resolved.resources.content_block.exclude_patterns,
+                    "content_block",
+                )?;
+                let (diffs, _idx) = compute_content_block_plan(
+                    &client,
+                    &content_blocks_root,
+                    args.name.as_deref(),
+                    &excludes,
+                )
+                .await
+                .context("computing content_block diff")?;
                 summary.diffs.extend(diffs);
             }
             ResourceKind::EmailTemplate => {
+                let excludes = compile_exclude_patterns(
+                    &resolved.resources.email_template.exclude_patterns,
+                    "email_template",
+                )?;
                 let (diffs, _idx) = compute_email_template_plan(
                     &client,
                     &email_templates_root,
                     args.name.as_deref(),
+                    &excludes,
                 )
                 .await
                 .context("computing email_template diff")?;
                 summary.diffs.extend(diffs);
             }
             ResourceKind::CustomAttribute => {
+                let excludes = compile_exclude_patterns(
+                    &resolved.resources.custom_attribute.exclude_patterns,
+                    "custom_attribute",
+                )?;
                 let diffs = compute_custom_attribute_diffs(
                     &client,
                     &custom_attributes_path,
                     args.name.as_deref(),
+                    &excludes,
                 )
                 .await
                 .context("computing custom_attribute diff")?;
@@ -116,13 +142,15 @@ pub(crate) async fn compute_catalog_schema_diffs(
     client: &BrazeClient,
     catalogs_root: &Path,
     name_filter: Option<&str>,
+    excludes: &[regex_lite::Regex],
 ) -> anyhow::Result<Vec<ResourceDiff>> {
     let mut local = catalog_io::load_all_schemas(catalogs_root)?;
     if let Some(name) = name_filter {
         local.retain(|c| c.name == name);
     }
+    local.retain(|c| !is_excluded(&c.name, excludes));
 
-    let remote: Vec<Catalog> = match name_filter {
+    let mut remote: Vec<Catalog> = match name_filter {
         Some(name) => match client.get_catalog(name).await {
             Ok(c) => vec![c],
             // NotFound on a filtered fetch just means "no remote"; the
@@ -132,6 +160,7 @@ pub(crate) async fn compute_catalog_schema_diffs(
         },
         None => client.list_catalogs().await?,
     };
+    remote.retain(|c| !is_excluded(&c.name, excludes));
 
     let local_by_name: BTreeMap<&str, &Catalog> =
         local.iter().map(|c| (c.name.as_str(), c)).collect();
@@ -161,16 +190,19 @@ pub(crate) async fn compute_content_block_plan(
     client: &BrazeClient,
     content_blocks_root: &Path,
     name_filter: Option<&str>,
+    excludes: &[regex_lite::Regex],
 ) -> anyhow::Result<(Vec<ResourceDiff>, ContentBlockIdIndex)> {
     let mut local = content_block_io::load_all_content_blocks(content_blocks_root)?;
     if let Some(name) = name_filter {
         local.retain(|c| c.name == name);
     }
+    local.retain(|c| !is_excluded(&c.name, excludes));
 
     let mut summaries = client.list_content_blocks().await?;
     if let Some(name) = name_filter {
         summaries.retain(|s| s.name == name);
     }
+    summaries.retain(|s| !is_excluded(&s.name, excludes));
 
     let id_index: ContentBlockIdIndex = summaries
         .into_iter()
@@ -244,16 +276,19 @@ pub(crate) async fn compute_email_template_plan(
     client: &BrazeClient,
     email_templates_root: &Path,
     name_filter: Option<&str>,
+    excludes: &[regex_lite::Regex],
 ) -> anyhow::Result<(Vec<ResourceDiff>, EmailTemplateIdIndex)> {
     let mut local = email_template_io::load_all_email_templates(email_templates_root)?;
     if let Some(name) = name_filter {
         local.retain(|t| t.name == name);
     }
+    local.retain(|t| !is_excluded(&t.name, excludes));
 
     let mut summaries = client.list_email_templates().await?;
     if let Some(name) = name_filter {
         summaries.retain(|s| s.name == name);
     }
+    summaries.retain(|s| !is_excluded(&s.name, excludes));
 
     let id_index: EmailTemplateIdIndex = summaries
         .into_iter()
@@ -323,6 +358,7 @@ pub(crate) async fn compute_custom_attribute_diffs(
     client: &BrazeClient,
     registry_path: &Path,
     name_filter: Option<&str>,
+    excludes: &[regex_lite::Regex],
 ) -> anyhow::Result<Vec<ResourceDiff>> {
     let mut local = custom_attribute_io::load_registry(registry_path)?;
     let mut remote = client.list_custom_attributes().await?;
@@ -332,6 +368,10 @@ pub(crate) async fn compute_custom_attribute_diffs(
         }
         remote.retain(|a| a.name == name);
     }
+    if let Some(r) = local.as_mut() {
+        r.attributes.retain(|a| !is_excluded(&a.name, excludes));
+    }
+    remote.retain(|a| !is_excluded(&a.name, excludes));
     let attr_diffs = diff_custom_attributes(local.as_ref(), &remote);
     Ok(attr_diffs
         .into_iter()

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -27,7 +27,7 @@ use regex_lite::Regex;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use super::{selected_kinds, FETCH_CONCURRENCY};
+use super::{selected_kinds, warn_if_name_excluded, FETCH_CONCURRENCY};
 
 #[derive(Args, Debug)]
 pub struct DiffArgs {
@@ -60,6 +60,9 @@ pub async fn run(
 
     let mut summary = DiffSummary::default();
     for kind in kinds {
+        if warn_if_name_excluded(kind, args.name.as_deref(), resolved.excludes_for(kind)) {
+            continue;
+        }
         match kind {
             ResourceKind::CatalogSchema => {
                 let diffs = compute_catalog_schema_diffs(

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -11,7 +11,7 @@ use futures::stream::{StreamExt, TryStreamExt};
 use regex_lite::Regex;
 use std::path::Path;
 
-use super::{selected_kinds, FETCH_CONCURRENCY};
+use super::{selected_kinds, warn_if_name_excluded, FETCH_CONCURRENCY};
 
 #[derive(Args, Debug, Default)]
 pub struct ExportArgs {
@@ -40,6 +40,14 @@ pub async fn run(
 
     let mut total_written: usize = 0;
     for kind in kinds {
+        // `custom_attribute` ignores `--name` (registry is a single file),
+        // so skipping by exclude match before dispatching wouldn't fit —
+        // handle it per-arm alongside the existing --name warning.
+        if !matches!(kind, ResourceKind::CustomAttribute)
+            && warn_if_name_excluded(kind, args.name.as_deref(), resolved.excludes_for(kind))
+        {
+            continue;
+        }
         match kind {
             ResourceKind::CatalogSchema => {
                 let n = export_catalog_schemas(
@@ -141,13 +149,11 @@ async fn export_content_blocks(
     excludes: &[Regex],
 ) -> anyhow::Result<usize> {
     let summaries = client.list_content_blocks().await?;
-    let targets: Vec<_> = match name_filter {
-        Some(name) => summaries.into_iter().filter(|s| s.name == name).collect(),
-        None => summaries
-            .into_iter()
-            .filter(|s| !is_excluded(&s.name, excludes))
-            .collect(),
-    };
+    let targets: Vec<_> = summaries
+        .into_iter()
+        .filter(|s| name_filter.is_none_or(|n| s.name == n))
+        .filter(|s| !is_excluded(&s.name, excludes))
+        .collect();
 
     if targets.is_empty() {
         if let Some(name) = name_filter {
@@ -185,13 +191,11 @@ async fn export_email_templates(
     excludes: &[Regex],
 ) -> anyhow::Result<usize> {
     let summaries = client.list_email_templates().await?;
-    let targets: Vec<_> = match name_filter {
-        Some(name) => summaries.into_iter().filter(|s| s.name == name).collect(),
-        None => summaries
-            .into_iter()
-            .filter(|s| !is_excluded(&s.name, excludes))
-            .collect(),
-    };
+    let targets: Vec<_> = summaries
+        .into_iter()
+        .filter(|s| name_filter.is_none_or(|n| s.name == n))
+        .filter(|s| !is_excluded(&s.name, excludes))
+        .collect();
 
     if targets.is_empty() {
         if let Some(name) = name_filter {

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -2,7 +2,7 @@
 
 use crate::braze::error::BrazeApiError;
 use crate::braze::BrazeClient;
-use crate::config::ResolvedConfig;
+use crate::config::{compile_exclude_patterns, is_excluded, ResolvedConfig};
 use crate::fs::{catalog_io, content_block_io, custom_attribute_io, email_template_io};
 use crate::resource::{CustomAttributeRegistry, ResourceKind};
 use anyhow::Context as _;
@@ -41,24 +41,50 @@ pub async fn run(
     for kind in kinds {
         match kind {
             ResourceKind::CatalogSchema => {
-                let n = export_catalog_schemas(&client, &catalogs_root, args.name.as_deref())
-                    .await
-                    .context("exporting catalog_schema")?;
+                let excludes = compile_exclude_patterns(
+                    &resolved.resources.catalog_schema.exclude_patterns,
+                    "catalog_schema",
+                )?;
+                let n = export_catalog_schemas(
+                    &client,
+                    &catalogs_root,
+                    args.name.as_deref(),
+                    &excludes,
+                )
+                .await
+                .context("exporting catalog_schema")?;
                 eprintln!("✓ catalog_schema: exported {n} resource(s)");
                 total_written += n;
             }
             ResourceKind::ContentBlock => {
-                let n = export_content_blocks(&client, &content_blocks_root, args.name.as_deref())
-                    .await
-                    .context("exporting content_block")?;
+                let excludes = compile_exclude_patterns(
+                    &resolved.resources.content_block.exclude_patterns,
+                    "content_block",
+                )?;
+                let n = export_content_blocks(
+                    &client,
+                    &content_blocks_root,
+                    args.name.as_deref(),
+                    &excludes,
+                )
+                .await
+                .context("exporting content_block")?;
                 eprintln!("✓ content_block: exported {n} resource(s)");
                 total_written += n;
             }
             ResourceKind::EmailTemplate => {
-                let n =
-                    export_email_templates(&client, &email_templates_root, args.name.as_deref())
-                        .await
-                        .context("exporting email_template")?;
+                let excludes = compile_exclude_patterns(
+                    &resolved.resources.email_template.exclude_patterns,
+                    "email_template",
+                )?;
+                let n = export_email_templates(
+                    &client,
+                    &email_templates_root,
+                    args.name.as_deref(),
+                    &excludes,
+                )
+                .await
+                .context("exporting email_template")?;
                 eprintln!("✓ email_template: exported {n} resource(s)");
                 total_written += n;
             }
@@ -69,7 +95,11 @@ pub async fn run(
                          (the registry is a single file); exporting all attributes"
                     );
                 }
-                let n = export_custom_attributes(&client, &custom_attributes_path)
+                let excludes = compile_exclude_patterns(
+                    &resolved.resources.custom_attribute.exclude_patterns,
+                    "custom_attribute",
+                )?;
+                let n = export_custom_attributes(&client, &custom_attributes_path, &excludes)
                     .await
                     .context("exporting custom_attribute")?;
                 eprintln!("✓ custom_attribute: exported {n} attribute(s)");
@@ -86,6 +116,7 @@ async fn export_catalog_schemas(
     client: &BrazeClient,
     catalogs_root: &Path,
     name_filter: Option<&str>,
+    excludes: &[regex_lite::Regex],
 ) -> anyhow::Result<usize> {
     let catalogs = match name_filter {
         Some(name) => match client.get_catalog(name).await {
@@ -100,8 +131,12 @@ async fn export_catalog_schemas(
         None => client.list_catalogs().await?,
     };
 
-    let count = catalogs.len();
-    for cat in catalogs {
+    let filtered: Vec<_> = catalogs
+        .into_iter()
+        .filter(|c| !is_excluded(&c.name, excludes))
+        .collect();
+    let count = filtered.len();
+    for cat in filtered {
         catalog_io::save_schema(catalogs_root, &cat)?;
     }
     Ok(count)
@@ -114,11 +149,15 @@ async fn export_content_blocks(
     client: &BrazeClient,
     content_blocks_root: &Path,
     name_filter: Option<&str>,
+    excludes: &[regex_lite::Regex],
 ) -> anyhow::Result<usize> {
     let summaries = client.list_content_blocks().await?;
     let targets: Vec<_> = match name_filter {
         Some(name) => summaries.into_iter().filter(|s| s.name == name).collect(),
-        None => summaries,
+        None => summaries
+            .into_iter()
+            .filter(|s| !is_excluded(&s.name, excludes))
+            .collect(),
     };
 
     if targets.is_empty() {
@@ -154,11 +193,15 @@ async fn export_email_templates(
     client: &BrazeClient,
     email_templates_root: &Path,
     name_filter: Option<&str>,
+    excludes: &[regex_lite::Regex],
 ) -> anyhow::Result<usize> {
     let summaries = client.list_email_templates().await?;
     let targets: Vec<_> = match name_filter {
         Some(name) => summaries.into_iter().filter(|s| s.name == name).collect(),
-        None => summaries,
+        None => summaries
+            .into_iter()
+            .filter(|s| !is_excluded(&s.name, excludes))
+            .collect(),
     };
 
     if targets.is_empty() {
@@ -192,8 +235,14 @@ async fn export_email_templates(
 async fn export_custom_attributes(
     client: &BrazeClient,
     registry_path: &Path,
+    excludes: &[regex_lite::Regex],
 ) -> anyhow::Result<usize> {
-    let attrs = client.list_custom_attributes().await?;
+    let attrs: Vec<_> = client
+        .list_custom_attributes()
+        .await?
+        .into_iter()
+        .filter(|a| !is_excluded(&a.name, excludes))
+        .collect();
     let count = attrs.len();
     let registry = CustomAttributeRegistry { attributes: attrs };
     custom_attribute_io::save_registry(registry_path, &registry)?;

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -2,12 +2,13 @@
 
 use crate::braze::error::BrazeApiError;
 use crate::braze::BrazeClient;
-use crate::config::{compile_exclude_patterns, is_excluded, ResolvedConfig};
+use crate::config::{is_excluded, ResolvedConfig};
 use crate::fs::{catalog_io, content_block_io, custom_attribute_io, email_template_io};
 use crate::resource::{CustomAttributeRegistry, ResourceKind};
 use anyhow::Context as _;
 use clap::Args;
 use futures::stream::{StreamExt, TryStreamExt};
+use regex_lite::Regex;
 use std::path::Path;
 
 use super::{selected_kinds, FETCH_CONCURRENCY};
@@ -41,15 +42,11 @@ pub async fn run(
     for kind in kinds {
         match kind {
             ResourceKind::CatalogSchema => {
-                let excludes = compile_exclude_patterns(
-                    &resolved.resources.catalog_schema.exclude_patterns,
-                    "catalog_schema",
-                )?;
                 let n = export_catalog_schemas(
                     &client,
                     &catalogs_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::CatalogSchema),
                 )
                 .await
                 .context("exporting catalog_schema")?;
@@ -57,15 +54,11 @@ pub async fn run(
                 total_written += n;
             }
             ResourceKind::ContentBlock => {
-                let excludes = compile_exclude_patterns(
-                    &resolved.resources.content_block.exclude_patterns,
-                    "content_block",
-                )?;
                 let n = export_content_blocks(
                     &client,
                     &content_blocks_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::ContentBlock),
                 )
                 .await
                 .context("exporting content_block")?;
@@ -73,15 +66,11 @@ pub async fn run(
                 total_written += n;
             }
             ResourceKind::EmailTemplate => {
-                let excludes = compile_exclude_patterns(
-                    &resolved.resources.email_template.exclude_patterns,
-                    "email_template",
-                )?;
                 let n = export_email_templates(
                     &client,
                     &email_templates_root,
                     args.name.as_deref(),
-                    &excludes,
+                    resolved.excludes_for(ResourceKind::EmailTemplate),
                 )
                 .await
                 .context("exporting email_template")?;
@@ -95,13 +84,13 @@ pub async fn run(
                          (the registry is a single file); exporting all attributes"
                     );
                 }
-                let excludes = compile_exclude_patterns(
-                    &resolved.resources.custom_attribute.exclude_patterns,
-                    "custom_attribute",
-                )?;
-                let n = export_custom_attributes(&client, &custom_attributes_path, &excludes)
-                    .await
-                    .context("exporting custom_attribute")?;
+                let n = export_custom_attributes(
+                    &client,
+                    &custom_attributes_path,
+                    resolved.excludes_for(ResourceKind::CustomAttribute),
+                )
+                .await
+                .context("exporting custom_attribute")?;
                 eprintln!("✓ custom_attribute: exported {n} attribute(s)");
                 total_written += n;
             }
@@ -116,7 +105,7 @@ async fn export_catalog_schemas(
     client: &BrazeClient,
     catalogs_root: &Path,
     name_filter: Option<&str>,
-    excludes: &[regex_lite::Regex],
+    excludes: &[Regex],
 ) -> anyhow::Result<usize> {
     let catalogs = match name_filter {
         Some(name) => match client.get_catalog(name).await {
@@ -149,7 +138,7 @@ async fn export_content_blocks(
     client: &BrazeClient,
     content_blocks_root: &Path,
     name_filter: Option<&str>,
-    excludes: &[regex_lite::Regex],
+    excludes: &[Regex],
 ) -> anyhow::Result<usize> {
     let summaries = client.list_content_blocks().await?;
     let targets: Vec<_> = match name_filter {
@@ -193,7 +182,7 @@ async fn export_email_templates(
     client: &BrazeClient,
     email_templates_root: &Path,
     name_filter: Option<&str>,
-    excludes: &[regex_lite::Regex],
+    excludes: &[Regex],
 ) -> anyhow::Result<usize> {
     let summaries = client.list_email_templates().await?;
     let targets: Vec<_> = match name_filter {
@@ -235,7 +224,7 @@ async fn export_email_templates(
 async fn export_custom_attributes(
     client: &BrazeClient,
     registry_path: &Path,
-    excludes: &[regex_lite::Regex],
+    excludes: &[Regex],
 ) -> anyhow::Result<usize> {
     let attrs: Vec<_> = client
         .list_custom_attributes()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -193,6 +193,30 @@ async fn dispatch(cli: &Cli, resolved: ResolvedConfig, config_dir: &Path) -> any
     }
 }
 
+/// When `--name <n>` matches `kind`'s `exclude_patterns`, emit a warning
+/// and return `true` so the caller can skip the kind. Keeps the
+/// "excludes always win" invariant explicit at the CLI boundary so a
+/// user who names an excluded resource isn't left staring at a silently
+/// empty result.
+pub(crate) fn warn_if_name_excluded(
+    kind: ResourceKind,
+    name: Option<&str>,
+    excludes: &[regex_lite::Regex],
+) -> bool {
+    let Some(name) = name else {
+        return false;
+    };
+    if crate::config::is_excluded(name, excludes) {
+        eprintln!(
+            "⚠ {}: '{}' matches exclude_patterns; skipping",
+            kind.as_str(),
+            name
+        );
+        return true;
+    }
+    false
+}
+
 /// Expand an optional resource filter to the list of kinds to process,
 /// excluding any kinds disabled in the config.
 pub(crate) fn selected_kinds(

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -41,29 +41,48 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
         match kind {
             ResourceKind::CatalogSchema => {
                 let catalogs_root = config_dir.join(&cfg.resources.catalog_schema.path);
+                let excludes = crate::config::compile_exclude_patterns(
+                    &cfg.resources.catalog_schema.exclude_patterns,
+                    "catalog_schema",
+                )?;
                 validate_catalog_schemas(
                     &catalogs_root,
                     cfg.naming.catalog_name_pattern.as_deref(),
+                    &excludes,
                     &mut issues,
                 )?;
             }
             ResourceKind::ContentBlock => {
                 let content_blocks_root = config_dir.join(&cfg.resources.content_block.path);
+                let excludes = crate::config::compile_exclude_patterns(
+                    &cfg.resources.content_block.exclude_patterns,
+                    "content_block",
+                )?;
                 validate_content_blocks(
                     &content_blocks_root,
                     cfg.naming.content_block_name_pattern.as_deref(),
+                    &excludes,
                     &mut issues,
                 )?;
             }
             ResourceKind::EmailTemplate => {
                 let email_templates_root = config_dir.join(&cfg.resources.email_template.path);
-                validate_email_templates(&email_templates_root, &mut issues)?;
+                let excludes = crate::config::compile_exclude_patterns(
+                    &cfg.resources.email_template.exclude_patterns,
+                    "email_template",
+                )?;
+                validate_email_templates(&email_templates_root, &excludes, &mut issues)?;
             }
             ResourceKind::CustomAttribute => {
                 let registry_path = config_dir.join(&cfg.resources.custom_attribute.path);
+                let excludes = crate::config::compile_exclude_patterns(
+                    &cfg.resources.custom_attribute.exclude_patterns,
+                    "custom_attribute",
+                )?;
                 validate_custom_attributes(
                     &registry_path,
                     cfg.naming.custom_attribute_name_pattern.as_deref(),
+                    &excludes,
                     &mut issues,
                 )?;
             }
@@ -145,6 +164,7 @@ fn check_name_pattern(
 fn validate_catalog_schemas(
     catalogs_root: &Path,
     name_pattern: Option<&str>,
+    excludes: &[Regex],
     issues: &mut Vec<ValidationIssue>,
 ) -> anyhow::Result<()> {
     let Some(read_dir) = open_resource_dir(catalogs_root, "catalogs", issues)? else {
@@ -176,6 +196,10 @@ fn validate_catalog_schemas(
             }
         };
 
+        if crate::config::is_excluded(&cat.name, excludes) {
+            continue;
+        }
+
         // load_all_schemas treats dir/name mismatch as a hard error;
         // here we downgrade to a soft issue so a single run reports
         // every bad file.
@@ -206,6 +230,7 @@ fn validate_catalog_schemas(
 fn validate_content_blocks(
     content_blocks_root: &Path,
     name_pattern: Option<&str>,
+    excludes: &[Regex],
     issues: &mut Vec<ValidationIssue>,
 ) -> anyhow::Result<()> {
     let Some(read_dir) = open_resource_dir(content_blocks_root, "content_blocks", issues)? else {
@@ -241,6 +266,10 @@ fn validate_content_blocks(
             }
         };
 
+        if crate::config::is_excluded(&cb.name, excludes) {
+            continue;
+        }
+
         if cb.name != stem {
             issues.push(ValidationIssue {
                 path: path.clone(),
@@ -266,6 +295,7 @@ fn validate_content_blocks(
 
 fn validate_email_templates(
     email_templates_root: &Path,
+    excludes: &[Regex],
     issues: &mut Vec<ValidationIssue>,
 ) -> anyhow::Result<()> {
     let Some(read_dir) = open_resource_dir(email_templates_root, "email_templates", issues)? else {
@@ -296,6 +326,10 @@ fn validate_email_templates(
             }
         };
 
+        if crate::config::is_excluded(&et.name, excludes) {
+            continue;
+        }
+
         if et.name != dir_name {
             issues.push(ValidationIssue {
                 path: template_yaml_path.clone(),
@@ -320,6 +354,7 @@ fn validate_email_templates(
 fn validate_custom_attributes(
     registry_path: &Path,
     name_pattern: Option<&str>,
+    excludes: &[Regex],
     issues: &mut Vec<ValidationIssue>,
 ) -> anyhow::Result<()> {
     let registry = match custom_attribute_io::load_registry(registry_path) {
@@ -339,6 +374,9 @@ fn validate_custom_attributes(
 
     let mut seen = HashSet::with_capacity(registry.attributes.len());
     for attr in &registry.attributes {
+        if crate::config::is_excluded(&attr.name, excludes) {
+            continue;
+        }
         if !seen.insert(attr.name.as_str()) {
             issues.push(ValidationIssue {
                 path: registry_path.to_path_buf(),

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -41,10 +41,7 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
         match kind {
             ResourceKind::CatalogSchema => {
                 let catalogs_root = config_dir.join(&cfg.resources.catalog_schema.path);
-                let excludes = crate::config::compile_exclude_patterns(
-                    &cfg.resources.catalog_schema.exclude_patterns,
-                    "catalog_schema",
-                )?;
+                let excludes = compile_kind_excludes(cfg, kind)?;
                 validate_catalog_schemas(
                     &catalogs_root,
                     cfg.naming.catalog_name_pattern.as_deref(),
@@ -54,10 +51,7 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
             }
             ResourceKind::ContentBlock => {
                 let content_blocks_root = config_dir.join(&cfg.resources.content_block.path);
-                let excludes = crate::config::compile_exclude_patterns(
-                    &cfg.resources.content_block.exclude_patterns,
-                    "content_block",
-                )?;
+                let excludes = compile_kind_excludes(cfg, kind)?;
                 validate_content_blocks(
                     &content_blocks_root,
                     cfg.naming.content_block_name_pattern.as_deref(),
@@ -67,18 +61,12 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
             }
             ResourceKind::EmailTemplate => {
                 let email_templates_root = config_dir.join(&cfg.resources.email_template.path);
-                let excludes = crate::config::compile_exclude_patterns(
-                    &cfg.resources.email_template.exclude_patterns,
-                    "email_template",
-                )?;
+                let excludes = compile_kind_excludes(cfg, kind)?;
                 validate_email_templates(&email_templates_root, &excludes, &mut issues)?;
             }
             ResourceKind::CustomAttribute => {
                 let registry_path = config_dir.join(&cfg.resources.custom_attribute.path);
-                let excludes = crate::config::compile_exclude_patterns(
-                    &cfg.resources.custom_attribute.exclude_patterns,
-                    "custom_attribute",
-                )?;
+                let excludes = compile_kind_excludes(cfg, kind)?;
                 validate_custom_attributes(
                     &registry_path,
                     cfg.naming.custom_attribute_name_pattern.as_deref(),
@@ -100,6 +88,13 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
     }
 
     Err(Error::Config(format!("{} validation issue(s) found", issues.len())).into())
+}
+
+fn compile_kind_excludes(cfg: &ConfigFile, kind: ResourceKind) -> anyhow::Result<Vec<Regex>> {
+    Ok(crate::config::compile_exclude_patterns(
+        &cfg.resources.for_kind(kind).exclude_patterns,
+        kind.as_str(),
+    )?)
 }
 
 /// Try to open a resource root directory. Returns `None` (and pushes an

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -191,6 +191,10 @@ fn validate_catalog_schemas(
             }
         };
 
+        // Exclude is checked AFTER parse so a malformed file still
+        // surfaces — excludes mean "don't enforce rules on this name",
+        // not "silence this file". A broken YAML is a workspace problem
+        // regardless of whether the resource is managed out of band.
         if crate::config::is_excluded(&cat.name, excludes) {
             continue;
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,7 +21,10 @@ pub use schema::{
 };
 
 use crate::error::{Error, Result};
+use crate::resource::ResourceKind;
+use regex_lite::Regex;
 use secrecy::SecretString;
+use std::collections::HashMap;
 use std::path::Path;
 use url::Url;
 
@@ -37,6 +40,18 @@ pub struct ResolvedConfig {
     pub api_key: SecretString,
     pub resources: ResourcesConfig,
     pub naming: NamingConfig,
+    /// Compiled `exclude_patterns` per resource kind. Populated by
+    /// [`ConfigFile::resolve_with`] so callers can look up a `&[Regex]`
+    /// without recompiling on every invocation.
+    pub excludes: HashMap<ResourceKind, Vec<Regex>>,
+}
+
+impl ResolvedConfig {
+    /// Compiled exclude patterns for `kind`. Returns an empty slice when
+    /// no patterns are configured.
+    pub fn excludes_for(&self, kind: ResourceKind) -> &[Regex] {
+        self.excludes.get(&kind).map(Vec::as_slice).unwrap_or(&[])
+    }
 }
 
 impl ConfigFile {
@@ -88,13 +103,9 @@ impl ConfigFile {
         }
         // Compile every resource's exclude_patterns at load time so
         // malformed regexes fail fast instead of at first use.
-        for (kind, rc) in [
-            ("catalog_schema", &self.resources.catalog_schema),
-            ("content_block", &self.resources.content_block),
-            ("email_template", &self.resources.email_template),
-            ("custom_attribute", &self.resources.custom_attribute),
-        ] {
-            compile_exclude_patterns(&rc.exclude_patterns, kind)?;
+        for kind in ResourceKind::all() {
+            let rc = self.resources.for_kind(*kind);
+            compile_exclude_patterns(&rc.exclude_patterns, kind.as_str())?;
         }
         Ok(())
     }
@@ -137,12 +148,22 @@ impl ConfigFile {
             )));
         }
 
+        let mut excludes: HashMap<ResourceKind, Vec<Regex>> = HashMap::new();
+        for kind in ResourceKind::all() {
+            let rc = self.resources.for_kind(*kind);
+            excludes.insert(
+                *kind,
+                compile_exclude_patterns(&rc.exclude_patterns, kind.as_str())?,
+            );
+        }
+
         Ok(ResolvedConfig {
             environment_name: env_name,
             api_endpoint: env_cfg.api_endpoint,
             api_key: SecretString::from(api_key_str),
             resources: self.resources,
             naming: self.naming,
+            excludes,
         })
     }
 }
@@ -150,15 +171,12 @@ impl ConfigFile {
 /// Compile a list of raw regex patterns from a resource's
 /// `exclude_patterns` into `Regex` values. The `context` label is used
 /// in error messages (e.g. `"custom_attribute"`).
-pub fn compile_exclude_patterns(
-    patterns: &[String],
-    context: &str,
-) -> Result<Vec<regex_lite::Regex>> {
+pub fn compile_exclude_patterns(patterns: &[String], context: &str) -> Result<Vec<Regex>> {
     patterns
         .iter()
         .enumerate()
         .map(|(i, p)| {
-            regex_lite::Regex::new(p).map_err(|e| {
+            Regex::new(p).map_err(|e| {
                 Error::Config(format!(
                     "{context}.exclude_patterns[{i}]: invalid regex {p:?}: {e}"
                 ))
@@ -168,7 +186,7 @@ pub fn compile_exclude_patterns(
 }
 
 /// Return `true` if `name` matches any of the compiled patterns.
-pub fn is_excluded(name: &str, patterns: &[regex_lite::Regex]) -> bool {
+pub fn is_excluded(name: &str, patterns: &[Regex]) -> bool {
     patterns.iter().any(|r| r.is_match(name))
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -86,6 +86,16 @@ impl ConfigFile {
                 }
             }
         }
+        // Compile every resource's exclude_patterns at load time so
+        // malformed regexes fail fast instead of at first use.
+        for (kind, rc) in [
+            ("catalog_schema", &self.resources.catalog_schema),
+            ("content_block", &self.resources.content_block),
+            ("email_template", &self.resources.email_template),
+            ("custom_attribute", &self.resources.custom_attribute),
+        ] {
+            compile_exclude_patterns(&rc.exclude_patterns, kind)?;
+        }
         Ok(())
     }
 
@@ -135,6 +145,31 @@ impl ConfigFile {
             naming: self.naming,
         })
     }
+}
+
+/// Compile a list of raw regex patterns from a resource's
+/// `exclude_patterns` into `Regex` values. The `context` label is used
+/// in error messages (e.g. `"custom_attribute"`).
+pub fn compile_exclude_patterns(
+    patterns: &[String],
+    context: &str,
+) -> Result<Vec<regex_lite::Regex>> {
+    patterns
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            regex_lite::Regex::new(p).map_err(|e| {
+                Error::Config(format!(
+                    "{context}.exclude_patterns[{i}]: invalid regex {p:?}: {e}"
+                ))
+            })
+        })
+        .collect()
+}
+
+/// Return `true` if `name` matches any of the compiled patterns.
+pub fn is_excluded(name: &str, patterns: &[regex_lite::Regex]) -> bool {
+    patterns.iter().any(|r| r.is_match(name))
 }
 
 /// Load `.env` from the current working directory only — no parent
@@ -312,6 +347,67 @@ environments:
         let f = write_config(yaml);
         let err = ConfigFile::load(f.path()).unwrap_err();
         assert!(matches!(err, Error::YamlParse { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn accepts_exclude_patterns_on_resource_config() {
+        let yaml = r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_DEV_API_KEY
+resources:
+  custom_attribute:
+    path: custom_attributes/registry.yaml
+    exclude_patterns:
+      - "^_"
+      - "^(hoge|hack)$"
+"#;
+        let f = write_config(yaml);
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        assert_eq!(
+            cfg.resources.custom_attribute.exclude_patterns,
+            vec!["^_".to_string(), "^(hoge|hack)$".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_exclude_pattern_at_load_time() {
+        // Unbalanced paren — invalid regex should hard-error at load,
+        // not at first use.
+        let yaml = r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_DEV_API_KEY
+resources:
+  custom_attribute:
+    path: custom_attributes/registry.yaml
+    exclude_patterns:
+      - "("
+"#;
+        let f = write_config(yaml);
+        let err = ConfigFile::load(f.path()).unwrap_err();
+        match err {
+            Error::Config(msg) => {
+                assert!(msg.contains("custom_attribute"), "msg: {msg}");
+                assert!(msg.contains("exclude_patterns[0]"), "msg: {msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_excluded_matches_any_pattern() {
+        let patterns =
+            compile_exclude_patterns(&["^_".to_string(), "^test_".to_string()], "test").unwrap();
+        assert!(is_excluded("_unset", &patterns));
+        assert!(is_excluded("test_foo", &patterns));
+        assert!(!is_excluded("regular_attr", &patterns));
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -82,6 +82,13 @@ pub struct ResourceConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
     pub path: PathBuf,
+    /// Regex patterns (matched against resource `name`) that mark a
+    /// resource as **managed out of band**. Names matching any pattern
+    /// are skipped by `export`, `diff`, `apply`, and `validate` so
+    /// Braze reserved attributes (`_unset`) or camelCase duplicates
+    /// don't produce noise. See `docs/configuration.md §exclude_patterns`.
+    #[serde(default)]
+    pub exclude_patterns: Vec<String>,
 }
 
 fn default_enabled() -> bool {
@@ -92,6 +99,7 @@ fn default_catalog_schema() -> ResourceConfig {
     ResourceConfig {
         enabled: true,
         path: PathBuf::from("catalogs/"),
+        exclude_patterns: Vec::new(),
     }
 }
 
@@ -99,6 +107,7 @@ fn default_content_block() -> ResourceConfig {
     ResourceConfig {
         enabled: true,
         path: PathBuf::from("content_blocks/"),
+        exclude_patterns: Vec::new(),
     }
 }
 
@@ -106,6 +115,7 @@ fn default_email_template() -> ResourceConfig {
     ResourceConfig {
         enabled: true,
         path: PathBuf::from("email_templates/"),
+        exclude_patterns: Vec::new(),
     }
 }
 
@@ -113,6 +123,7 @@ fn default_custom_attribute() -> ResourceConfig {
     ResourceConfig {
         enabled: true,
         path: PathBuf::from("custom_attributes/registry.yaml"),
+        exclude_patterns: Vec::new(),
     }
 }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -54,14 +54,18 @@ pub struct ResourcesConfig {
 }
 
 impl ResourcesConfig {
-    pub fn is_enabled(&self, kind: crate::resource::ResourceKind) -> bool {
+    pub fn for_kind(&self, kind: crate::resource::ResourceKind) -> &ResourceConfig {
         use crate::resource::ResourceKind;
         match kind {
-            ResourceKind::CatalogSchema => self.catalog_schema.enabled,
-            ResourceKind::ContentBlock => self.content_block.enabled,
-            ResourceKind::EmailTemplate => self.email_template.enabled,
-            ResourceKind::CustomAttribute => self.custom_attribute.enabled,
+            ResourceKind::CatalogSchema => &self.catalog_schema,
+            ResourceKind::ContentBlock => &self.content_block,
+            ResourceKind::EmailTemplate => &self.email_template,
+            ResourceKind::CustomAttribute => &self.custom_attribute,
         }
+    }
+
+    pub fn is_enabled(&self, kind: crate::resource::ResourceKind) -> bool {
+        self.for_kind(kind).enabled
     }
 }
 


### PR DESCRIPTION
## Summary

- Each resource config now accepts \`exclude_patterns: [<regex>, ...]\`
- Names matching any pattern are skipped by \`export\`, \`diff\`, \`apply\`, and \`validate\`
- Regexes are compiled at config load time — a bad regex hard-errors before any command runs
- Dialect: \`regex-lite\` (same as the existing \`naming.*_name_pattern\`)

## Why

Real workspaces tend to accumulate names that are not worth trying to keep in sync:

- Braze reserved attributes (e.g. \`_unset\`)
- Developer debugging leftovers (\`hoge\`, \`hack\`)
- Legacy camelCase duplicates created by dashboard operators that cannot be renamed without disrupting downstream pipelines

Renaming them case-by-case is not realistic. The tool needs a way to mark them as "managed out of band" so they stop producing noise on every \`diff\` / \`export\` / \`validate\` run. This is the P2 item in the API-alignment plan.

## Example

\`\`\`yaml
custom_attribute:
  enabled: true
  path: custom_attributes/registry.yaml
  exclude_patterns:
    - "^_"
    - "^(hoge|hack)$"
    - "^test_"
\`\`\`

## Test plan

- [x] \`cargo test\` workspace green (289 lib tests + all integration)
- [x] \`cargo clippy --all-targets\` clean
- [x] New config tests: \`accepts_exclude_patterns_on_resource_config\`, \`rejects_invalid_exclude_pattern_at_load_time\`, \`is_excluded_matches_any_pattern\`
- [x] Existing resource tests still pass (default empty patterns preserve behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)