### PR TITLE
Release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ## [Unreleased]
 
+## [0.9.2] — 2026-05-03
+
+### Fixed
+
+- **Catalog creation no longer fails with `id-not-first-column` on
+  freshly-exported workspaces.** `POST /catalogs` rejects bodies whose
+  `fields[0].name` is not `id`, but exported `schema.yaml` files
+  alphabetize fields, so any catalog whose id was not first
+  alphabetically failed to create on a clean target environment.
+  `Catalog::normalized()` now hoists the `id` field to position 0 and
+  alphabetizes the rest; both the wire payload and the on-disk
+  `schema.yaml` share this ordering, so export ↔ apply stays
+  round-trip stable. (#26)
+
 ## [0.9.1] — 2026-05-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps `braze-sync` to **0.9.2**.
- Ships the catalog `id-not-first-column` fix from #26: `Catalog::normalized()` now hoists the `id` field to position 0 before both wire serialization (`POST /catalogs`) and on-disk `schema.yaml` writes, so freshly-exported workspaces apply cleanly to a new environment.

## Test plan

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Tag `v0.9.2` and publish to crates.io after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)