### PR TITLE
feat: topo-sort content_block apply order by inter-block references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
-## [Unreleased]
+## [0.11.0] — 2026-05-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ## [Unreleased]
 
+### Added
+
+- **Topological apply order for content blocks.** When a local content
+  block body references another via the Liquid include syntax
+  `{{content_blocks.${other} | id: '...'}}`, `apply` now creates the
+  target block before its referrer. Pre-v0.11 behavior sorted by name
+  alphabetically and broke on a fresh workspace whenever a referrer
+  sorted before its target — Braze validates the body at create time
+  and rejects forward references with an opaque HTTP 500, halting the
+  whole apply pass mid-pipeline. The new ordering pass parses
+  references out of every actionable diff body, builds a
+  `referrer → target` graph limited to blocks in the actionable set
+  (references to already-present blocks are treated as no-op edges, so
+  the referrer becomes a leaf), topologically sorts so targets precede
+  referrers, and aborts before any HTTP write if it detects a cycle —
+  surfacing the cycle path with named blocks so the operator can fix
+  the loop instead of decoding a 500. The dry-run plan is emitted in
+  the chosen order, so `apply` (without `--confirm`) previews the
+  exact write sequence.
+- **`apply_order` config field on `ResourceConfig`.** Default
+  `dependency` (the new behavior). Set
+  `resources.content_block.apply_order: alphabetical` to opt back into
+  the v0.10 ordering — useful for repos that have built tooling around
+  the old apply sequence and don't yet have inter-block references.
+  The field is consulted only by content_block apply; setting it on
+  other resource kinds is accepted but inert.
+
 ## [0.10.0] — 2026-05-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ synchronize it to Braze with the same workflow you'd use for
 detection in CI, and an `--allow-destructive` gate that has to be
 crossed explicitly before anything is dropped.
 
-## Status: v0.8.0 (4 resources + init)
+## Status: v0.10.0 (5 resources + init)
 
-braze-sync manages Braze **configuration** as code. The four managed
+braze-sync manages Braze **configuration** as code. The five managed
 resource kinds are:
 
 - **Catalog Schema** (field definitions, types, constraints)
 - **Content Block** (reusable Liquid fragments)
 - **Email Template** (HTML/Liquid templates)
 - **Custom Attribute** registry (definition-level; deprecation toggle)
+- **Tag** registry (workspace tags referenced by other resources;
+  derived from local frontmatter because Braze exposes no tag API)
 
 **Out of scope**: runtime data like catalog **items**, user attribute
 values, events, and campaigns. Those have their own systems of record;
@@ -172,19 +174,6 @@ These will be lifted across the v0.x → v1.0 milestones:
   The diff layer also ignores the field to prevent an "infinite
   drift" loop (Braze has no DELETE, so a persistently-Modified
   Content Block is a trap).
-- **No pagination yet.** v0.2.0 sends a single page request to
-  `/catalogs` and `/content_blocks/list` (limit 100). For
-  `/content_blocks/list` this is a **hard error** if Braze reports more
-  results than fit on one page, or if a full page comes back with no
-  total to verify against — workspaces with >100 content blocks cannot
-  use v0.2.0 yet. Without the guard, `apply` could create duplicates of
-  blocks living on page 2+ (their names would diff as `Added`). This
-  limit is symmetric for `--name <foo>`: content blocks have no
-  get-by-name endpoint, so `diff --name`, `apply --name`, and
-  `export --name` still list-then-filter and hit the same page cap.
-  For `/catalogs` v0.2.0 still only warns; the same guard will be
-  applied symmetrically in a follow-up. Pagination support lands in
-  Phase C scale validation.
 - **`--archive-orphans` is a two-step read-modify-write.** The rename
   fetches `/content_blocks/info` to preserve the body, then posts
   `/content_blocks/update` with the archived name. If another operator
@@ -193,9 +182,9 @@ These will be lifted across the v0.x → v1.0 milestones:
   single-operator GitOps workflow v0.2.0 targets; a compare-and-swap
   header would lift it, but Braze's content_blocks API does not
   currently document one.
-- **`--no-color` only affects tracing output.** v0.2.0 does not emit
-  ANSI colors in table or diff output, so the flag currently only
-  suppresses ANSI escapes from the tracing subscriber on stderr.
+- **`--no-color` only affects tracing output.** Table and diff output
+  do not currently emit ANSI colors, so the flag only suppresses
+  ANSI escapes from the tracing subscriber on stderr.
 
 ## Exit codes
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ them and `apply` does nothing about them by default. Pass
 `--archive-orphans` to rename them remotely with an
 `[ARCHIVED-YYYY-MM-DD]` prefix; the data is never silently dropped.
 
