### PR TITLE
Omit offset=0 on first page of list endpoints

### DIFF
--- a/src/braze/content_block.rs
+++ b/src/braze/content_block.rs
@@ -23,12 +23,8 @@ pub struct ContentBlockSummary {
 
 impl BrazeClient {
     /// Braze has no `has_more`/cursor field, so we loop until a short page.
-    ///
-    /// `offset` is omitted on the first request: Braze rejects
-    /// `offset=0` with `400 "Offset must be greater than 0."` on this
-    /// endpoint, reading "strictly greater than 0" rather than "at
-    /// least 0". Subsequent pages send `offset=LIST_LIMIT`, `2*LIST_LIMIT`,
-    /// etc.
+    /// `offset` is omitted on the first request because this endpoint rejects
+    /// `offset=0` with `400 "Offset must be greater than 0."`.
     pub async fn list_content_blocks(&self) -> Result<Vec<ContentBlockSummary>, BrazeApiError> {
         let mut all: Vec<ContentBlockListEntry> = Vec::with_capacity(LIST_LIMIT as usize);
         let mut offset: u32 = 0;
@@ -539,39 +535,6 @@ mod tests {
             }
             other => panic!("expected Http, got {other:?}"),
         }
-    }
-
-    #[tokio::test]
-    async fn list_first_page_does_not_send_offset_zero() {
-        // Regression: Braze rejects `offset=0` with
-        // `400 "Offset must be greater than 0."` on this endpoint, so
-        // the first request must omit the offset query param entirely.
-        // A mock that requires `offset` to be present and non-zero
-        // would 400 on page 1 before this fix landed; the `expect(0)`
-        // on a strict "offset present" matcher makes the regression
-        // fail loudly.
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/content_blocks/list"))
-            .and(wiremock::matchers::query_param_contains("offset", ""))
-            .respond_with(
-                ResponseTemplate::new(400)
-                    .set_body_json(json!({"message": "Offset must be greater than 0."})),
-            )
-            .expect(0)
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path("/content_blocks/list"))
-            .and(query_param_is_missing("offset"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({"content_blocks": []})),
-            )
-            .mount(&server)
-            .await;
-        let client = make_client(&server);
-        let summaries = client.list_content_blocks().await.unwrap();
-        assert!(summaries.is_empty());
     }
 
     #[tokio::test]

