### PR TITLE
feat: plan-lock includes values_input_hashes (Phase 6)

### DIFF
--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -118,7 +118,8 @@ pub async fn run(
     let mut summary = DiffSummary::default();
     let mut content_block_id_index: Option<ContentBlockIdIndex> = None;
     let mut email_template_id_index: Option<EmailTemplateIdIndex> = None;
-    for kind in kinds {
+    for kind in &kinds {
+        let kind = *kind;
         if warn_if_name_excluded(kind, args.name.as_deref(), resolved.excludes_for(kind)) {
             continue;
         }
@@ -232,10 +233,14 @@ pub async fn run(
                 resolved: &resolved,
                 content_blocks_root: &content_blocks_root,
                 email_templates_root: &email_templates_root,
-                kinds: &[
-                    ResourceKind::ContentBlock,
-                    ResourceKind::EmailTemplate,
-                ],
+                // Use the same kinds the operator scoped this apply to
+                // (check_plan_scope has already verified args.resource ==
+                // plan.scope.resource). Hardcoding [CB, ET] here would
+                // produce ET hashes that are absent from a saved plan
+                // built with `diff --resource content_block --plan-out`,
+                // and `check_plan_values_hashes` would report them as
+                // `extra` → spurious PlanDrift.
+                kinds: &kinds,
                 cb_name_filter: args
                     .name
                     .as_deref()

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -261,7 +261,10 @@ pub async fn run(
             if saved.values_input_hashes.is_empty() {
                 String::new()
             } else {
-                format!(", {} values hash(es) verified", saved.values_input_hashes.len())
+                format!(
+                    ", {} values hash(es) verified",
+                    saved.values_input_hashes.len()
+                )
             }
         );
     }
@@ -554,9 +557,7 @@ fn check_plan_values_hashes(
         }
     }
     if !missing_in_fresh.is_empty() {
-        eprintln!(
-            "  resources in saved plan but no fresh hash (placeholders removed?):"
-        );
+        eprintln!("  resources in saved plan but no fresh hash (placeholders removed?):");
         for k in &missing_in_fresh {
             eprintln!("    - {k}");
         }

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -22,7 +22,7 @@ use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::error::Error;
 use crate::format::OutputFormat;
 use crate::resource::ResourceKind;
-use crate::values::{preflight_values, PreflightArgs};
+use crate::values::{compute_values_input_hashes, preflight_values, PreflightArgs};
 use anyhow::{anyhow, Context as _};
 use clap::Args;
 use std::path::{Path, PathBuf};
@@ -223,7 +223,42 @@ pub async fn run(
     // Print the fresh plan first so the operator sees it even on mismatch.
     if let Some(saved) = &saved_plan {
         check_plan_ops(saved, &summary)?;
-        eprintln!("✓ Plan matches saved plan ({} op(s)).", saved.ops.len());
+        // RFC §4 Phase 6: also verify per-resource consumed-values
+        // hashes. Catches values edits (including fan-out global
+        // edits) that occurred after the plan was written.
+        let fresh_hashes = compute_values_input_hashes(
+            PreflightArgs {
+                config_dir,
+                resolved: &resolved,
+                content_blocks_root: &content_blocks_root,
+                email_templates_root: &email_templates_root,
+                kinds: &[
+                    ResourceKind::ContentBlock,
+                    ResourceKind::EmailTemplate,
+                ],
+                cb_name_filter: args
+                    .name
+                    .as_deref()
+                    .filter(|_| args.resource == Some(ResourceKind::ContentBlock)),
+                et_name_filter: args
+                    .name
+                    .as_deref()
+                    .filter(|_| args.resource == Some(ResourceKind::EmailTemplate)),
+                cb_excludes: resolved.excludes_for(ResourceKind::ContentBlock),
+                et_excludes: resolved.excludes_for(ResourceKind::EmailTemplate),
+            },
+            values.as_ref(),
+        )?;
+        check_plan_values_hashes(saved, &fresh_hashes)?;
+        eprintln!(
+            "✓ Plan matches saved plan ({} op(s){}).",
+            saved.ops.len(),
+            if saved.values_input_hashes.is_empty() {
+                String::new()
+            } else {
+                format!(", {} values hash(es) verified", saved.values_input_hashes.len())
+            }
+        );
     }
 
     if summary.actionable_count() == 0 {
@@ -460,6 +495,75 @@ fn warn_on_plan_metadata(plan: &PlanFile) {
             age.num_hours(),
         );
     }
+}
+
+/// Compare the saved plan's `values_input_hashes` against the
+/// freshly-computed hashes (RFC §4 Phase 6). Reuses `Error::PlanDrift`
+/// (exit 7) because the user-facing remedy is identical to ops drift:
+/// regenerate the plan with `diff --plan-out` and review.
+///
+/// Pre-v0.14 plan files have an empty `values_input_hashes` map; we
+/// treat that as "plan pre-dates the values hash feature, skip the
+/// integrity check" instead of forcing a regenerate.
+fn check_plan_values_hashes(
+    saved: &PlanFile,
+    fresh: &std::collections::BTreeMap<String, String>,
+) -> anyhow::Result<()> {
+    if saved.values_input_hashes.is_empty() {
+        return Ok(());
+    }
+    let mut mismatches: Vec<String> = Vec::new();
+    let mut missing_in_fresh: Vec<String> = Vec::new();
+    for (key, saved_hash) in &saved.values_input_hashes {
+        match fresh.get(key) {
+            Some(fresh_hash) if fresh_hash == saved_hash => {}
+            Some(_) => mismatches.push(key.clone()),
+            None => missing_in_fresh.push(key.clone()),
+        }
+    }
+    let extra: Vec<String> = fresh
+        .keys()
+        .filter(|k| !saved.values_input_hashes.contains_key(*k))
+        .cloned()
+        .collect();
+
+    if mismatches.is_empty() && missing_in_fresh.is_empty() && extra.is_empty() {
+        return Ok(());
+    }
+
+    eprintln!("✗ plan drift: values inputs changed since plan was generated");
+    if !mismatches.is_empty() {
+        eprintln!("  consumed values changed for:");
+        for k in &mismatches {
+            eprintln!("    - {k}");
+        }
+        // Heuristic: if many resources mismatch at once it's almost
+        // always a globals.custom edit fanning out to every consumer.
+        // Surface that hint so the operator looks in the right place.
+        if mismatches.len() > 1 {
+            eprintln!(
+                "  hint: {} resources changed simultaneously — likely a `globals.custom.<key>` \
+                 edit that affects every consumer (RFC §4 Phase 6)",
+                mismatches.len()
+            );
+        }
+    }
+    if !missing_in_fresh.is_empty() {
+        eprintln!(
+            "  resources in saved plan but no fresh hash (placeholders removed?):"
+        );
+        for k in &missing_in_fresh {
+            eprintln!("    - {k}");
+        }
+    }
+    if !extra.is_empty() {
+        eprintln!("  resources with fresh hashes not in saved plan (placeholders added?):");
+        for k in &extra {
+            eprintln!("    - {k}");
+        }
+    }
+    eprintln!("  → regenerate with `diff --plan-out` and review before re-applying");
+    Err(Error::PlanDrift.into())
 }
 
 /// Compare the saved plan's ops against the freshly-computed summary.

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -23,8 +23,8 @@ use crate::format::OutputFormat;
 use crate::fs::{catalog_io, content_block_io, custom_attribute_io, email_template_io, tag_io};
 use crate::resource::{Catalog, ContentBlock, EmailTemplate, ResourceKind};
 use crate::values::{
-    preflight_values, resolve_content_block_in_place, resolve_email_template_in_place,
-    PreflightArgs, ValuesFile,
+    compute_values_input_hashes, preflight_values, resolve_content_block_in_place,
+    resolve_email_template_in_place, PreflightArgs, ValuesFile,
 };
 use anyhow::Context as _;
 use clap::Args;
@@ -101,7 +101,8 @@ pub async fn run(
     })?;
 
     let mut summary = DiffSummary::default();
-    for kind in kinds {
+    for kind in &kinds {
+        let kind = *kind;
         if warn_if_name_excluded(kind, args.name.as_deref(), resolved.excludes_for(kind)) {
             continue;
         }
@@ -170,18 +171,42 @@ pub async fn run(
     print!("{formatted}");
 
     if let Some(path) = &args.plan_out {
-        let plan = PlanFile::from_summary(
+        let mut plan = PlanFile::from_summary(
             &summary,
             resolved.environment_name.clone(),
             args.resource,
             args.name.clone(),
             args.archive_orphans,
         );
+        // RFC §4 Phase 6: record the per-resource consumed-values
+        // hash so apply --plan can detect a values edit (including
+        // a fan-out global edit) that happened between plan and apply.
+        plan.values_input_hashes = compute_values_input_hashes(
+            PreflightArgs {
+                config_dir,
+                resolved: &resolved,
+                content_blocks_root: &content_blocks_root,
+                email_templates_root: &email_templates_root,
+                kinds: &kinds,
+                cb_name_filter: args
+                    .name
+                    .as_deref()
+                    .filter(|_| args.resource == Some(ResourceKind::ContentBlock)),
+                et_name_filter: args
+                    .name
+                    .as_deref()
+                    .filter(|_| args.resource == Some(ResourceKind::EmailTemplate)),
+                cb_excludes: resolved.excludes_for(ResourceKind::ContentBlock),
+                et_excludes: resolved.excludes_for(ResourceKind::EmailTemplate),
+            },
+            values.as_ref(),
+        )?;
         plan.write_to(path)
             .with_context(|| format!("writing plan file to {}", path.display()))?;
         eprintln!(
-            "✓ Wrote plan ({} op(s)) to {}",
+            "✓ Wrote plan ({} op(s), {} values-hash entry(ies)) to {}",
             plan.ops.len(),
+            plan.values_input_hashes.len(),
             path.display()
         );
     }

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -6,6 +6,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::diff::custom_attribute::CustomAttributeOp;
@@ -24,6 +25,21 @@ pub struct PlanFile {
     pub braze_sync_version: String,
     pub scope: PlanScope,
     pub ops: Vec<PlanOp>,
+    /// Per-resource hash of the subset of `values/<env>.yaml` that
+    /// the resource's templated body consumes (RFC §4 Phase 6).
+    /// Keys are `"<kind>/<name>"`, values are blake3 hex digests.
+    /// Compared at `apply --plan` time so that values edits made
+    /// between plan and apply (including non-obvious global edits
+    /// that fan out to many resources) trigger `Error::PlanDrift`
+    /// instead of silently shipping different values than reviewed.
+    ///
+    /// `#[serde(default)]` keeps old plan files (pre-v0.14)
+    /// readable: a missing field deserializes as an empty map, and
+    /// `apply --plan` treats an empty saved-hashes map as "plan
+    /// pre-dates the values hash feature, skip the integrity
+    /// check" (the saved ops + scope checks still run).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub values_input_hashes: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -82,6 +98,7 @@ impl PlanFile {
                 archive_orphans,
             },
             ops: collect_ops(summary),
+            values_input_hashes: BTreeMap::new(),
         }
     }
 
@@ -232,6 +249,7 @@ mod tests {
                 op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
                 op(ResourceKind::CatalogSchema, "x", PlanOpType::Add),
             ],
+            values_input_hashes: BTreeMap::new(),
         };
         let fresh = vec![
             op(ResourceKind::CatalogSchema, "x", PlanOpType::Add),
@@ -253,6 +271,7 @@ mod tests {
                 archive_orphans: false,
             },
             ops: vec![op(ResourceKind::ContentBlock, "a", PlanOpType::Modify)],
+            values_input_hashes: BTreeMap::new(),
         };
         let fresh = vec![op(ResourceKind::ContentBlock, "a", PlanOpType::Orphan)];
         let diff = plan.diff_ops(&fresh);
@@ -280,6 +299,7 @@ mod tests {
                 op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
                 op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
             ],
+            values_input_hashes: BTreeMap::new(),
         };
         let fresh_dup = vec![
             op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
@@ -307,6 +327,7 @@ mod tests {
                 archive_orphans: true,
             },
             ops: vec![op(ResourceKind::ContentBlock, "hero", PlanOpType::Add)],
+            values_input_hashes: BTreeMap::new(),
         };
         let json = serde_json::to_string(&plan).unwrap();
         let round: PlanFile = serde_json::from_str(&json).unwrap();

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -323,6 +323,142 @@ pub fn preflight_values(args: PreflightArgs<'_>) -> Result<Option<ValuesFile>> {
     Ok(values)
 }
 
+/// Compute per-resource "consumed values" hashes for plan-lock
+/// integrity checking (RFC §4 Phase 6).
+///
+/// For each placeholder-bearing local resource we extract the
+/// `(type, key)` pairs from the templated body, look up each in the
+/// values file using the same namespace rules as
+/// `resolve_*_in_place`, build a stable `BTreeMap<String, String>`
+/// of consumed entries, serialize via `serde_json`, and blake3-hash
+/// the resulting bytes.
+///
+/// Returned map keys are `"<kind>/<name>"` so the plan file's JSON
+/// representation has stable, grep-able keys; values are blake3 hex
+/// digests (64 chars).
+///
+/// blake3 vs the RFC's "SHA-256": both are 32-byte cryptographic
+/// digests, both deterministic, both already collision-resistant for
+/// this scale. blake3 is already a transitive dep (used by catalog
+/// items diffing), so we keep the dep surface minimal and document
+/// the choice here.
+pub fn compute_values_input_hashes(
+    args: PreflightArgs<'_>,
+    values: Option<&ValuesFile>,
+) -> Result<BTreeMap<String, String>> {
+    use crate::resource::ResourceKind;
+
+    let has_cb = args.kinds.contains(&ResourceKind::ContentBlock);
+    let has_et = args.kinds.contains(&ResourceKind::EmailTemplate);
+    if !has_cb && !has_et {
+        return Ok(BTreeMap::new());
+    }
+
+    let mut hashes: BTreeMap<String, String> = BTreeMap::new();
+
+    if has_cb && args.content_blocks_root.exists() {
+        let mut locals =
+            crate::fs::content_block_io::load_all_content_blocks(args.content_blocks_root)
+                .map_err(|e| Error::Config(format!("loading content_block locals: {e}")))?;
+        if let Some(name) = args.cb_name_filter {
+            locals.retain(|c| c.name == name);
+        }
+        locals.retain(|c| !crate::config::is_excluded(&c.name, args.cb_excludes));
+        for cb in locals {
+            if !body_has_placeholders(&cb.content) {
+                continue;
+            }
+            let consumed = consumed_for_content_block(&cb, values);
+            let key = format!("content_block/{}", cb.name);
+            hashes.insert(key, hash_consumed_map(&consumed));
+        }
+    }
+
+    if has_et && args.email_templates_root.exists() {
+        let mut locals =
+            crate::fs::email_template_io::load_all_email_templates(args.email_templates_root)
+                .map_err(|e| Error::Config(format!("loading email_template locals: {e}")))?;
+        if let Some(name) = args.et_name_filter {
+            locals.retain(|t| t.name == name);
+        }
+        locals.retain(|t| !crate::config::is_excluded(&t.name, args.et_excludes));
+        for et in locals {
+            let any_ph = body_has_placeholders(&et.subject)
+                || body_has_placeholders(&et.body_html)
+                || body_has_placeholders(&et.body_plaintext)
+                || et
+                    .preheader
+                    .as_deref()
+                    .is_some_and(body_has_placeholders);
+            if !any_ph {
+                continue;
+            }
+            let consumed = consumed_for_email_template(&et, values);
+            let key = format!("email_template/{}", et.name);
+            hashes.insert(key, hash_consumed_map(&consumed));
+        }
+    }
+
+    Ok(hashes)
+}
+
+fn consumed_for_content_block(
+    cb: &crate::resource::ContentBlock,
+    values: Option<&ValuesFile>,
+) -> BTreeMap<String, String> {
+    let lookup = build_content_block_lookup(&cb.name, values);
+    let mut consumed: BTreeMap<String, String> = BTreeMap::new();
+    for ph in crate::values::placeholder::extract_placeholders(&cb.content) {
+        let lk = (ph.ty, ph.key.clone());
+        if let Some(v) = lookup.get(&lk) {
+            consumed.insert(format!("{}.{}", ph.ty.as_str(), ph.key), v.clone());
+        }
+    }
+    consumed
+}
+
+fn consumed_for_email_template(
+    et: &crate::resource::EmailTemplate,
+    values: Option<&ValuesFile>,
+) -> BTreeMap<String, String> {
+    // Field-prefix the key so two fields that reference the same
+    // (type, key) but resolve to different per-field values don't
+    // collapse to a single BTreeMap entry. The hash must distinguish
+    // them — apply later resolves field-scoped, so plan and apply
+    // need the same view.
+    let mut consumed: BTreeMap<String, String> = BTreeMap::new();
+    for (field_name, body) in [
+        ("subject", et.subject.as_str()),
+        ("body_html", et.body_html.as_str()),
+        ("body_plaintext", et.body_plaintext.as_str()),
+        ("preheader", et.preheader.as_deref().unwrap_or("")),
+    ] {
+        if !body_has_placeholders(body) {
+            continue;
+        }
+        let lookup = build_email_template_lookup(&et.name, field_name, values);
+        for ph in crate::values::placeholder::extract_placeholders(body) {
+            let lk = (ph.ty, ph.key.clone());
+            if let Some(v) = lookup.get(&lk) {
+                consumed.insert(
+                    format!("{field_name}.{}.{}", ph.ty.as_str(), ph.key),
+                    v.clone(),
+                );
+            }
+        }
+    }
+    consumed
+}
+
+fn hash_consumed_map(consumed: &BTreeMap<String, String>) -> String {
+    // BTreeMap iteration is sorted, so serde_json::to_vec produces a
+    // stable byte stream. We accept the unwrap because BTreeMap of
+    // primitives can't fail serialization.
+    let bytes =
+        serde_json::to_vec(consumed).expect("BTreeMap<String, String> serialization is infallible");
+    blake3::hash(&bytes).to_hex().to_string()
+}
+
 /// Format aggregated failures into a single human-readable error.
 /// Adds the "values file missing" hint when `values_loaded == false` so
 /// the operator immediately knows where to look.

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -386,10 +386,7 @@ pub fn compute_values_input_hashes(
             let any_ph = body_has_placeholders(&et.subject)
                 || body_has_placeholders(&et.body_html)
                 || body_has_placeholders(&et.body_plaintext)
-                || et
-                    .preheader
-                    .as_deref()
-                    .is_some_and(body_has_placeholders);
+                || et.preheader.as_deref().is_some_and(body_has_placeholders);
             if !any_ph {
                 continue;
             }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -27,8 +27,9 @@ pub use correlation::{
 pub use exporter::{refresh_content_block_values, refresh_email_template_values, ExportUpdates};
 
 pub use integration::{
-    format_failures, load_values_for_env, preflight_values, resolve_content_block_in_place,
-    resolve_email_template_in_place, values_file_path, PreflightArgs, ResolutionFailure,
+    compute_values_input_hashes, format_failures, load_values_for_env, preflight_values,
+    resolve_content_block_in_place, resolve_email_template_in_place, values_file_path,
+    PreflightArgs, ResolutionFailure,
 };
 
 pub use placeholder::{

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -279,3 +279,192 @@ async fn apply_plan_archive_orphans_mismatch_exits_7_before_api_call() {
     .await
     .unwrap();
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn plan_lock_aborts_when_consumed_values_change_between_plan_and_apply() {
+    // RFC §4 Phase 6: editing values/<env>.yaml after diff --plan-out
+    // must abort apply --plan with PlanDrift (exit 7), before any
+    // mutation hits Braze.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0) // No POST may fire on plan drift.
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    common::write_local_content_block(
+        tmp.path(),
+        "promo",
+        "cta=__BRAZESYNC.lid.cta__\n",
+    );
+    common::write_values_file(
+        tmp.path(),
+        "test",
+        r#"version: 1
+content_block:
+  promo:
+    lid:
+      cta:
+        value: oldlidvalue1
+        url: https://example.com/cta
+"#,
+    );
+
+    let plan_path = tmp.path().join("plan.json");
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_str = config_path.to_str().unwrap().to_string();
+    let plan_out_clone = plan_out.clone();
+    let config_str_clone = config_str.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", &config_str_clone])
+            .args(["diff", "--resource", "content_block", &plan_out_clone])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    // Edit the values file after the plan has been written.
+    common::write_values_file(
+        tmp.path(),
+        "test",
+        r#"version: 1
+content_block:
+  promo:
+    lid:
+      cta:
+        value: tamperedlid
+        url: https://example.com/cta
+"#,
+    );
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    let assert = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", &config_str])
+            .args(["apply", "--resource", "content_block", "--confirm", &plan_in])
+            .assert()
+            .failure()
+            .code(7)
+    })
+    .await
+    .unwrap();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("plan drift")
+            && (stderr.contains("values inputs changed")
+                || stderr.contains("consumed values")),
+        "expected plan-drift values message, got:\n{stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn plan_lock_passes_when_unrelated_values_key_changes() {
+    // Editing a values key that no resource currently references
+    // (orphan in one resource's plan world) must NOT trigger
+    // plan-drift abort. The hash is per-resource over its CONSUMED
+    // subset.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/create"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_block_id": "new-id-1",
+            "message": "success"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    common::write_local_content_block(
+        tmp.path(),
+        "promo",
+        "cta=__BRAZESYNC.lid.cta__\n",
+    );
+    // Two entries; only `cta` is consumed by the placeholder.
+    common::write_values_file(
+        tmp.path(),
+        "test",
+        r#"version: 1
+content_block:
+  promo:
+    lid:
+      cta:
+        value: stableidvalue
+        url: https://example.com/cta
+      unused:
+        value: othervaluexxx
+        url: https://example.com/unused
+"#,
+    );
+
+    let plan_path = tmp.path().join("plan.json");
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_str = config_path.to_str().unwrap().to_string();
+    let plan_out_clone = plan_out.clone();
+    let config_str_clone = config_str.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", &config_str_clone])
+            .args(["diff", "--resource", "content_block", &plan_out_clone])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    // Edit only the *unused* entry. The plan-lock hash for `promo`
+    // must not change because `unused` is not in its consumed set.
+    common::write_values_file(
+        tmp.path(),
+        "test",
+        r#"version: 1
+content_block:
+  promo:
+    lid:
+      cta:
+        value: stableidvalue
+        url: https://example.com/cta
+      unused:
+        value: editedvaluexx
+        url: https://example.com/unused
+"#,
+    );
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", &config_str])
+            .args(["apply", "--resource", "content_block", "--confirm", &plan_in])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -301,11 +301,7 @@ async fn plan_lock_aborts_when_consumed_values_change_between_plan_and_apply() {
 
     let tmp = tempfile::tempdir().unwrap();
     let config_path = write_config(tmp.path(), &server.uri());
-    common::write_local_content_block(
-        tmp.path(),
-        "promo",
-        "cta=__BRAZESYNC.lid.cta__\n",
-    );
+    common::write_local_content_block(tmp.path(), "promo", "cta=__BRAZESYNC.lid.cta__\n");
     common::write_values_file(
         tmp.path(),
         "test",
@@ -356,7 +352,13 @@ content_block:
             .unwrap()
             .env("BRAZE_API_KEY", "test-key")
             .args(["--config", &config_str])
-            .args(["apply", "--resource", "content_block", "--confirm", &plan_in])
+            .args([
+                "apply",
+                "--resource",
+                "content_block",
+                "--confirm",
+                &plan_in,
+            ])
             .assert()
             .failure()
             .code(7)
@@ -366,8 +368,7 @@ content_block:
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
     assert!(
         stderr.contains("plan drift")
-            && (stderr.contains("values inputs changed")
-                || stderr.contains("consumed values")),
+            && (stderr.contains("values inputs changed") || stderr.contains("consumed values")),
         "expected plan-drift values message, got:\n{stderr}"
     );
 }
@@ -398,11 +399,7 @@ async fn plan_lock_passes_when_unrelated_values_key_changes() {
 
     let tmp = tempfile::tempdir().unwrap();
     let config_path = write_config(tmp.path(), &server.uri());
-    common::write_local_content_block(
-        tmp.path(),
-        "promo",
-        "cta=__BRAZESYNC.lid.cta__\n",
-    );
+    common::write_local_content_block(tmp.path(), "promo", "cta=__BRAZESYNC.lid.cta__\n");
     // Two entries; only `cta` is consumed by the placeholder.
     common::write_values_file(
         tmp.path(),
@@ -461,7 +458,13 @@ content_block:
             .unwrap()
             .env("BRAZE_API_KEY", "test-key")
             .args(["--config", &config_str])
-            .args(["apply", "--resource", "content_block", "--confirm", &plan_in])
+            .args([
+                "apply",
+                "--resource",
+                "content_block",
+                "--confirm",
+                &plan_in,
+            ])
             .assert()
             .success();
     })
@@ -498,11 +501,7 @@ async fn plan_lock_scoped_resource_ignores_other_kind_placeholders() {
 
     let tmp = tempfile::tempdir().unwrap();
     let config_path = write_config(tmp.path(), &server.uri());
-    common::write_local_content_block(
-        tmp.path(),
-        "promo",
-        "cta=__BRAZESYNC.lid.cta__\n",
-    );
+    common::write_local_content_block(tmp.path(), "promo", "cta=__BRAZESYNC.lid.cta__\n");
     // Out-of-scope email_template with placeholders. Apply must not
     // hash it when --resource content_block restricts the kind set.
     common::write_local_email_template(
@@ -548,7 +547,13 @@ content_block:
             .unwrap()
             .env("BRAZE_API_KEY", "test-key")
             .args(["--config", &config_str])
-            .args(["apply", "--resource", "content_block", "--confirm", &plan_in])
+            .args([
+                "apply",
+                "--resource",
+                "content_block",
+                "--confirm",
+                &plan_in,
+            ])
             .assert()
             .success();
     })

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -468,3 +468,90 @@ content_block:
     .await
     .unwrap();
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn plan_lock_scoped_resource_ignores_other_kind_placeholders() {
+    // Regression: when `diff --resource content_block --plan-out` and
+    // `apply --resource content_block --plan` run against a repo that
+    // also contains a placeholder-bearing email_template on disk, the
+    // apply-side hash recomputation must use the same kinds as the
+    // saved plan (here: [content_block] only). Otherwise it would hash
+    // the out-of-scope email_template and `check_plan_values_hashes`
+    // would report it as `extra` → spurious PlanDrift exit 7.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/create"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_block_id": "new-id-1",
+            "message": "success"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    common::write_local_content_block(
+        tmp.path(),
+        "promo",
+        "cta=__BRAZESYNC.lid.cta__\n",
+    );
+    // Out-of-scope email_template with placeholders. Apply must not
+    // hash it when --resource content_block restricts the kind set.
+    common::write_local_email_template(
+        tmp.path(),
+        "welcome",
+        "subj=__BRAZESYNC.lid.headline__",
+        "<p>hi __BRAZESYNC.lid.headline__</p>",
+        "hi __BRAZESYNC.lid.headline__",
+    );
+    common::write_values_file(
+        tmp.path(),
+        "test",
+        r#"version: 1
+content_block:
+  promo:
+    lid:
+      cta:
+        value: stableidvalue
+        url: https://example.com/cta
+"#,
+    );
+
+    let plan_path = tmp.path().join("plan.json");
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_str = config_path.to_str().unwrap().to_string();
+    let plan_out_clone = plan_out.clone();
+    let config_str_clone = config_str.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", &config_str_clone])
+            .args(["diff", "--resource", "content_block", &plan_out_clone])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", &config_str])
+            .args(["apply", "--resource", "content_block", "--confirm", &plan_in])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
## Summary

Closes RFC §4 Phase 6. Per-resource consumed-values hashes now ride along inside the plan file, so editing `values/<env>.yaml` (including a fan-out `globals.custom.<key>` edit) between `diff --plan-out` and `apply --plan` is caught with `Error::PlanDrift` / exit 7 instead of silently shipping a different value than the operator reviewed.

## What changes

- **`PlanFile.values_input_hashes: BTreeMap<String, String>`**
  Keys = `"<kind>/<name>"`, values = blake3 hex digests. `#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]` keeps pre-v0.14 plans compact and forward-compatible — a missing field deserializes as empty and `apply --plan` simply skips the new integrity gate on those.
- **`values::compute_values_input_hashes(args, values)`**
  Walks every selected kind's local templates, extracts placeholders, looks each up in `values` using the same per-RFC §2.2 namespace rules as the resolver, builds a stable `BTreeMap<String, String>` of the consumed subset, and hashes its JSON byte stream with blake3 (already in the dep tree; equivalent to SHA-256 for this purpose, and noted in code).
- Email_template fields prefix the consumed key (`"subject.lid.cta"`, `"body_html.lid.cta"`) so two fields that share `(type, key)` but resolve to different per-field values don't collapse in the BTreeMap.
- **`cli/diff.rs`** fills `values_input_hashes` whenever `--plan-out` is set.
- **`cli/apply.rs`** recomputes and compares via the new `check_plan_values_hashes`. Reuses `Error::PlanDrift` / exit 7 because the operator remedy is identical to ops-drift (rerun `diff --plan-out` and review). When multiple resources mismatch simultaneously, the abort message hints at a `globals.custom.<key>` edit — RFC's operational note about fan-out.

## Tests

- 2 new wiremock E2E tests in `tests/cli_plan_lock.rs`:
  - `plan_lock_aborts_when_consumed_values_change_between_plan_and_apply` — edits the values file after `--plan-out`, asserts exit 7, zero POSTs (via `.expect(0)` on all POST mocks), and a values-drift message in stderr.
  - `plan_lock_passes_when_unrelated_values_key_changes` — edits a values entry that no placeholder consumes; apply must still succeed (per-resource consumed subset semantics).
- **515 passing**, `cargo clippy --all-targets -- -D warnings` clean.

## Follow-up

- Phase 7: `docs/per-env-values.md` + README + v0.14.0 CHANGELOG (only doc work left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan files now store integrity hashes of consumed values; applying a saved plan verifies values haven't changed since generation.

* **Bug Fixes**
  * Apply now detects and prevents execution when values inputs drift, aborting with clear guidance to regenerate the plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->