+When a block body references another block via the Liquid include
+syntax `{{content_blocks.${other} | id: '...'}}`, `apply` topologically
+sorts so the referenced block is created before the referrer. Without
+this, Braze rejects forward references at create time with an opaque
+HTTP 500. Cycles abort the apply with a named-blocks error before any
+write fires. Set `resources.content_block.apply_order: alphabetical` to
+restore pre-v0.11 ordering.
+
 ## Install
 
 **Pre-built binaries** (recommended):

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -157,15 +157,16 @@ pub async fn run(
         resolved.resources.content_block.apply_order,
         ApplyOrder::Dependency
     ) {
-        summary.diffs =
-            reorder_content_block_diffs_by_dependency(std::mem::take(&mut summary.diffs))
-                .map_err(|cycle| {
-                    anyhow!(
-                        "content_block dependency cycle detected\n       \
+        summary.diffs = reorder_content_block_diffs_by_dependency(std::mem::take(
+            &mut summary.diffs,
+        ))
+        .map_err(|cycle| {
+            anyhow!(
+                "content_block dependency cycle detected\n       \
                          {cycle}\n       \
                          resolve by removing one of these references and try again"
-                    )
-                })?;
+            )
+        })?;
     }
 
     let mode_label = if args.confirm {

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -10,9 +10,10 @@
 //! cross-write atomicity.
 
 use crate::braze::BrazeClient;
-use crate::config::ResolvedConfig;
+use crate::config::{ApplyOrder, ResolvedConfig};
 use crate::diff::catalog::CatalogSchemaDiff;
 use crate::diff::content_block::{ContentBlockDiff, ContentBlockIdIndex};
+use crate::diff::content_block_order::reorder_content_block_diffs_by_dependency;
 use crate::diff::custom_attribute::CustomAttributeOp;
 use crate::diff::email_template::{EmailTemplateDiff, EmailTemplateIdIndex};
 use crate::diff::orphan;
@@ -147,6 +148,26 @@ pub async fn run(
     // halts mid-pipeline. Runs even when --kind is restricted to a non-tag
     // kind so tag drift cannot sneak past a per-kind apply.
     enforce_tag_preflight(config_dir, &resolved, &summary)?;
+
+    // Content_block apply-order pass. Targets must precede referrers
+    // because Braze validates `{{content_blocks.${other}}}` includes at
+    // create time and rejects forward references with an opaque HTTP
+    // 500. Done before plan-print so the dry-run preview reflects the
+    // exact order writes will fire.
+    if matches!(
+        resolved.resources.content_block.apply_order,
+        ApplyOrder::Dependency
+    ) {
+        let reordered = reorder_content_block_diffs_by_dependency(std::mem::take(&mut summary.diffs))
+            .map_err(|cycle| {
+                anyhow!(
+                    "content_block dependency cycle detected\n       \
+                     {cycle}\n       \
+                     resolve by removing one of these references and try again"
+                )
+            })?;
+        summary.diffs = reordered;
+    }
 
     let mode_label = if args.confirm {
         "Plan:"

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -157,14 +157,16 @@ pub async fn run(
         resolved.resources.content_block.apply_order,
         ApplyOrder::Dependency
     ) {
-        let reordered = reorder_content_block_diffs_by_dependency(std::mem::take(&mut summary.diffs))
-            .map_err(|cycle| {
-                anyhow!(
-                    "content_block dependency cycle detected\n       \
+        let reordered = reorder_content_block_diffs_by_dependency(std::mem::take(
+            &mut summary.diffs,
+        ))
+        .map_err(|cycle| {
+            anyhow!(
+                "content_block dependency cycle detected\n       \
                      {cycle}\n       \
                      resolve by removing one of these references and try again"
-                )
-            })?;
+            )
+        })?;
         summary.diffs = reordered;
     }
 

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -149,11 +149,10 @@ pub async fn run(
     // kind so tag drift cannot sneak past a per-kind apply.
     enforce_tag_preflight(config_dir, &resolved, &summary)?;
 
-    // Content_block apply-order pass. Targets must precede referrers
-    // because Braze validates `{{content_blocks.${other}}}` includes at
-    // create time and rejects forward references with an opaque HTTP
-    // 500. Done before plan-print so the dry-run preview reflects the
-    // exact order writes will fire.
+    // Targets must precede referrers because Braze validates
+    // `{{content_blocks.${other}}}` includes at create time and rejects
+    // forward references with an opaque HTTP 500. Done before
+    // plan-print so the dry-run preview reflects actual write order.
     if matches!(
         resolved.resources.content_block.apply_order,
         ApplyOrder::Dependency

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -157,17 +157,15 @@ pub async fn run(
         resolved.resources.content_block.apply_order,
         ApplyOrder::Dependency
     ) {
-        let reordered = reorder_content_block_diffs_by_dependency(std::mem::take(
-            &mut summary.diffs,
-        ))
-        .map_err(|cycle| {
-            anyhow!(
-                "content_block dependency cycle detected\n       \
-                     {cycle}\n       \
-                     resolve by removing one of these references and try again"
-            )
-        })?;
-        summary.diffs = reordered;
+        summary.diffs =
+            reorder_content_block_diffs_by_dependency(std::mem::take(&mut summary.diffs))
+                .map_err(|cycle| {
+                    anyhow!(
+                        "content_block dependency cycle detected\n       \
+                         {cycle}\n       \
+                         resolve by removing one of these references and try again"
+                    )
+                })?;
     }
 
     let mode_label = if args.confirm {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,7 +17,8 @@
 pub mod schema;
 
 pub use schema::{
-    ConfigFile, Defaults, EnvironmentConfig, NamingConfig, ResourceConfig, ResourcesConfig,
+    ApplyOrder, ConfigFile, Defaults, EnvironmentConfig, NamingConfig, ResourceConfig,
+    ResourcesConfig,
 };
 
 use crate::error::{Error, Result};

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -108,11 +108,11 @@ pub struct ResourceConfig {
     pub apply_order: ApplyOrder,
 }
 
-/// Apply-time ordering policy. Default `Dependency` — strictly better
-/// than alphabetical when a content_block references another block,
-/// equivalent when none does. `Alphabetical` preserves pre-v0.11.0
-/// behavior for callers who built tooling around the exact apply
-/// sequence.
+/// Apply-time ordering policy. `Dependency` topo-sorts content_blocks
+/// so a referrer is never created before its target (see
+/// `diff::content_block_order`). `Alphabetical` skips that pass and
+/// applies in name order — kept for callers who built tooling around
+/// the exact apply sequence.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ApplyOrder {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -97,6 +97,28 @@ pub struct ResourceConfig {
     /// don't produce noise. See `docs/configuration.md §exclude_patterns`.
     #[serde(default)]
     pub exclude_patterns: Vec<String>,
+    /// Apply-time ordering policy. Currently consulted only by
+    /// `content_block` apply, which uses `Dependency` to topologically
+    /// sort `{{content_blocks.${other}}}` references so a referrer is
+    /// never created before its target. The field is shared on
+    /// `ResourceConfig` (rather than scoped to a content_block-only
+    /// type) to keep `ResourcesConfig::for_kind` type-stable; setting
+    /// it on other resource kinds is accepted but inert.
+    #[serde(default)]
+    pub apply_order: ApplyOrder,
+}
+
+/// Apply-time ordering policy. Default `Dependency` — strictly better
+/// than alphabetical when a content_block references another block,
+/// equivalent when none does. `Alphabetical` preserves pre-v0.11.0
+/// behavior for callers who built tooling around the exact apply
+/// sequence.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApplyOrder {
+    #[default]
+    Dependency,
+    Alphabetical,
 }
 
 fn default_enabled() -> bool {
@@ -108,6 +130,7 @@ fn default_catalog_schema() -> ResourceConfig {
         enabled: true,
         path: PathBuf::from("catalogs/"),
         exclude_patterns: Vec::new(),
+        apply_order: ApplyOrder::Dependency,
     }
 }
 
@@ -116,6 +139,7 @@ fn default_content_block() -> ResourceConfig {
         enabled: true,
         path: PathBuf::from("content_blocks/"),
         exclude_patterns: Vec::new(),
+        apply_order: ApplyOrder::Dependency,
     }
 }
 
@@ -124,6 +148,7 @@ fn default_email_template() -> ResourceConfig {
         enabled: true,
         path: PathBuf::from("email_templates/"),
         exclude_patterns: Vec::new(),
+        apply_order: ApplyOrder::Dependency,
     }
 }
 
@@ -132,6 +157,7 @@ fn default_custom_attribute() -> ResourceConfig {
         enabled: true,
         path: PathBuf::from("custom_attributes/registry.yaml"),
         exclude_patterns: Vec::new(),
+        apply_order: ApplyOrder::Dependency,
     }
 }
 
@@ -142,6 +168,7 @@ fn default_tag() -> ResourceConfig {
         enabled: false,
         path: PathBuf::from("tags/registry.yaml"),
         exclude_patterns: Vec::new(),
+        apply_order: ApplyOrder::Dependency,
     }
 }
 

