### PR TITLE
ci: bump release action versions to clear Node 20 deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.UNY_RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.UNY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.UNY_RELEASE_BOT_PRIVATE_KEY }}
           owner: uny
           repositories: homebrew-tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           files: artifacts/*
@@ -183,7 +183,7 @@ jobs:
 
       - name: Mint tap token (uny-release-bot App)
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.UNY_RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.UNY_RELEASE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Clears all actionable CI annotations on the v0.12.0 release run ([run 25956611893](https://github.com/uny/braze-sync/actions/runs/25956611893)):

- **`softprops/action-gh-release` v2.6.1 → v3.0.0.** v3 runs on Node 24, silencing the *"Node.js 20 actions are deprecated"* annotation.
- **`actions/create-github-app-token` v3.1.1 → v3.2.0.**
- **`app-id` → `client-id` input.** Switches the deprecated input on `create-github-app-token`, which is what raised *"Input 'app-id' has been deprecated with message: Use 'client-id' instead."*. Requires the `UNY_RELEASE_BOT_CLIENT_ID` secret (the GitHub App's Client ID, distinct from the numeric App ID) — already added on the repo. The old `UNY_RELEASE_BOT_APP_ID` secret is no longer referenced and can be deleted whenever convenient.

## Not addressed

- **`windows-latest` redirect notice** — informational only; the runner auto-redirects to `windows-2025-vs2026` from June 15, 2026. No action required.

## Test plan
- [x] SHAs verified via `gh api`.
- [x] Confirmed v3.0.0 of `action-gh-release` declares `using: node24`.
- [x] Confirmed v3.2.0 of `create-github-app-token` accepts `client-id`.
- [ ] Next tagged release run shows the Node 20 and `app-id` annotations gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)