### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-04-27
+
 ### Added
 
 - **Catalog creation in `apply`.** A new catalog directory committed to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.9.0
- Promote `[Unreleased]` catalog creation entry to `[0.9.0] — 2026-04-27` in CHANGELOG

Catalog creation in `apply` (#22) is the user-facing change.

## Test plan
- [ ] CI green
- [ ] Tag `v0.9.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)