### PR TITLE
feat: support catalog schema deletion

### DIFF
--- a/src/braze/catalog.rs
+++ b/src/braze/catalog.rs
@@ -146,6 +146,19 @@ impl BrazeClient {
         let req = self.delete(&["catalogs", catalog_name, "fields", field_name]);
         self.send_ok(req).await
     }
+
+    /// `DELETE /catalogs/{name}` — drop an entire catalog schema and all its
+    /// items. **Destructive** and irreversible on the Braze side: the items
+    /// table is gone, not soft-deleted.
+    ///
+    /// 404 stays as `Http { status: 404, .. }` rather than being mapped to
+    /// `NotFound`, matching `delete_catalog_field`: a 404 here means "the
+    /// catalog you wanted to delete is already gone" — drift the user should
+    /// see, not a silent no-op.
+    pub async fn delete_catalog(&self, catalog_name: &str) -> Result<(), BrazeApiError> {
+        let req = self.delete(&["catalogs", catalog_name]);
+        self.send_ok(req).await
+    }
 }
 
 #[derive(Serialize)]
@@ -758,6 +771,59 @@ mod tests {
             .delete_catalog_field("cardiology", "x")
             .await
             .unwrap_err();
+        match err {
+            BrazeApiError::Http { status, body } => {
+                assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+                assert!(body.contains("oops"));
+            }
+            other => panic!("expected Http, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_catalog_happy_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/catalogs/cardiology"))
+            .and(header("authorization", "Bearer test-key"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server);
+        client.delete_catalog("cardiology").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_catalog_404_stays_as_http_not_mapped_to_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/catalogs/missing"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server);
+        let err = client.delete_catalog("missing").await.unwrap_err();
+        match err {
+            BrazeApiError::Http { status, .. } => {
+                assert_eq!(status, StatusCode::NOT_FOUND);
+            }
+            other => panic!("expected Http(404), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_catalog_server_error_returns_http() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/catalogs/cardiology"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("oops"))
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server);
+        let err = client.delete_catalog("cardiology").await.unwrap_err();
         match err {
             BrazeApiError::Http { status, body } => {
                 assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);

--- a/src/braze/catalog.rs
+++ b/src/braze/catalog.rs
@@ -148,13 +148,10 @@ impl BrazeClient {
     }
 
     /// `DELETE /catalogs/{name}` — drop an entire catalog schema and all its
-    /// items. **Destructive** and irreversible on the Braze side: the items
-    /// table is gone, not soft-deleted.
+    /// items. **Destructive** and irreversible on the Braze side: items are
+    /// not soft-deleted.
     ///
-    /// 404 stays as `Http { status: 404, .. }` rather than being mapped to
-    /// `NotFound`, matching `delete_catalog_field`: a 404 here means "the
-    /// catalog you wanted to delete is already gone" — drift the user should
-    /// see, not a silent no-op.
+    /// 404 handling matches `delete_catalog_field` — see there.
     pub async fn delete_catalog(&self, catalog_name: &str) -> Result<(), BrazeApiError> {
         let req = self.delete(&["catalogs", catalog_name]);
         self.send_ok(req).await

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -351,17 +351,6 @@ fn enforce_tag_preflight(
 fn check_for_unsupported_ops(summary: &DiffSummary) -> anyhow::Result<()> {
     for diff in &summary.diffs {
         if let ResourceDiff::CatalogSchema(d) = diff {
-            match &d.op {
-                DiffOp::Added(_) => {}
-                DiffOp::Removed(_) => {
-                    return Err(anyhow!(
-                        "deleting catalog '{}' (top-level) is not supported by braze-sync; \
-                         only field-level changes can be applied",
-                        d.name
-                    ));
-                }
-                _ => {}
-            }
             // Field type change would require delete-then-add, which is
             // data-losing on the field — refuse rather than silently drop.
             for fd in &d.field_diffs {
@@ -470,6 +459,18 @@ async fn apply_catalog_schema(
             .create_catalog(cat)
             .await
             .with_context(|| format!("creating catalog '{}'", d.name))?;
+        return Ok(1);
+    }
+
+    // Top-level delete short-circuits the field loop: `DELETE /catalogs/{name}`
+    // drops the schema and all items in one call, so per-field DELETEs would
+    // be redundant (and would 404 once the catalog is gone).
+    if let DiffOp::Removed(_) = &d.op {
+        tracing::info!(catalog = %d.name, "deleting catalog");
+        client
+            .delete_catalog(&d.name)
+            .await
+            .with_context(|| format!("deleting catalog '{}'", d.name))?;
         return Ok(1);
     }
 

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -250,6 +250,100 @@ async fn confirm_with_allow_destructive_calls_delete_and_exits_zero() {
     .unwrap();
 }
 
+/// Local-side absence of a catalog must produce a top-level DELETE
+/// against `/catalogs/{name}` and skip the per-field DELETE loop — one
+/// remote call drops the schema and all items.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn confirm_with_allow_destructive_deletes_entire_catalog_in_one_call() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "catalogs": [
+                {"name": "cardiology", "fields": [
+                    {"name": "id", "type": "string"},
+                    {"name": "legacy", "type": "string"}
+                ]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/catalogs/cardiology"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Per-field DELETEs must NOT fire when the whole catalog is dropped.
+    Mock::given(method("DELETE"))
+        .and(path("/catalogs/cardiology/fields/legacy"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    // No local schema for "cardiology" — diff produces top-level Removed.
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "catalog_schema",
+                "--confirm",
+                "--allow-destructive",
+            ])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
+/// Top-level catalog removal is destructive and must be gated by
+/// `--allow-destructive`; without it, apply exits 6 and issues no
+/// DELETE.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn confirm_without_allow_destructive_blocks_full_catalog_delete() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "catalogs": [
+                {"name": "cardiology", "fields": [{"name": "id", "type": "string"}]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    // No local schema for "cardiology".
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "catalog_schema", "--confirm"])
+            .assert()
+            .failure()
+            .code(6);
+    })
+    .await
+    .unwrap();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn confirm_with_new_catalog_posts_create_and_skips_per_field_post() {
     let server = MockServer::start().await;


### PR DESCRIPTION
## Summary
- Wrap `DELETE /catalogs/{name}` as `BrazeClient::delete_catalog` (404 stays as `Http`, matching `delete_catalog_field`'s drift-visibility policy).
- Handle `DiffOp::Removed` for catalog schemas in `apply`: short-circuit before the per-field loop and issue a single top-level DELETE (one call drops the schema and all items).
- Remove the old `check_for_unsupported_ops` rejection that hard-errored on catalog top-level removals.
- Existing destructive-op gate (`is_destructive() == true` for `Removed`) is reused, so `--allow-destructive` is required.

Among managed resources, catalog was the only one with a Braze DELETE endpoint not yet supported — content_block / email_template have no DELETE on Braze's side; custom_attribute / tag have no per-entity delete API at all.

## Test plan
- [x] `cargo test` — 412 tests pass, including 3 new client tests (happy path, 404, 500).
- [ ] Manual: with a catalog dir removed locally, `braze-sync apply --confirm` shows the destructive-blocked error.
- [ ] Manual: same scenario with `--confirm --allow-destructive` issues `DELETE /catalogs/{name}` and the catalog disappears from Braze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete entire remote catalogs via the apply command. Catalog removal operations are now fully supported with appropriate validation handling.

* **Tests**
  * Added comprehensive unit tests for catalog deletion, validating successful removals, not-found errors, and server failure responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->