--- a/src/diff/content_block_order.rs
+++ b/src/diff/content_block_order.rs
@@ -1,0 +1,420 @@
+//! Apply-order computation for content blocks.
+//!
+//! ### Why this module exists
+//!
+//! Braze's `POST /content_blocks/create` validates the body at create time
+//! and rejects the request when a `{{content_blocks.${other_block}}}`
+//! include refers to a block that does not yet exist in the workspace.
+//! Worse, the failure surfaces as **HTTP 500** with an opaque body, not
+//! as a 4xx validation error — so a single forward reference halts the
+//! whole apply pass and leaves earlier writes committed.
+//!
+//! Default alphabetical apply order is unaware of these cross-block
+//! dependencies and any `A → B` reference where `A < B` alphabetically
+//! breaks on a fresh workspace. This module parses references out of
+//! the local Liquid bodies, builds a `referrer → target` graph over the
+//! actionable diffs, and re-emits them in dependency order (targets
+//! before referrers). Cycles are reported with named blocks before any
+//! HTTP write fires; references that point outside the actionable set
+//! (already-present blocks, or out-of-scope names) are treated as
+//! no-ops — the referrer becomes a leaf for sort purposes.
+//!
+//! Pure module: no I/O, no Braze calls.
+
+use crate::diff::{DiffOp, ResourceDiff};
+use crate::resource::ContentBlock;
+use regex_lite::Regex;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
+
+/// Match `{{content_blocks.${NAME}}}` with whitespace tolerance and an
+/// optional `| id: '...'` filter. The id alias is not load-bearing for
+/// the dependency graph — only `NAME` matters. Inside `${...}` we accept
+/// any run of non-space, non-`}`, non-`|` characters so unusual but
+/// valid Braze names (digits, hyphens) round-trip.
+fn ref_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}(?:\s*\|[^}]*)?\s*\}\}",
+        )
+        .expect("static regex")
+    })
+}
+
+/// Names of content blocks referenced by `body` via the Liquid include
+/// syntax. Order is source-order; duplicates are preserved (callers
+/// dedupe as needed). Self-references are not filtered here — the
+/// caller has the surrounding context to decide.
+pub fn extract_block_references(body: &str) -> Vec<String> {
+    ref_regex()
+        .captures_iter(body)
+        .map(|cap| cap[1].to_string())
+        .collect()
+}
+
+/// A dependency cycle. The path is reported in the order encountered
+/// during DFS, with the closing node repeated so callers can render
+/// `A → B → C → A`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cycle {
+    pub path: Vec<String>,
+}
+
+impl std::fmt::Display for Cycle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.path.join(" → "))
+    }
+}
+
+/// Topologically sort `nodes` by `edges` (referrer → targets). Targets
+/// that are not in `nodes` are treated as no-op edges — the referrer
+/// just becomes a leaf for sort purposes. Output is dependency-order:
+/// targets before referrers. Stable across runs: ties broken by input
+/// order of `nodes`, so the dry-run plan for the same repo state is
+/// reproducible.
+pub fn topo_sort(nodes: &[String], edges: &BTreeMap<String, Vec<String>>) -> Result<Vec<String>, Cycle> {
+    let in_set: BTreeSet<&str> = nodes.iter().map(String::as_str).collect();
+    let mut visited: BTreeSet<String> = BTreeSet::new();
+    let mut on_stack: Vec<String> = Vec::new();
+    let mut on_stack_set: BTreeSet<String> = BTreeSet::new();
+    let mut out: Vec<String> = Vec::with_capacity(nodes.len());
+
+    for n in nodes {
+        if !visited.contains(n) {
+            visit(
+                n,
+                edges,
+                &in_set,
+                &mut visited,
+                &mut on_stack,
+                &mut on_stack_set,
+                &mut out,
+            )?;
+        }
+    }
+    Ok(out)
+}
+
+fn visit(
+    node: &str,
+    edges: &BTreeMap<String, Vec<String>>,
+    in_set: &BTreeSet<&str>,
+    visited: &mut BTreeSet<String>,
+    on_stack: &mut Vec<String>,
+    on_stack_set: &mut BTreeSet<String>,
+    out: &mut Vec<String>,
+) -> Result<(), Cycle> {
+    if on_stack_set.contains(node) {
+        // Cycle: cut the prefix before the first occurrence and append
+        // the closing node so the message reads `A → B → C → A`.
+        let start = on_stack.iter().position(|n| n == node).unwrap_or(0);
+        let mut path: Vec<String> = on_stack[start..].to_vec();
+        path.push(node.to_string());
+        return Err(Cycle { path });
+    }
+    if visited.contains(node) {
+        return Ok(());
+    }
+    on_stack.push(node.to_string());
+    on_stack_set.insert(node.to_string());
+
+    if let Some(targets) = edges.get(node) {
+        // Iterate targets in stable order so cycle paths are deterministic.
+        let mut sorted: Vec<&String> = targets.iter().filter(|t| in_set.contains(t.as_str())).collect();
+        sorted.sort();
+        sorted.dedup();
+        for t in sorted {
+            visit(t, edges, in_set, visited, on_stack, on_stack_set, out)?;
+        }
+    }
+
+    on_stack.pop();
+    on_stack_set.remove(node);
+    visited.insert(node.to_string());
+    out.push(node.to_string());
+    Ok(())
+}
+
+/// Reorder content_block diffs so that, for every actionable
+/// (`Added`/`Modified`) diff with a `{{content_blocks.${target}}}`
+/// reference whose `target` is also in the actionable set, `target`
+/// appears earlier in the returned list than the referrer.
+///
+/// Non-actionable diffs (`Unchanged`, orphans) keep their relative
+/// position among themselves but are emitted **after** the actionable
+/// block — they don't fire writes, so apply order doesn't affect them
+/// and putting them after the actionable group keeps the dry-run plan
+/// readable: changes first, no-ops last.
+pub fn reorder_content_block_diffs_by_dependency(
+    diffs: Vec<ResourceDiff>,
+) -> Result<Vec<ResourceDiff>, Cycle> {
+    let mut content_blocks: Vec<ResourceDiff> = Vec::new();
+    let mut others: Vec<ResourceDiff> = Vec::new();
+    for d in diffs {
+        match d {
+            ResourceDiff::ContentBlock(_) => content_blocks.push(d),
+            _ => others.push(d),
+        }
+    }
+    if content_blocks.is_empty() {
+        return Ok(others);
+    }
+
+    // Split actionable (carry a body) vs non-actionable (no body to
+    // parse, no write to fire). Only actionable blocks participate in
+    // topo-sort.
+    let mut actionable_names: Vec<String> = Vec::new();
+    let mut actionable_by_name: BTreeMap<String, ResourceDiff> = BTreeMap::new();
+    let mut inactionable: Vec<ResourceDiff> = Vec::new();
+
+    for d in content_blocks {
+        let actionable_body: Option<(&str, &ContentBlock)> = match &d {
+            ResourceDiff::ContentBlock(cb) if !cb.orphan => match &cb.op {
+                DiffOp::Added(body) => Some((cb.name.as_str(), body)),
+                DiffOp::Modified { to, .. } => Some((cb.name.as_str(), to)),
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some((name, _body)) = actionable_body {
+            actionable_names.push(name.to_string());
+            actionable_by_name.insert(name.to_string(), d);
+        } else {
+            inactionable.push(d);
+        }
+    }
+
+    // Build edges: referrer → [targets] limited to actionable names.
+    // Self-references (a block including itself) are dropped — they
+    // are a Braze-side problem, not an apply-order problem, and we
+    // don't want them to surface here as cycles.
+    let mut edges: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for name in &actionable_names {
+        let body = match actionable_by_name.get(name).expect("just inserted") {
+            ResourceDiff::ContentBlock(cb) => match &cb.op {
+                DiffOp::Added(b) => &b.content,
+                DiffOp::Modified { to, .. } => &to.content,
+                _ => unreachable!("split above"),
+            },
+            _ => unreachable!("split above"),
+        };
+        let refs: Vec<String> = extract_block_references(body)
+            .into_iter()
+            .filter(|t| t != name)
+            .collect();
+        if !refs.is_empty() {
+            edges.insert(name.clone(), refs);
+        }
+    }
+
+    let sorted_names = topo_sort(&actionable_names, &edges)?;
+
+    let mut out = Vec::with_capacity(others.len() + actionable_names.len() + inactionable.len());
+    // Non-content_block diffs keep their original relative position
+    // before the content_block group, mirroring the per-kind iteration
+    // order of `apply::run`.
+    out.extend(others);
+    for n in &sorted_names {
+        out.push(
+            actionable_by_name
+                .remove(n)
+                .expect("topo_sort returns names from actionable set"),
+        );
+    }
+    out.extend(inactionable);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::content_block::ContentBlockDiff;
+    use crate::resource::ContentBlockState;
+
+    fn cb(name: &str, body: &str) -> ContentBlock {
+        ContentBlock {
+            name: name.into(),
+            description: None,
+            content: body.into(),
+            tags: vec![],
+            state: ContentBlockState::Active,
+        }
+    }
+
+    fn added(name: &str, body: &str) -> ResourceDiff {
+        ResourceDiff::ContentBlock(ContentBlockDiff {
+            name: name.into(),
+            op: DiffOp::Added(cb(name, body)),
+            text_diff: None,
+            orphan: false,
+        })
+    }
+
+    fn unchanged(name: &str) -> ResourceDiff {
+        ResourceDiff::ContentBlock(ContentBlockDiff {
+            name: name.into(),
+            op: DiffOp::Unchanged,
+            text_diff: None,
+            orphan: false,
+        })
+    }
+
+    fn order(diffs: &[ResourceDiff]) -> Vec<&str> {
+        diffs
+            .iter()
+            .filter_map(|d| match d {
+                ResourceDiff::ContentBlock(cb) => Some(cb.name.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn extracts_a_single_reference() {
+        let body = "Hello {{content_blocks.${other_block} | id: 'cb1'}}!";
+        assert_eq!(extract_block_references(body), vec!["other_block"]);
+    }
+
+    #[test]
+    fn extracts_references_with_whitespace_variations() {
+        let body = "
+            {{content_blocks.${a}}}
+            {{ content_blocks.${ b } }}
+            {{content_blocks.${c} | id: 'x' }}
+            {{ content_blocks.${d}  | id: 'y'}}
+        ";
+        assert_eq!(extract_block_references(body), vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn extracts_multiple_references_in_one_body() {
+        let body = "head {{content_blocks.${one}}} mid {{content_blocks.${two}}} tail";
+        assert_eq!(extract_block_references(body), vec!["one", "two"]);
+    }
+
+    #[test]
+    fn ignores_unrelated_liquid() {
+        let body = "{{ user.${first_name} }} {{ campaign.${id} }}";
+        assert!(extract_block_references(body).is_empty());
+    }
+
+    #[test]
+    fn topo_sort_emits_targets_before_referrers() {
+        // A → B (A references B). B must come first.
+        let nodes = vec!["a".to_string(), "b".to_string()];
+        let mut edges: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        edges.insert("a".into(), vec!["b".into()]);
+        let out = topo_sort(&nodes, &edges).unwrap();
+        assert_eq!(out, vec!["b".to_string(), "a".to_string()]);
+    }
+
+    #[test]
+    fn topo_sort_drops_edges_to_unknown_targets() {
+        // A → B, but B isn't in the input set. A is treated as a leaf.
+        let nodes = vec!["a".to_string()];
+        let mut edges: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        edges.insert("a".into(), vec!["b".into()]);
+        let out = topo_sort(&nodes, &edges).unwrap();
+        assert_eq!(out, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn topo_sort_detects_cycle_and_names_it() {
+        let nodes = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let mut edges: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        edges.insert("a".into(), vec!["b".into()]);
+        edges.insert("b".into(), vec!["c".into()]);
+        edges.insert("c".into(), vec!["a".into()]);
+        let err = topo_sort(&nodes, &edges).unwrap_err();
+        // Cycle path closes on itself.
+        assert_eq!(err.path.first(), err.path.last());
+        let s: BTreeSet<&str> = err.path.iter().map(String::as_str).collect();
+        assert!(s.contains("a") && s.contains("b") && s.contains("c"));
+    }
+
+    #[test]
+    fn reorder_puts_dependency_target_before_referrer() {
+        // Spec example: A < B alphabetically, A references B → after
+        // reorder, B is emitted before A.
+        let diffs = vec![
+            added("a_referrer", "see {{content_blocks.${b_target}}}"),
+            added("b_target", "leaf"),
+        ];
+        let out = reorder_content_block_diffs_by_dependency(diffs).unwrap();
+        assert_eq!(order(&out), vec!["b_target", "a_referrer"]);
+    }
+
+    #[test]
+    fn reorder_keeps_independent_blocks_in_input_order() {
+        let diffs = vec![
+            added("alpha", "no refs"),
+            added("bravo", "no refs"),
+            added("charlie", "no refs"),
+        ];
+        let out = reorder_content_block_diffs_by_dependency(diffs).unwrap();
+        assert_eq!(order(&out), vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[test]
+    fn reorder_treats_reference_to_unchanged_block_as_leaf() {
+        // The target is already in Braze (Unchanged here stands in for
+        // "remote-known"), so the referrer can be emitted in its
+        // natural slot — no error, no reorder needed.
+        let diffs = vec![
+            added("referrer", "see {{content_blocks.${already_there}}}"),
+            unchanged("already_there"),
+        ];
+        let out = reorder_content_block_diffs_by_dependency(diffs).unwrap();
+        let names = order(&out);
+        // Actionable group first, non-actionable after.
+        assert_eq!(names, vec!["referrer", "already_there"]);
+    }
+
+    #[test]
+    fn reorder_reports_cycle_with_block_names() {
+        let diffs = vec![
+            added("a", "{{content_blocks.${b}}}"),
+            added("b", "{{content_blocks.${a}}}"),
+        ];
+        let err = reorder_content_block_diffs_by_dependency(diffs).unwrap_err();
+        let s: BTreeSet<&str> = err.path.iter().map(String::as_str).collect();
+        assert!(s.contains("a") && s.contains("b"));
+    }
+
+    #[test]
+    fn reorder_drops_self_reference_silently() {
+        // A self-reference is a Braze-side problem (the body refers to
+        // itself), not an apply-order problem. Don't surface it as a
+        // false-positive cycle here.
+        let diffs = vec![added("loner", "{{content_blocks.${loner}}}")];
+        let out = reorder_content_block_diffs_by_dependency(diffs).unwrap();
+        assert_eq!(order(&out), vec!["loner"]);
+    }
+
+    #[test]
+    fn reorder_handles_diamond_correctly() {
+        //   a
+        //  / \
+        // b   c
+        //  \ /
+        //   d
+        // d must come first; b and c before a.
+        let diffs = vec![
+            added(
+                "a",
+                "{{content_blocks.${b}}} and {{content_blocks.${c}}}",
+            ),
+            added("b", "{{content_blocks.${d}}}"),
+            added("c", "{{content_blocks.${d}}}"),
+            added("d", "leaf"),
+        ];
+        let out = reorder_content_block_diffs_by_dependency(diffs).unwrap();
+        let names = order(&out);
+        let pos = |n: &str| names.iter().position(|x| *x == n).unwrap();
+        assert!(pos("d") < pos("b"));
+        assert!(pos("d") < pos("c"));
+        assert!(pos("b") < pos("a"));
+        assert!(pos("c") < pos("a"));
+    }
+}

--- a/src/diff/content_block_order.rs
+++ b/src/diff/content_block_order.rs
@@ -34,10 +34,8 @@ use std::sync::OnceLock;
 fn ref_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(
-            r"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}(?:\s*\|[^}]*)?\s*\}\}",
-        )
-        .expect("static regex")
+        Regex::new(r"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}(?:\s*\|[^}]*)?\s*\}\}")
+            .expect("static regex")
     })
 }
 
@@ -73,7 +71,10 @@ impl std::fmt::Display for Cycle {
 /// order of `nodes`, so the dry-run plan for the same repo state is
 /// reproducible. Edge target lists are walked in given order; callers
 /// who want deterministic cycle-path messages should pre-sort/dedup.
-pub fn topo_sort(nodes: &[String], edges: &BTreeMap<String, Vec<String>>) -> Result<Vec<String>, Cycle> {
+pub fn topo_sort(
+    nodes: &[String],
+    edges: &BTreeMap<String, Vec<String>>,
+) -> Result<Vec<String>, Cycle> {
     let in_set: BTreeSet<&str> = nodes.iter().map(String::as_str).collect();
     let mut visited: BTreeSet<String> = BTreeSet::new();
     let mut on_stack: Vec<String> = Vec::new();
@@ -384,10 +385,7 @@ mod tests {
         //   d
         // d must come first; b and c before a.
         let diffs = vec![
-            added(
-                "a",
-                "{{content_blocks.${b}}} and {{content_blocks.${c}}}",
-            ),
+            added("a", "{{content_blocks.${b}}} and {{content_blocks.${c}}}"),
             added("b", "{{content_blocks.${d}}}"),
             added("c", "{{content_blocks.${d}}}"),
             added("d", "leaf"),

--- a/src/diff/content_block_order.rs
+++ b/src/diff/content_block_order.rs
@@ -110,7 +110,10 @@ fn visit<'a>(
     if on_stack_set.contains(node) {
         // Cycle: cut the prefix before the first occurrence and append
         // the closing node so the message reads `A → B → C → A`.
-        let start = on_stack.iter().position(|n| *n == node).unwrap_or(0);
+        let start = on_stack
+            .iter()
+            .position(|n| *n == node)
+            .expect("on_stack and on_stack_set must stay in sync");
         let mut path: Vec<String> = on_stack[start..].iter().map(|s| (*s).to_owned()).collect();
         path.push(node.to_owned());
         return Err(Cycle { path });

--- a/src/diff/content_block_order.rs
+++ b/src/diff/content_block_order.rs
@@ -22,7 +22,6 @@
 //! Pure module: no I/O, no Braze calls.
 
 use crate::diff::{DiffOp, ResourceDiff};
-use crate::resource::ContentBlock;
 use regex_lite::Regex;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
@@ -72,7 +71,8 @@ impl std::fmt::Display for Cycle {
 /// just becomes a leaf for sort purposes. Output is dependency-order:
 /// targets before referrers. Stable across runs: ties broken by input
 /// order of `nodes`, so the dry-run plan for the same repo state is
-/// reproducible.
+/// reproducible. Edge target lists are walked in given order; callers
+/// who want deterministic cycle-path messages should pre-sort/dedup.
 pub fn topo_sort(nodes: &[String], edges: &BTreeMap<String, Vec<String>>) -> Result<Vec<String>, Cycle> {
     let in_set: BTreeSet<&str> = nodes.iter().map(String::as_str).collect();
     let mut visited: BTreeSet<String> = BTreeSet::new();
@@ -120,12 +120,10 @@ fn visit(
     on_stack_set.insert(node.to_string());
 
     if let Some(targets) = edges.get(node) {
-        // Iterate targets in stable order so cycle paths are deterministic.
-        let mut sorted: Vec<&String> = targets.iter().filter(|t| in_set.contains(t.as_str())).collect();
-        sorted.sort();
-        sorted.dedup();
-        for t in sorted {
-            visit(t, edges, in_set, visited, on_stack, on_stack_set, out)?;
+        for t in targets {
+            if in_set.contains(t.as_str()) {
+                visit(t, edges, in_set, visited, on_stack, on_stack_set, out)?;
+            }
         }
     }
 
@@ -149,77 +147,62 @@ fn visit(
 pub fn reorder_content_block_diffs_by_dependency(
     diffs: Vec<ResourceDiff>,
 ) -> Result<Vec<ResourceDiff>, Cycle> {
-    let mut content_blocks: Vec<ResourceDiff> = Vec::new();
     let mut others: Vec<ResourceDiff> = Vec::new();
+    let mut inactionable: Vec<ResourceDiff> = Vec::new();
+    let mut actionable_names: Vec<String> = Vec::new();
+    let mut by_name: BTreeMap<String, ResourceDiff> = BTreeMap::new();
+    let mut edges: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
     for d in diffs {
         match d {
-            ResourceDiff::ContentBlock(_) => content_blocks.push(d),
-            _ => others.push(d),
-        }
-    }
-    if content_blocks.is_empty() {
-        return Ok(others);
-    }
-
-    // Split actionable (carry a body) vs non-actionable (no body to
-    // parse, no write to fire). Only actionable blocks participate in
-    // topo-sort.
-    let mut actionable_names: Vec<String> = Vec::new();
-    let mut actionable_by_name: BTreeMap<String, ResourceDiff> = BTreeMap::new();
-    let mut inactionable: Vec<ResourceDiff> = Vec::new();
-
-    for d in content_blocks {
-        let actionable_body: Option<(&str, &ContentBlock)> = match &d {
-            ResourceDiff::ContentBlock(cb) if !cb.orphan => match &cb.op {
-                DiffOp::Added(body) => Some((cb.name.as_str(), body)),
-                DiffOp::Modified { to, .. } => Some((cb.name.as_str(), to)),
-                _ => None,
-            },
-            _ => None,
-        };
-        if let Some((name, _body)) = actionable_body {
-            actionable_names.push(name.to_string());
-            actionable_by_name.insert(name.to_string(), d);
-        } else {
-            inactionable.push(d);
-        }
-    }
-
-    // Build edges: referrer → [targets] limited to actionable names.
-    // Self-references (a block including itself) are dropped — they
-    // are a Braze-side problem, not an apply-order problem, and we
-    // don't want them to surface here as cycles.
-    let mut edges: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for name in &actionable_names {
-        let body = match actionable_by_name.get(name).expect("just inserted") {
-            ResourceDiff::ContentBlock(cb) => match &cb.op {
-                DiffOp::Added(b) => &b.content,
-                DiffOp::Modified { to, .. } => &to.content,
-                _ => unreachable!("split above"),
-            },
-            _ => unreachable!("split above"),
-        };
-        let refs: Vec<String> = extract_block_references(body)
-            .into_iter()
-            .filter(|t| t != name)
-            .collect();
-        if !refs.is_empty() {
-            edges.insert(name.clone(), refs);
+            ResourceDiff::ContentBlock(cb) => {
+                let body: Option<&str> = if cb.orphan {
+                    None
+                } else {
+                    match &cb.op {
+                        DiffOp::Added(b) => Some(b.content.as_str()),
+                        DiffOp::Modified { to, .. } => Some(to.content.as_str()),
+                        _ => None,
+                    }
+                };
+                match body {
+                    Some(b) => {
+                        let name = cb.name.clone();
+                        // Self-references are a Braze-side problem, not
+                        // an apply-order problem — drop them so they
+                        // don't surface as false-positive cycles.
+                        let mut refs: Vec<String> = extract_block_references(b)
+                            .into_iter()
+                            .filter(|t| *t != name)
+                            .collect();
+                        refs.sort();
+                        refs.dedup();
+                        if !refs.is_empty() {
+                            edges.insert(name.clone(), refs);
+                        }
+                        actionable_names.push(name.clone());
+                        by_name.insert(name, ResourceDiff::ContentBlock(cb));
+                    }
+                    None => inactionable.push(ResourceDiff::ContentBlock(cb)),
+                }
+            }
+            other => others.push(other),
         }
     }
 
     let sorted_names = topo_sort(&actionable_names, &edges)?;
 
-    let mut out = Vec::with_capacity(others.len() + actionable_names.len() + inactionable.len());
+    let mut out = Vec::with_capacity(others.len() + sorted_names.len() + inactionable.len());
     // Non-content_block diffs keep their original relative position
-    // before the content_block group, mirroring the per-kind iteration
-    // order of `apply::run`.
+    // before the content_block group, mirroring `apply::run`'s per-kind
+    // iteration order. Inactionable blocks trail — apply order doesn't
+    // affect them and trailing keeps the dry-run plan readable.
     out.extend(others);
     for n in &sorted_names {
         out.push(
-            actionable_by_name
+            by_name
                 .remove(n)
-                .expect("topo_sort returns names from actionable set"),
+                .expect("topo_sort returns names from input set"),
         );
     }
     out.extend(inactionable);
@@ -230,7 +213,7 @@ pub fn reorder_content_block_diffs_by_dependency(
 mod tests {
     use super::*;
     use crate::diff::content_block::ContentBlockDiff;
-    use crate::resource::ContentBlockState;
+    use crate::resource::{ContentBlock, ContentBlockState};
 
     fn cb(name: &str, body: &str) -> ContentBlock {
         ContentBlock {

--- a/src/diff/content_block_order.rs
+++ b/src/diff/content_block_order.rs
@@ -71,17 +71,18 @@ impl std::fmt::Display for Cycle {
 /// order of `nodes`, so the dry-run plan for the same repo state is
 /// reproducible. Edge target lists are walked in given order; callers
 /// who want deterministic cycle-path messages should pre-sort/dedup.
-pub fn topo_sort(
-    nodes: &[String],
-    edges: &BTreeMap<String, Vec<String>>,
+pub fn topo_sort<'a>(
+    nodes: &'a [String],
+    edges: &'a BTreeMap<String, Vec<String>>,
 ) -> Result<Vec<String>, Cycle> {
-    let in_set: BTreeSet<&str> = nodes.iter().map(String::as_str).collect();
-    let mut visited: BTreeSet<String> = BTreeSet::new();
-    let mut on_stack: Vec<String> = Vec::new();
-    let mut on_stack_set: BTreeSet<String> = BTreeSet::new();
-    let mut out: Vec<String> = Vec::with_capacity(nodes.len());
+    let in_set: BTreeSet<&'a str> = nodes.iter().map(String::as_str).collect();
+    let mut visited: BTreeSet<&'a str> = BTreeSet::new();
+    let mut on_stack: Vec<&'a str> = Vec::new();
+    let mut on_stack_set: BTreeSet<&'a str> = BTreeSet::new();
+    let mut out: Vec<&'a str> = Vec::with_capacity(nodes.len());
 
     for n in nodes {
+        let n = n.as_str();
         if !visited.contains(n) {
             visit(
                 n,
@@ -94,35 +95,36 @@ pub fn topo_sort(
             )?;
         }
     }
-    Ok(out)
+    Ok(out.into_iter().map(str::to_owned).collect())
 }
 
-fn visit(
-    node: &str,
-    edges: &BTreeMap<String, Vec<String>>,
-    in_set: &BTreeSet<&str>,
-    visited: &mut BTreeSet<String>,
-    on_stack: &mut Vec<String>,
-    on_stack_set: &mut BTreeSet<String>,
-    out: &mut Vec<String>,
+fn visit<'a>(
+    node: &'a str,
+    edges: &'a BTreeMap<String, Vec<String>>,
+    in_set: &BTreeSet<&'a str>,
+    visited: &mut BTreeSet<&'a str>,
+    on_stack: &mut Vec<&'a str>,
+    on_stack_set: &mut BTreeSet<&'a str>,
+    out: &mut Vec<&'a str>,
 ) -> Result<(), Cycle> {
     if on_stack_set.contains(node) {
         // Cycle: cut the prefix before the first occurrence and append
         // the closing node so the message reads `A → B → C → A`.
-        let start = on_stack.iter().position(|n| n == node).unwrap_or(0);
-        let mut path: Vec<String> = on_stack[start..].to_vec();
-        path.push(node.to_string());
+        let start = on_stack.iter().position(|n| *n == node).unwrap_or(0);
+        let mut path: Vec<String> = on_stack[start..].iter().map(|s| (*s).to_owned()).collect();
+        path.push(node.to_owned());
         return Err(Cycle { path });
     }
     if visited.contains(node) {
         return Ok(());
     }
-    on_stack.push(node.to_string());
-    on_stack_set.insert(node.to_string());
+    on_stack.push(node);
+    on_stack_set.insert(node);
 
     if let Some(targets) = edges.get(node) {
         for t in targets {
-            if in_set.contains(t.as_str()) {
+            let t = t.as_str();
+            if in_set.contains(t) {
                 visit(t, edges, in_set, visited, on_stack, on_stack_set, out)?;
             }
         }
@@ -130,8 +132,8 @@ fn visit(
 
     on_stack.pop();
     on_stack_set.remove(node);
-    visited.insert(node.to_string());
-    out.push(node.to_string());
+    visited.insert(node);
+    out.push(node);
     Ok(())
 }
 

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -10,6 +10,7 @@ use similar::{ChangeTag, TextDiff};
 
 pub mod catalog;
 pub mod content_block;
+pub mod content_block_order;
 pub mod custom_attribute;
 pub mod email_template;
 pub mod orphan;

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1218,3 +1218,215 @@ async fn apply_custom_attribute_batches_both_directions() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Applied 2 change(s)"), "stderr: {stderr}");
 }
+
+// =====================================================================
+// Content Block apply order (v0.11.0)
+// =====================================================================
+//
+// Topological apply: when a local block references another via the
+// Liquid `{{content_blocks.${target}}}` include, the target must be
+// created first because Braze validates the body at create time and
+// returns an opaque HTTP 500 if the reference doesn't resolve. These
+// tests pin the new ordering and the cycle-detection guard rail.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn content_block_apply_creates_dependency_target_before_referrer() {
+    // a_referrer (alphabetically first) references b_target. Pre-v0.11.0
+    // this would create a_referrer first and trip Braze's forward-ref
+    // 500. We assert that POSTs land in dependency order: b_target
+    // before a_referrer.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/create"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_block_id": "new-id",
+            "message": "success"
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(
+        tmp.path(),
+        "a_referrer",
+        "see {{content_blocks.${b_target} | id: 'cb1'}}\n",
+    );
+    write_local_content_block(tmp.path(), "b_target", "leaf body\n");
+
+    tokio::task::spawn_blocking({
+        let cfg = config_path.clone();
+        move || {
+            Command::cargo_bin("braze-sync")
+                .unwrap()
+                .env("BRAZE_API_KEY", "test-key")
+                .args(["--config", cfg.to_str().unwrap()])
+                .args(["apply", "--resource", "content_block", "--confirm"])
+                .assert()
+                .success();
+        }
+    })
+    .await
+    .unwrap();
+
+    // Inspect the received request log: pull out the create POSTs in
+    // order and assert b_target lands first. Wiremock records every
+    // request the server received in the order it received it, so the
+    // index of each create call is the apply order.
+    let received = server
+        .received_requests()
+        .await
+        .expect("recording is on by default");
+    let create_names: Vec<String> = received
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::POST && r.url.path() == "/content_blocks/create")
+        .map(|r| {
+            let v: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+            v.get("name").and_then(|n| n.as_str()).unwrap().to_string()
+        })
+        .collect();
+    assert_eq!(
+        create_names,
+        vec!["b_target".to_string(), "a_referrer".to_string()],
+        "dependency target must be created before referrer"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn content_block_apply_aborts_on_reference_cycle_before_any_write() {
+    // A → B → A. Topo-sort must reject this with a named-block error
+    // before any HTTP write goes out. `.expect(0)` on POST proves no
+    // create call fires.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(tmp.path(), "cycle_a", "{{content_blocks.${cycle_b}}}\n");
+    write_local_content_block(tmp.path(), "cycle_b", "{{content_blocks.${cycle_a}}}\n");
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "content_block", "--confirm"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("dependency cycle"),
+        "expected cycle error in stderr; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("cycle_a") && stderr.contains("cycle_b"),
+        "cycle error must name both blocks; got:\n{stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn content_block_apply_alphabetical_opt_out_preserves_input_order() {
+    // With `apply_order: alphabetical` the topo pass is skipped and the
+    // forward reference would explode against real Braze. Here we just
+    // assert ordering: a_referrer first (alphabetical), b_target
+    // second — i.e. the v0.10 behavior is opt-in-able.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/create"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_block_id": "new-id",
+            "message": "success"
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    // Hand-write config with apply_order override; write_config doesn't
+    // surface the field and we don't want to grow that helper for one
+    // test.
+    let config_path = tmp.path().join("braze-sync.config.yaml");
+    let yaml = format!(
+        "version: 1
+default_environment: test
+environments:
+  test:
+    api_endpoint: {uri}
+    api_key_env: BRAZE_API_KEY
+resources:
+  content_block:
+    enabled: true
+    path: content_blocks/
+    apply_order: alphabetical
+",
+        uri = server.uri()
+    );
+    std::fs::write(&config_path, yaml).unwrap();
+    write_local_content_block(
+        tmp.path(),
+        "a_referrer",
+        "see {{content_blocks.${b_target}}}\n",
+    );
+    write_local_content_block(tmp.path(), "b_target", "leaf\n");
+
+    tokio::task::spawn_blocking({
+        let cfg = config_path.clone();
+        move || {
+            Command::cargo_bin("braze-sync")
+                .unwrap()
+                .env("BRAZE_API_KEY", "test-key")
+                .args(["--config", cfg.to_str().unwrap()])
+                .args(["apply", "--resource", "content_block", "--confirm"])
+                .assert()
+                .success();
+        }
+    })
+    .await
+    .unwrap();
+
+    let received = server.received_requests().await.unwrap();
+    let create_names: Vec<String> = received
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::POST && r.url.path() == "/content_blocks/create")
+        .map(|r| {
+            let v: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+            v.get("name").and_then(|n| n.as_str()).unwrap().to_string()
+        })
+        .collect();
+    assert_eq!(
+        create_names,
+        vec!["a_referrer".to_string(), "b_target".to_string()],
+        "alphabetical opt-out must preserve pre-v0.11 ordering"
+    );
+}

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1220,21 +1220,32 @@ async fn apply_custom_attribute_batches_both_directions() {
 }
 
 // =====================================================================
-// Content Block apply order (v0.11.0)
+// Content Block apply order
 // =====================================================================
 //
 // Topological apply: when a local block references another via the
 // Liquid `{{content_blocks.${target}}}` include, the target must be
 // created first because Braze validates the body at create time and
-// returns an opaque HTTP 500 if the reference doesn't resolve. These
-// tests pin the new ordering and the cycle-detection guard rail.
+// returns an opaque HTTP 500 if the reference doesn't resolve.
+
+async fn received_create_names(server: &MockServer) -> Vec<String> {
+    server
+        .received_requests()
+        .await
+        .expect("recording is on by default")
+        .iter()
+        .filter(|r| {
+            r.method == wiremock::http::Method::POST && r.url.path() == "/content_blocks/create"
+        })
+        .map(|r| {
+            let v: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+            v.get("name").and_then(|n| n.as_str()).unwrap().to_string()
+        })
+        .collect()
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn content_block_apply_creates_dependency_target_before_referrer() {
-    // a_referrer (alphabetically first) references b_target. Pre-v0.11.0
-    // this would create a_referrer first and trip Braze's forward-ref
-    // 500. We assert that POSTs land in dependency order: b_target
-    // before a_referrer.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/content_blocks/list"))
@@ -1277,24 +1288,10 @@ async fn content_block_apply_creates_dependency_target_before_referrer() {
     .await
     .unwrap();
 
-    // Inspect the received request log: pull out the create POSTs in
-    // order and assert b_target lands first. Wiremock records every
-    // request the server received in the order it received it, so the
-    // index of each create call is the apply order.
-    let received = server
-        .received_requests()
-        .await
-        .expect("recording is on by default");
-    let create_names: Vec<String> = received
-        .iter()
-        .filter(|r| r.method == wiremock::http::Method::POST && r.url.path() == "/content_blocks/create")
-        .map(|r| {
-            let v: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
-            v.get("name").and_then(|n| n.as_str()).unwrap().to_string()
-        })
-        .collect();
+    // Wiremock records requests in receive order, so create-call index
+    // is the apply order.
     assert_eq!(
-        create_names,
+        received_create_names(&server).await,
         vec!["b_target".to_string(), "a_referrer".to_string()],
         "dependency target must be created before referrer"
     );
@@ -1302,9 +1299,8 @@ async fn content_block_apply_creates_dependency_target_before_referrer() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn content_block_apply_aborts_on_reference_cycle_before_any_write() {
-    // A → B → A. Topo-sort must reject this with a named-block error
-    // before any HTTP write goes out. `.expect(0)` on POST proves no
-    // create call fires.
+    // `.expect(0)` on POST proves no create call fires before the
+    // cycle is reported.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/content_blocks/list"))
@@ -1350,10 +1346,8 @@ async fn content_block_apply_aborts_on_reference_cycle_before_any_write() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn content_block_apply_alphabetical_opt_out_preserves_input_order() {
-    // With `apply_order: alphabetical` the topo pass is skipped and the
-    // forward reference would explode against real Braze. Here we just
-    // assert ordering: a_referrer first (alphabetical), b_target
-    // second — i.e. the v0.10 behavior is opt-in-able.
+    // With `apply_order: alphabetical` the topo pass is skipped; we
+    // assert a_referrer comes first (alphabetical), b_target second.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/content_blocks/list"))
@@ -1373,9 +1367,8 @@ async fn content_block_apply_alphabetical_opt_out_preserves_input_order() {
         .await;
 
     let tmp = tempfile::tempdir().unwrap();
-    // Hand-write config with apply_order override; write_config doesn't
-    // surface the field and we don't want to grow that helper for one
-    // test.
+    // write_config doesn't surface apply_order; hand-write the YAML
+    // rather than grow the helper for one test.
     let config_path = tmp.path().join("braze-sync.config.yaml");
     let yaml = format!(
         "version: 1
@@ -1415,18 +1408,9 @@ resources:
     .await
     .unwrap();
 
-    let received = server.received_requests().await.unwrap();
-    let create_names: Vec<String> = received
-        .iter()
-        .filter(|r| r.method == wiremock::http::Method::POST && r.url.path() == "/content_blocks/create")
-        .map(|r| {
-            let v: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
-            v.get("name").and_then(|n| n.as_str()).unwrap().to_string()
-        })
-        .collect();
     assert_eq!(
-        create_names,
+        received_create_names(&server).await,
         vec!["a_referrer".to_string(), "b_target".to_string()],
-        "alphabetical opt-out must preserve pre-v0.11 ordering"
+        "alphabetical opt-out must preserve input order"
     );
 }

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1273,6 +1273,35 @@ async fn content_block_apply_creates_dependency_target_before_referrer() {
     );
     write_local_content_block(tmp.path(), "b_target", "leaf body\n");
 
+    // Dry-run first: the plan must list b_target before a_referrer so
+    // operators see the actual write sequence before passing --confirm.
+    let dry_run = tokio::task::spawn_blocking({
+        let cfg = config_path.clone();
+        move || {
+            Command::cargo_bin("braze-sync")
+                .unwrap()
+                .env("BRAZE_API_KEY", "test-key")
+                .args(["--config", cfg.to_str().unwrap()])
+                .args(["apply", "--resource", "content_block"])
+                .output()
+                .unwrap()
+        }
+    })
+    .await
+    .unwrap();
+    assert!(dry_run.status.success(), "dry-run must succeed");
+    let dry_stdout = String::from_utf8_lossy(&dry_run.stdout);
+    let pos_target = dry_stdout
+        .find("Content Block: b_target")
+        .expect("plan must list b_target");
+    let pos_referrer = dry_stdout
+        .find("Content Block: a_referrer")
+        .expect("plan must list a_referrer");
+    assert!(
+        pos_target < pos_referrer,
+        "dry-run plan must list b_target before a_referrer; got:\n{dry_stdout}"
+    );
+
     tokio::task::spawn_blocking({
         let cfg = config_path.clone();
         move || {
@@ -1392,6 +1421,35 @@ resources:
         "see {{content_blocks.${b_target}}}\n",
     );
     write_local_content_block(tmp.path(), "b_target", "leaf\n");
+
+    // Dry-run first: with apply_order=alphabetical the topo pass is
+    // skipped so the plan must echo input/alphabetical order.
+    let dry_run = tokio::task::spawn_blocking({
+        let cfg = config_path.clone();
+        move || {
+            Command::cargo_bin("braze-sync")
+                .unwrap()
+                .env("BRAZE_API_KEY", "test-key")
+                .args(["--config", cfg.to_str().unwrap()])
+                .args(["apply", "--resource", "content_block"])
+                .output()
+                .unwrap()
+        }
+    })
+    .await
+    .unwrap();
+    assert!(dry_run.status.success(), "dry-run must succeed");
+    let dry_stdout = String::from_utf8_lossy(&dry_run.stdout);
+    let pos_referrer = dry_stdout
+        .find("Content Block: a_referrer")
+        .expect("plan must list a_referrer");
+    let pos_target = dry_stdout
+        .find("Content Block: b_target")
+        .expect("plan must list b_target");
+    assert!(
+        pos_referrer < pos_target,
+        "dry-run plan under alphabetical mode must keep a_referrer before b_target; got:\n{dry_stdout}"
+    );
 
     tokio::task::spawn_blocking({
         let cfg = config_path.clone();


### PR DESCRIPTION
## Summary

- Parse `{{content_blocks.${other} | id: '...'}}` references out of local Liquid bodies and topologically sort `apply` so dependency targets are created before referrers. Pre-v0.11 alphabetical order broke any `A → B` reference where `A < B` on a fresh workspace — Braze validates includes at create time and rejects forward references with an opaque HTTP 500, halting the whole apply pass mid-pipeline.
- Cycles are detected before any HTTP write fires and reported with named blocks (`A → B → C → A`) so the operator can fix the loop instead of decoding a 500.
- New `resources.content_block.apply_order` config field. Default `dependency` (the new behavior); set to `alphabetical` to restore v0.10 ordering. References to blocks not in the actionable set (already-present in Braze, or out-of-scope) are treated as no-op edges — the referrer becomes a leaf.
- Dry-run plan is emitted in the chosen order, so `apply` (without `--confirm`) previews the exact write sequence.

Spec: `docs/local/feat-content-block-topo-sort.md`.

## Test plan

- [x] `cargo test` — 409 tests pass (13 new unit tests in `diff::content_block_order`, 3 new integration tests in `tests/cli_apply.rs`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Integration tests assert via wiremock request log: dependency target POSTed before referrer; cycle aborts with `.expect(0)` on POST; `apply_order: alphabetical` preserves v0.10 ordering
- [ ] Manual smoke against a Braze sandbox before tagging v0.11.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content blocks now apply in dependency-aware order (targets before referrers), aborting early on detected cycles and previewing the chosen write sequence; opt out with an apply_order: alphabetical setting.
  * Added Tag registry as a managed resource kind.

* **Documentation**
  * Release updated to v0.11.0; docs and README updated to describe new apply behavior and clarify limitations.

* **Tests**
  * Added integration tests covering content-block apply ordering and cycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->