### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-05-04
+
 ### Added
 
 - **`tag` resource kind, GitOps-only.** Workspace tags are now tracked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps `braze-sync` to **0.10.0**.
- Ships the new `tag` resource kind from #28: workspace tags are tracked as a GitOps-only registry at `tags/registry.yaml`, with `export`/`validate`/`diff` integrations and an `apply` pre-flight that fails fast on unregistered tag references — closing the cascading "Tags could not be found" 400 that previously halted apply on a fresh target environment.
- Tag tracking is opt-in: existing projects upgrade without surprise validation failures (declare `resources.tag` and create the registry to enable).

## Test plan

- [x] \`cargo test\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [ ] Tag \`v0.10.0\` and publish to crates.io after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new GitOps-only `tag` resource kind for managing workspace tags. Tags are maintained in a central registry and fully integrated with core operations including export, validate, diff, and apply. Pre-flight validation prevents applying changes when referenced tags are missing. Disabled by default with automated setup support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->