--- a/src/braze/content_block.rs
+++ b/src/braze/content_block.rs
@@ -23,14 +23,22 @@ pub struct ContentBlockSummary {
 
 impl BrazeClient {
     /// Braze has no `has_more`/cursor field, so we loop until a short page.
+    ///
+    /// `offset` is omitted on the first request: Braze rejects
+    /// `offset=0` with `400 "Offset must be greater than 0."` on this
+    /// endpoint, reading "strictly greater than 0" rather than "at
+    /// least 0". Subsequent pages send `offset=LIST_LIMIT`, `2*LIST_LIMIT`,
+    /// etc.
     pub async fn list_content_blocks(&self) -> Result<Vec<ContentBlockSummary>, BrazeApiError> {
         let mut all: Vec<ContentBlockListEntry> = Vec::with_capacity(LIST_LIMIT as usize);
         let mut offset: u32 = 0;
         loop {
-            let req = self.get(&["content_blocks", "list"]).query(&[
-                ("limit", LIST_LIMIT.to_string()),
-                ("offset", offset.to_string()),
-            ]);
+            let mut req = self
+                .get(&["content_blocks", "list"])
+                .query(&[("limit", LIST_LIMIT.to_string())]);
+            if offset > 0 {
+                req = req.query(&[("offset", offset.to_string())]);
+            }
             let resp: ContentBlockListResponse = self.send_json(req).await?;
             let page_len = resp.content_blocks.len();
             if all.len().saturating_add(page_len) > LIST_SAFETY_CAP_ITEMS {
@@ -208,7 +216,9 @@ mod tests {
     use crate::braze::test_client as make_client;
     use reqwest::StatusCode;
     use serde_json::json;
-    use wiremock::matchers::{body_json, header, method, path, query_param};
+    use wiremock::matchers::{
+        body_json, header, method, path, query_param, query_param_is_missing,
+    };
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -218,7 +228,7 @@ mod tests {
             .and(path("/content_blocks/list"))
             .and(header("authorization", "Bearer test-key"))
             .and(query_param("limit", "1000"))
-            .and(query_param("offset", "0"))
+            .and(query_param_is_missing("offset"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "content_blocks": [
                     {"content_block_id": "id-1", "name": "promo"},
@@ -532,11 +542,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_first_page_does_not_send_offset_zero() {
+        // Regression: Braze rejects `offset=0` with
+        // `400 "Offset must be greater than 0."` on this endpoint, so
+        // the first request must omit the offset query param entirely.
+        // A mock that requires `offset` to be present and non-zero
+        // would 400 on page 1 before this fix landed; the `expect(0)`
+        // on a strict "offset present" matcher makes the regression
+        // fail loudly.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/content_blocks/list"))
+            .and(wiremock::matchers::query_param_contains("offset", ""))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_json(json!({"message": "Offset must be greater than 0."})),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/content_blocks/list"))
+            .and(query_param_is_missing("offset"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"content_blocks": []})),
+            )
+            .mount(&server)
+            .await;
+        let client = make_client(&server);
+        let summaries = client.list_content_blocks().await.unwrap();
+        assert!(summaries.is_empty());
+    }
+
+    #[tokio::test]
     async fn list_short_page_is_treated_as_complete() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/content_blocks/list"))
-            .and(query_param("offset", "0"))
+            .and(query_param_is_missing("offset"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "content_blocks": [
                     {"content_block_id": "id-1", "name": "a"},
@@ -595,7 +638,7 @@ mod tests {
             .await;
         Mock::given(method("GET"))
             .and(path("/content_blocks/list"))
-            .and(query_param("offset", "0"))
+            .and(query_param_is_missing("offset"))
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(json!({ "content_blocks": page1 })),
             )

--- a/src/braze/email_template.rs
+++ b/src/braze/email_template.rs
@@ -30,11 +30,8 @@ pub struct EmailTemplateSummary {
 
 impl BrazeClient {
     /// Braze has no `has_more`/cursor field, so we loop until a short page.
-    ///
-    /// `offset` is omitted on the first request: Braze rejects
-    /// `offset=0` with `400 "Offset must be greater than 0."` on this
-    /// endpoint (same wording as `/content_blocks/list`), reading
-    /// "strictly greater than 0" rather than "at least 0".
+    /// `offset` is omitted on the first request because this endpoint rejects
+    /// `offset=0` with `400 "Offset must be greater than 0."`.
     pub async fn list_email_templates(&self) -> Result<Vec<EmailTemplateSummary>, BrazeApiError> {
         let mut all: Vec<EmailTemplateListEntry> = Vec::with_capacity(LIST_LIMIT as usize);
         let mut offset: u32 = 0;

--- a/src/braze/email_template.rs
+++ b/src/braze/email_template.rs
@@ -30,14 +30,21 @@ pub struct EmailTemplateSummary {
 
 impl BrazeClient {
     /// Braze has no `has_more`/cursor field, so we loop until a short page.
+    ///
+    /// `offset` is omitted on the first request: Braze rejects
+    /// `offset=0` with `400 "Offset must be greater than 0."` on this
+    /// endpoint (same wording as `/content_blocks/list`), reading
+    /// "strictly greater than 0" rather than "at least 0".
     pub async fn list_email_templates(&self) -> Result<Vec<EmailTemplateSummary>, BrazeApiError> {
         let mut all: Vec<EmailTemplateListEntry> = Vec::with_capacity(LIST_LIMIT as usize);
         let mut offset: u32 = 0;
         loop {
-            let req = self.get(&["templates", "email", "list"]).query(&[
-                ("limit", LIST_LIMIT.to_string()),
-                ("offset", offset.to_string()),
-            ]);
+            let mut req = self
+                .get(&["templates", "email", "list"])
+                .query(&[("limit", LIST_LIMIT.to_string())]);
+            if offset > 0 {
+                req = req.query(&[("offset", offset.to_string())]);
+            }
             let resp: EmailTemplateListResponse = self.send_json(req).await?;
             let page_len = resp.templates.len();
             if all.len().saturating_add(page_len) > LIST_SAFETY_CAP_ITEMS {
@@ -207,7 +214,9 @@ mod tests {
     use super::*;
     use crate::braze::test_client as make_client;
     use serde_json::json;
-    use wiremock::matchers::{body_json, header, method, path, query_param};
+    use wiremock::matchers::{
+        body_json, header, method, path, query_param, query_param_is_missing,
+    };
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -217,7 +226,7 @@ mod tests {
             .and(path("/templates/email/list"))
             .and(header("authorization", "Bearer test-key"))
             .and(query_param("limit", "1000"))
-            .and(query_param("offset", "0"))
+            .and(query_param_is_missing("offset"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "templates": [
                     {"email_template_id": "id-1", "template_name": "welcome"},
@@ -530,7 +539,7 @@ mod tests {
             .await;
         Mock::given(method("GET"))
             .and(path("/templates/email/list"))
-            .and(query_param("offset", "0"))
+            .and(query_param_is_missing("offset"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "templates": page1 })))
             .mount(&server)
             .await;


### PR DESCRIPTION
## Summary

- `/content_blocks/list` and `/templates/email/list` reject `offset=0` with `400 "Offset must be greater than 0."`
- v0.8.0 sent `offset=0` on page 1 of the new offset-pagination loop, breaking `export` / `diff` for any non-empty workspace
- Fix: omit the `offset` query param on the first request; attach it only from the second page onward (`offset=1000`, `offset=2000`, ...)

## Reproduction

```
$ braze-sync export
✓ catalog_schema: exported 76 resource(s)
error: exporting content_block: HTTP 400 Bad Request: {"message":"Offset must be greater than 0."}
```

## Test plan

- [x] `cargo test` workspace green (289 lib + all integration)
- [x] `cargo clippy --all-targets` clean
- [x] New regression test `list_first_page_does_not_send_offset_zero` asserts the first request carries no `offset` query param
- [x] Updated existing wiremock matchers: `query_param_is_missing(\"offset\")` on page 1, `query_param(\"offset\", \"1000\")` etc. on subsequent pages
- [ ] Manually re-run `braze-sync export` against a real workspace to confirm completion

## Release note

Worth cutting a v0.8.1 patch once this merges — v0.8.0 is unusable against Braze for `export` / `diff` / `apply` on `content_block` and `email_template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)