### PR TITLE
Treat custom_attribute PresentInGitOnly as informational drift

### DIFF
--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -226,14 +226,6 @@ pub async fn run(
 /// (e.g. content-type change with no in-place update), re-evaluate.
 fn check_for_unsupported_ops(summary: &DiffSummary) -> anyhow::Result<()> {
     for diff in &summary.diffs {
-        if let ResourceDiff::CustomAttribute(d) = diff {
-            if matches!(d.op, CustomAttributeOp::PresentInGitOnly) {
-                return Err(Error::CustomAttributeCreateNotSupported {
-                    name: d.name.clone(),
-                }
-                .into());
-            }
-        }
         if let ResourceDiff::CatalogSchema(d) = diff {
             match &d.op {
                 DiffOp::Added(_) => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -280,8 +280,7 @@ fn exit_code_for(err: &anyhow::Error) -> i32 {
                 Error::Io(_)
                 | Error::YamlParse { .. }
                 | Error::CsvParse { .. }
-                | Error::InvalidFormat { .. }
-                | Error::CustomAttributeCreateNotSupported { .. } => return 1,
+                | Error::InvalidFormat { .. } => return 1,
             }
         }
     }

--- a/src/diff/custom_attribute.rs
+++ b/src/diff/custom_attribute.rs
@@ -39,17 +39,14 @@ impl CustomAttributeDiff {
     /// Whether `apply` should consider this diff actionable — i.e. it
     /// must not be skipped by the "No changes to apply" early exit.
     ///
-    /// - `DeprecationToggled` produces an API call.
-    /// - `PresentInGitOnly` is included so it reaches
-    ///   `check_for_unsupported_ops` and produces a clear rejection
-    ///   error rather than being silently ignored.
-    /// - `MetadataOnly` and `UnregisteredInGit` are informational drift
-    ///   that `apply` cannot resolve (the fix is `export`, not `apply`).
+    /// Only `DeprecationToggled` produces an API call. Every other variant
+    /// is informational drift that `apply` cannot resolve, including
+    /// `PresentInGitOnly`: Braze has no creation endpoint for custom
+    /// attributes (they materialize on first `/users/track` call), so a
+    /// registry entry that isn't in Braze yet is normal — and must not
+    /// block apply of unrelated resources.
     pub fn is_actionable(&self) -> bool {
-        matches!(
-            self.op,
-            CustomAttributeOp::DeprecationToggled { .. } | CustomAttributeOp::PresentInGitOnly
-        )
+        matches!(self.op, CustomAttributeOp::DeprecationToggled { .. })
     }
 }
 
@@ -361,7 +358,7 @@ mod tests {
             to: true
         })
         .is_actionable());
-        assert!(make(CustomAttributeOp::PresentInGitOnly).is_actionable());
+        assert!(!make(CustomAttributeOp::PresentInGitOnly).is_actionable());
         assert!(!make(CustomAttributeOp::MetadataOnly).is_actionable());
         assert!(!make(CustomAttributeOp::UnregisteredInGit).is_actionable());
         assert!(!make(CustomAttributeOp::Unchanged).is_actionable());

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -114,9 +114,11 @@ impl ResourceDiff {
 
     /// Whether `apply` can act on this diff. For most resource types this
     /// is the same as `has_changes()`. Custom Attributes are the exception:
-    /// `MetadataOnly` and `UnregisteredInGit` are informational drift
-    /// that `apply` cannot resolve via API. `PresentInGitOnly` is
-    /// actionable so `apply` can surface the unsupported-create error.
+    /// only `DeprecationToggled` produces an API call. `MetadataOnly`,
+    /// `UnregisteredInGit`, and `PresentInGitOnly` are all informational
+    /// drift — Braze has no create endpoint for custom attributes (they
+    /// materialize on first `/users/track`), so registry-only entries are
+    /// expected and must not block apply.
     pub fn is_actionable(&self) -> bool {
         match self {
             Self::CustomAttribute(d) => d.is_actionable(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,9 +48,4 @@ pub enum Error {
 
     #[error("Rate limit exhausted after {retries} retries")]
     RateLimitExhausted { retries: u32 },
-
-    #[error(
-        "Custom Attribute '{name}' cannot be created via API; created implicitly via /users/track"
-    )]
-    CustomAttributeCreateNotSupported { name: String },
 }

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -950,6 +950,11 @@ async fn apply_custom_attribute_present_in_git_only_is_informational_no_op() {
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("in Git registry but not in Braze"),
+        "expected PresentInGitOnly warning in plan output; stdout: {stdout}"
+    );
 }
 
 /// Regression: a registry-only custom_attribute (`PresentInGitOnly`) must

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -907,13 +907,22 @@ async fn apply_custom_attribute_dry_run_makes_no_write_call() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn apply_custom_attribute_present_in_git_only_rejects() {
+async fn apply_custom_attribute_present_in_git_only_is_informational_no_op() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/custom_attributes"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "attributes": []
         })))
