### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ## [Unreleased]
 
-### Breaking changes (targeted for v0.8.0)
+## [0.8.0] — 2026-04-19
+
+### Breaking changes
 
 - **Removed `catalog_items` support.** braze-sync now exclusively
   manages Braze configuration (schemas, content blocks, email
@@ -37,7 +39,7 @@ disk are no longer read or written — delete them.
 braze-sync no longer throttles proactively; Braze's own 429 signal is
 the only pacing mechanism.
 
-### Added (unreleased)
+### Added
 
 - `custom_attribute` now uses the Braze-verified wire schema
   (`attributes`/`name`/`status`) and follows RFC 5988 `Link: rel="next"`
@@ -45,10 +47,18 @@ the only pacing mechanism.
   workspaces where attributes carried suffixed type strings like
   `"String (Automatically Detected)"` or `status: "Blocklisted"`.
 - `content_blocks/list` and `templates/email/list` now use offset
-  pagination with `limit=1000` (Braze max). Workspaces with over 100
-  entries no longer hard-error.
+  pagination with `limit=1000` (the Braze documented max). Workspaces
+  with more than 100 entries no longer hard-error on `diff`/`apply`.
 - `CustomAttributeType::Object` / `ObjectArray` domain variants for
   the `Object` and `Object Array` types that Braze returns in practice.
+- `exclude_patterns: [<regex>, ...]` on every resource config. Names
+  matching any pattern are skipped by `export`, `diff`, `apply`, and
+  `validate`, so Braze-reserved attributes (`_unset`), developer
+  leftovers (`hoge`, `hack`), and legacy camelCase duplicates stop
+  surfacing as drift. Patterns compile at config load time (bad regex
+  → hard error before the command runs).
+- New `docs/scope-boundaries.md` — canonical "configuration vs runtime
+  data" reference.
 
 ## [0.7.0] — 2026-04-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ synchronize it to Braze with the same workflow you'd use for
 detection in CI, and an `--allow-destructive` gate that has to be
 crossed explicitly before anything is dropped.
 
-## Status: v0.8.0-prep (4 resources + init)
+## Status: v0.8.0 (4 resources + init)
 
 braze-sync manages Braze **configuration** as code. The four managed
 resource kinds are:


### PR DESCRIPTION
## Summary

Version bump and CHANGELOG finalization for the v0.8.0 release. No code changes — the release content is the set already merged:

- #15 — rate limiter removal, 429 retry rewrite, Link-header infrastructure, \`custom_attribute\` wire alignment
- #16 — \`catalog_items\` removed from the codebase
- #17 — offset pagination for \`content_blocks/list\` and \`templates/email/list\`
- #18 — config hard-errors pinned, \`docs/scope-boundaries.md\`, CHANGELOG/README scope update
- #19 — \`exclude_patterns\` on every resource config

## Release checklist

- [x] \`Cargo.toml\` version \`0.7.0\` → \`0.8.0\`
- [x] \`Cargo.lock\` regenerated via \`cargo build --release\`
- [x] CHANGELOG: Unreleased block moved under \`[0.8.0] — 2026-04-19\`
- [x] README status line updated
- [x] \`cargo test\` across the workspace is green
- [x] \`cargo build --release\` succeeds
- [ ] Tag \`v0.8.0\` and push after merge (triggers the release + Homebrew-tap workflows)

## Breaking changes (for release notes)

- \`catalog_items\` removed — use the Braze REST API (\`/catalogs/{name}/items\`) directly from a data pipeline or ETL job
- \`rate_limit_per_minute\` config key removed (both \`defaults.\` and per-environment) — deletion of the key is the migration
- \`resources.catalog_items:\` config section now hard-errors at load — remove it

See the \`[0.8.0]\` block in CHANGELOG.md for full migration notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)