### PR TITLE
fix: hoist catalog id field to first position on create

### DIFF
--- a/src/braze/catalog.rs
+++ b/src/braze/catalog.rs
@@ -80,16 +80,23 @@ impl BrazeClient {
 
     /// `POST /catalogs` — create a new catalog with its initial schema.
     ///
+    /// Normalizes field order before sending: Braze rejects creates whose
+    /// first field is not `id` (HTTP 400, `id-not-first-column`), and
+    /// on-disk schemas exported from existing workspaces are typically
+    /// alphabetized — so a literal `id` field can land mid-array.
+    /// `Catalog::normalized()` hoists `id` to position 0.
+    ///
     /// Duplicate names surface as `400` with body
     /// `error_id: "catalog-name-already-exists"` per Braze docs and are
     /// propagated to the caller; a subsequent `apply` will see the
     /// existing catalog and no-op on the create.
     pub async fn create_catalog(&self, catalog: &Catalog) -> Result<(), BrazeApiError> {
+        let normalized = catalog.normalized();
         let body = CreateCatalogRequest {
             catalogs: vec![CreateCatalogEntry {
-                name: &catalog.name,
-                description: catalog.description.as_deref(),
-                fields: catalog
+                name: &normalized.name,
+                description: normalized.description.as_deref(),
+                fields: normalized
                     .fields
                     .iter()
                     .map(|f| WireField {
@@ -559,6 +566,56 @@ mod tests {
                 CatalogField {
                     name: "severity_level".into(),
                     field_type: CatalogFieldType::Number,
+                },
+            ],
+        };
+        client.create_catalog(&cat).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_catalog_hoists_id_field_to_first_position() {
+        // Braze returns HTTP 400 `id-not-first-column` when fields[0]
+        // is not `id`. Repos exported by braze-sync sort fields
+        // alphabetically on disk, so a literal `id` lands mid-array;
+        // create_catalog must normalize before sending.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/catalogs"))
+            .and(body_json(json!({
+                "catalogs": [{
+                    "name": "alpha",
+                    "fields": [
+                        {"name": "id", "type": "string"},
+                        {"name": "URL", "type": "string"},
+                        {"name": "author", "type": "string"},
+                        {"name": "title", "type": "string"}
+                    ]
+                }]
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({"message": "success"})))
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server);
+        let cat = Catalog {
+            name: "alpha".into(),
+            description: None,
+            fields: vec![
+                CatalogField {
+                    name: "URL".into(),
+                    field_type: CatalogFieldType::String,
+                },
+                CatalogField {
+                    name: "author".into(),
+                    field_type: CatalogFieldType::String,
+                },
+                CatalogField {
+                    name: "id".into(),
+                    field_type: CatalogFieldType::String,
+                },
+                CatalogField {
+                    name: "title".into(),
+                    field_type: CatalogFieldType::String,
                 },
             ],
         };

--- a/src/fs/catalog_io.rs
+++ b/src/fs/catalog_io.rs
@@ -172,6 +172,29 @@ mod tests {
     }
 
     #[test]
+    fn save_hoists_id_field_to_top_then_sorts_rest() {
+        // Mirrors the wire requirement: Braze rejects POST /catalogs
+        // bodies whose first field isn't `id`. Keeping the on-disk
+        // representation aligned with the wire shape avoids surprise
+        // diffs after an `apply` writes back a freshly-created catalog.
+        let dir = tempfile::tempdir().unwrap();
+        let c = Catalog {
+            name: "x".into(),
+            description: None,
+            fields: vec![
+                field("URL", CatalogFieldType::String),
+                field("author", CatalogFieldType::String),
+                field("id", CatalogFieldType::String),
+                field("title", CatalogFieldType::String),
+            ],
+        };
+        save_schema(dir.path(), &c).unwrap();
+        let loaded = load_all_schemas(dir.path()).unwrap();
+        let names: Vec<_> = loaded[0].fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["id", "URL", "author", "title"]);
+    }
+
+    #[test]
     fn save_sorts_fields_alphabetically() {
         let dir = tempfile::tempdir().unwrap();
         let c = Catalog {

--- a/src/resource/catalog.rs
+++ b/src/resource/catalog.rs
@@ -5,6 +5,11 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Name of the privileged primary-key field on every Braze catalog.
+/// `POST /catalogs` rejects bodies whose `fields[0].name` is not this
+/// (error id `id-not-first-column`).
+pub const ID_FIELD_NAME: &str = "id";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Catalog {
     pub name: String,
@@ -65,13 +70,10 @@ impl Catalog {
     pub fn normalized(&self) -> Self {
         let mut sorted = self.clone();
         sorted.fields.sort_by(|a, b| {
-            let a_is_id = a.name == "id";
-            let b_is_id = b.name == "id";
-            match (a_is_id, b_is_id) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => a.name.cmp(&b.name),
-            }
+            let a_is_id = a.name == ID_FIELD_NAME;
+            let b_is_id = b.name == ID_FIELD_NAME;
+            // bool false < true, so reverse to put id first.
+            b_is_id.cmp(&a_is_id).then_with(|| a.name.cmp(&b.name))
         });
         sorted
     }

--- a/src/resource/catalog.rs
+++ b/src/resource/catalog.rs
@@ -57,11 +57,22 @@ impl CatalogFieldType {
 }
 
 impl Catalog {
-    /// Return a copy with `fields` sorted by name. Used to keep on-disk
-    /// output and diff input deterministic regardless of API ordering.
+    /// Return a copy with `fields` ordered for serialization: the `id`
+    /// field (if present) first, then the rest sorted alphabetically by
+    /// name. Used both for deterministic on-disk output and for the
+    /// `POST /catalogs` request body — Braze rejects creates whose
+    /// `fields[0]` is not the `id` column with `id-not-first-column`.
     pub fn normalized(&self) -> Self {
         let mut sorted = self.clone();
-        sorted.fields.sort_by(|a, b| a.name.cmp(&b.name));
+        sorted.fields.sort_by(|a, b| {
+            let a_is_id = a.name == "id";
+            let b_is_id = b.name == "id";
+            match (a_is_id, b_is_id) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => a.name.cmp(&b.name),
+            }
+        });
         sorted
     }
 }
@@ -142,6 +153,59 @@ fields:
 
     #[test]
     fn normalized_sorts_fields_by_name() {
+        let cat = Catalog {
+            name: "x".into(),
+            description: None,
+            fields: vec![
+                CatalogField {
+                    name: "z".into(),
+                    field_type: CatalogFieldType::String,
+                },
+                CatalogField {
+                    name: "a".into(),
+                    field_type: CatalogFieldType::String,
+                },
+            ],
+        };
+        let n = cat.normalized();
+        assert_eq!(n.fields[0].name, "a");
+        assert_eq!(n.fields[1].name, "z");
+    }
+
+    #[test]
+    fn normalized_hoists_id_field_to_front() {
+        // Braze's POST /catalogs rejects bodies whose first field is not
+        // `id` of type string with error id `id-not-first-column`. The
+        // hoist applies regardless of the id field's alphabetic position.
+        let cat = Catalog {
+            name: "x".into(),
+            description: None,
+            fields: vec![
+                CatalogField {
+                    name: "URL".into(),
+                    field_type: CatalogFieldType::String,
+                },
+                CatalogField {
+                    name: "author".into(),
+                    field_type: CatalogFieldType::String,
+                },
+                CatalogField {
+                    name: "id".into(),
+                    field_type: CatalogFieldType::String,
+                },
+                CatalogField {
+                    name: "title".into(),
+                    field_type: CatalogFieldType::String,
+                },
+            ],
+        };
+        let n = cat.normalized();
+        let names: Vec<_> = n.fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["id", "URL", "author", "title"]);
+    }
+
+    #[test]
+    fn normalized_without_id_field_is_pure_alphabetical() {
         let cat = Catalog {
             name: "x".into(),
             description: None,


### PR DESCRIPTION
## Summary

- `POST /catalogs` rejects requests whose `fields[0]` is not the `id` column with HTTP 400 `id-not-first-column`. Exported `schema.yaml` files sort fields alphabetically, so any catalog whose id was not first alphabetically failed to create on a clean workspace.
- `Catalog::normalized()` now hoists `id` to position 0 and alphabetizes the rest. `create_catalog` normalizes before building the wire payload; on-disk `schema.yaml` inherits the same ordering so export/apply stays round-trip safe.
- Skipped a validate-time warning for missing/non-string `id` to avoid failing repos with managed-out-of-band catalogs — can be added as a follow-up behind `--strict`.

## Test plan

- [x] `cargo test` (371 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] New regression: `create_catalog_hoists_id_field_to_first_position` asserts `URL, author, id, title` is sent as `id, URL, author, title`
- [x] New regression: `save_hoists_id_field_to_top_then_sorts_rest` asserts the same for on-disk output
- [ ] Replay a freshly-exported workspace onto a clean target environment and confirm catalog creates succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured catalogs are persisted and transmitted with a standardized field order, with the identifier field consistently appearing first followed by alphabetically sorted fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->