+        .mount(&server)
+        .await;
+    // PresentInGitOnly is informational drift — Braze has no create
+    // endpoint for custom attributes (they materialize on first
+    // /users/track), so `apply` must not POST and must not error.
+    Mock::given(method("POST"))
+        .and(path("/custom_attributes/blocklist"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
         .mount(&server)
         .await;
 
@@ -936,16 +945,10 @@ async fn apply_custom_attribute_present_in_git_only_rejects() {
     .await
     .unwrap();
 
-    assert_eq!(
-        output.status.code(),
-        Some(1),
+    assert!(
+        output.status.success(),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("cannot be created via API"),
-        "stderr: {stderr}"
     );
 }
 

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -952,6 +952,86 @@ async fn apply_custom_attribute_present_in_git_only_is_informational_no_op() {
     );
 }
 
+/// Regression: a registry-only custom_attribute (`PresentInGitOnly`) must
+/// not block apply of unrelated, actionable resources in the same run.
+/// Before this was reclassified as informational drift, the CA diff
+/// short-circuited `check_for_unsupported_ops` and prevented the
+/// content_block create POST from firing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_mixed_registry_only_ca_does_not_block_content_block_create() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "catalogs": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 0,
+            "templates": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/custom_attributes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "attributes": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/create"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_block_id": "new-id-1",
+            "message": "success"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/custom_attributes/blocklist"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(tmp.path(), "fresh", "Hello\n");
+    write_local_custom_attribute_registry(
+        tmp.path(),
+        "attributes:\n  - name: typo_attr\n    type: string\n",
+    );
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--confirm"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn apply_custom_attribute_metadata_only_is_informational_no_op() {
     let server = MockServer::start().await;


### PR DESCRIPTION
## Summary

- `braze-sync apply` aborted with a fatal `Custom Attribute '...' cannot be created via API` error whenever the local registry contained an attribute not yet present in Braze. This blocked *all* other resource changes (content blocks, catalogs, templates) in the same run, even though Braze has no creation endpoint for custom attributes (they materialize on first `/users/track` call).
- Align `apply` with the registry-only contract `diff` already follows: `PresentInGitOnly` joins `UnregisteredInGit` / `MetadataOnly` as non-actionable, informational drift. The plan-print still surfaces the `⚠ in Git registry but not in Braze (likely a typo)` warning, but the run no longer exits non-zero.
- Removed the now-unused `CustomAttributeCreateNotSupported` error variant and its exit-code mapping.

## Changes

- `src/diff/custom_attribute.rs`: `PresentInGitOnly` is no longer actionable.
- `src/cli/apply.rs`: dropped the `PresentInGitOnly` rejection branch from `check_for_unsupported_ops`.
- `src/error.rs` + `src/cli/mod.rs`: removed `CustomAttributeCreateNotSupported`.
- `src/diff/mod.rs`: updated `is_actionable` doc comment.
- `tests/cli_apply.rs`: renamed `apply_custom_attribute_present_in_git_only_rejects` → `..._is_informational_no_op`; asserts success and zero POSTs to `/custom_attributes/blocklist`.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 288 unit + integration tests pass (including the rewritten registry-only test)
- [x] `cargo clippy --all-targets` — clean
- [ ] Verify on a real workspace that `apply --confirm` lands content_block / catalog changes when the registry has entries missing from Braze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apply no longer rejects custom attributes that exist only in Git; these are treated as informational drift and will not block unrelated apply operations.

* **Behavior**
  * CLI exit behavior adjusted for certain custom-attribute error cases so apply succeeds where appropriate and proceeds with actionable changes.

* **Documentation**
  * Clarified drift vs. actionable semantics for custom attributes.

* **Tests**
  * Added regression and integration tests ensuring no write calls for registry-only attributes and that actionable creates still occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->