### PR TITLE
Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-05-01
+
+### Fixed
+
+- **`apply` no longer aborts on registry-only custom attributes.** A
+  custom attribute present in the local registry but missing from
+  Braze (`PresentInGitOnly`) is now treated as informational drift,
+  matching how `diff` already reports it. Previously `apply --confirm`
+  hard-errored with `Custom Attribute '...' cannot be created via
+  API`, which blocked all other resource changes (content blocks,
+  catalog schemas, email templates) in the same run. Braze has no
+  creation endpoint for custom attributes — they materialize on the
+  first `/users/track` call — so registry-only entries are an expected
+  state, especially right after `export` from a higher environment.
+  The plan-print still surfaces the `⚠ in Git registry but not in
+  Braze (likely a typo)` warning, but the run no longer exits
+  non-zero. (#24)
+
 ## [0.9.0] — 2026-04-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch release. Bumps `Cargo.toml` to `0.9.1` and adds the matching CHANGELOG entry.

### Fixed

- **`apply` no longer aborts on registry-only custom attributes** (#24). `PresentInGitOnly` joins `UnregisteredInGit` / `MetadataOnly` as informational drift — Braze has no create endpoint for custom attributes, so registry entries missing from Braze are an expected state, not a failure. Previously this blocked all other resource changes in the same run.

## Test plan

- [x] `cargo build` — clean (lockfile updated to 0.9.1)
- [x] CHANGELOG entry added under `[0.9.1] — 2026-05-01`
- [ ] Tag `v0.9.1` after merge so the release workflow publishes binaries / Homebrew tap