### PR TITLE
feat: surface suspicious placeholders and abort on duplicate lid keys

### DIFF
--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -16,8 +16,7 @@ use crate::config::ResolvedConfig;
 use crate::error::{Error, Result};
 use crate::resource::{ContentBlock, EmailTemplate};
 use crate::values::placeholder::{
-    find_suspicious_placeholders, resolve_placeholders, LookupKey, PlaceholderType,
-    ResolutionError,
+    find_suspicious_placeholders, resolve_placeholders, LookupKey, PlaceholderType, ResolutionError,
 };
 use crate::values::schema::{default_values_path, ValuesFile};
 
@@ -239,12 +238,7 @@ fn build_email_template_lookup(
 /// (missing E) or unknown types like `__BRAZESYNC.url.foo__` don't pass
 /// through silently. These wouldn't trigger the unresolved-key abort
 /// because the strict extractor returns nothing for them.
-fn warn_suspicious(
-    kind: &str,
-    name: &str,
-    field: Option<&str>,
-    suspicious: Vec<String>,
-) {
+fn warn_suspicious(kind: &str, name: &str, field: Option<&str>, suspicious: Vec<String>) {
     if suspicious.is_empty() {
         return;
     }

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -526,10 +526,16 @@ pub fn format_failures(
                         key,
                     ));
                 }
-                ResolutionError::DuplicateLidKey { key, count } => {
+                ResolutionError::DuplicateLidKey { key, occurrences } => {
+                    let offsets = occurrences
+                        .iter()
+                        .map(|o| o.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ");
                     msg.push_str(&format!(
-                        "    - __BRAZESYNC.lid.{key}__ referenced {count} times; lid IDs \
-                         are per-click-context — use a distinct key per occurrence\n",
+                        "    - __BRAZESYNC.lid.{key}__ referenced {} times (offsets {offsets}); \
+                         lid IDs are per-click-context — use a distinct key per occurrence\n",
+                        occurrences.len(),
                     ));
                 }
             }

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -16,7 +16,8 @@ use crate::config::ResolvedConfig;
 use crate::error::{Error, Result};
 use crate::resource::{ContentBlock, EmailTemplate};
 use crate::values::placeholder::{
-    resolve_placeholders, LookupKey, PlaceholderType, ResolutionError,
+    find_suspicious_placeholders, resolve_placeholders, LookupKey, PlaceholderType,
+    ResolutionError,
 };
 use crate::values::schema::{default_values_path, ValuesFile};
 
@@ -233,6 +234,32 @@ fn build_email_template_lookup(
     out
 }
 
+/// RFC §2.3: surface envelope-shaped tokens that don't match the strict
+/// placeholder grammar as warnings, so typos like `__BRAZSYNC.lid.foo__`
+/// (missing E) or unknown types like `__BRAZESYNC.url.foo__` don't pass
+/// through silently. These wouldn't trigger the unresolved-key abort
+/// because the strict extractor returns nothing for them.
+fn warn_suspicious(
+    kind: &str,
+    name: &str,
+    field: Option<&str>,
+    suspicious: Vec<String>,
+) {
+    if suspicious.is_empty() {
+        return;
+    }
+    let scope = match field {
+        Some(f) => format!("{kind} '{name}' ({f})"),
+        None => format!("{kind} '{name}'"),
+    };
+    for s in suspicious {
+        eprintln!(
+            "WARN: {scope}: suspicious placeholder `{s}` — strict form is \
+             __BRAZESYNC.<lid|cb_id|custom|global>.<key>__"
+        );
+    }
+}
+
 fn insert_globals(out: &mut BTreeMap<LookupKey, String>, vf: &ValuesFile) {
     for (k, e) in &vf.globals.custom {
         if let Some(v) = &e.value {
@@ -293,6 +320,12 @@ pub fn preflight_values(args: PreflightArgs<'_>) -> Result<Option<ValuesFile>> {
         }
         locals.retain(|c| !crate::config::is_excluded(&c.name, args.cb_excludes));
         for mut cb in locals {
+            warn_suspicious(
+                "content_block",
+                &cb.name,
+                None,
+                find_suspicious_placeholders(&cb.content),
+            );
             if let Err(f) = resolve_content_block_in_place(&mut cb, values.as_ref()) {
                 failures.push(f);
             }
@@ -308,6 +341,19 @@ pub fn preflight_values(args: PreflightArgs<'_>) -> Result<Option<ValuesFile>> {
         }
         locals.retain(|t| !crate::config::is_excluded(&t.name, args.et_excludes));
         for mut t in locals {
+            for (field, body) in [
+                ("subject", t.subject.as_str()),
+                ("body_html", t.body_html.as_str()),
+                ("body_plaintext", t.body_plaintext.as_str()),
+                ("preheader", t.preheader.as_deref().unwrap_or("")),
+            ] {
+                warn_suspicious(
+                    "email_template",
+                    &t.name,
+                    Some(field),
+                    find_suspicious_placeholders(body),
+                );
+            }
             if let Err(per_field_failures) =
                 resolve_email_template_in_place(&mut t, values.as_ref())
             {
@@ -484,6 +530,12 @@ pub fn format_failures(
                         start,
                         ty.as_str(),
                         key,
+                    ));
+                }
+                ResolutionError::DuplicateLidKey { key, count } => {
+                    msg.push_str(&format!(
+                        "    - __BRAZESYNC.lid.{key}__ referenced {count} times; lid IDs \
+                         are per-click-context — use a distinct key per occurrence\n",
                     ));
                 }
             }

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -134,13 +134,9 @@ pub fn find_suspicious_placeholders(body: &str) -> Vec<String> {
     loose_re()
         .find_iter(body)
         .filter(|m| {
-            // Exclude loose matches that overlap any strict span. The greedy
-            // loose regex can extend past a valid `__...__` envelope into
-            // adjacent text (e.g. trailing `__bold__` markdown, or two
-            // adjacent placeholders sharing `____`), producing a span that
-            // is neither equal to nor disjoint from the real placeholder.
-            // Any overlap means the region is already accounted for by the
-            // strict pass and is not suspicious.
+            // Overlap (not equality) — the greedy loose regex can extend past
+            // a valid envelope into adjacent `__...__` text. See regression
+            // tests below.
             !strict_spans
                 .iter()
                 .any(|&(s, e)| m.start() < e && s < m.end())
@@ -183,8 +179,6 @@ pub fn resolve_placeholders(
     let placeholders = extract_placeholders(body);
     let mut errors = Vec::new();
 
-    // RFC §5: lid re-use within one body is conceptually wrong. Detect
-    // and surface as an aggregated failure (deterministic key order).
     let mut lid_counts: BTreeMap<String, usize> = BTreeMap::new();
     for ph in &placeholders {
         if matches!(ph.ty, PlaceholderType::Lid) {
@@ -351,7 +345,6 @@ mod tests {
 
     #[test]
     fn duplicate_lid_aborts_with_dedicated_error() {
-        // RFC §5: same lid key referenced twice in one body must abort.
         let body = "<a>__BRAZESYNC.lid.cta__</a> <a>__BRAZESYNC.lid.cta__</a>";
         let map = lookup(&[(PlaceholderType::Lid, "cta", "ai8kexrxcp03")]);
         let err = resolve_placeholders(body, &map).unwrap_err();

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -161,10 +161,7 @@ pub enum ResolutionError {
     /// Same `lid` key referenced more than once in a single body / field.
     /// RFC §5 edge case: lid is a per-click-context ID so re-use is
     /// conceptually wrong — abort rather than substitute the same value.
-    DuplicateLidKey {
-        key: String,
-        count: usize,
-    },
+    DuplicateLidKey { key: String, count: usize },
 }
 
 /// Flat key for the resolver's lookup table.

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -157,7 +157,12 @@ pub enum ResolutionError {
     /// Same `lid` key referenced more than once in a single body / field.
     /// RFC §5 edge case: lid is a per-click-context ID so re-use is
     /// conceptually wrong — abort rather than substitute the same value.
-    DuplicateLidKey { key: String, count: usize },
+    /// `occurrences` holds the byte offsets of every reference so the
+    /// failure report can point operators at the duplicates directly.
+    DuplicateLidKey {
+        key: String,
+        occurrences: Vec<usize>,
+    },
 }
 
 /// Flat key for the resolver's lookup table.
@@ -179,15 +184,18 @@ pub fn resolve_placeholders(
     let placeholders = extract_placeholders(body);
     let mut errors = Vec::new();
 
-    let mut lid_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut lid_occurrences: BTreeMap<String, Vec<usize>> = BTreeMap::new();
     for ph in &placeholders {
         if matches!(ph.ty, PlaceholderType::Lid) {
-            *lid_counts.entry(ph.key.clone()).or_insert(0) += 1;
+            lid_occurrences
+                .entry(ph.key.clone())
+                .or_default()
+                .push(ph.start);
         }
     }
-    for (key, count) in lid_counts {
-        if count > 1 {
-            errors.push(ResolutionError::DuplicateLidKey { key, count });
+    for (key, occurrences) in lid_occurrences {
+        if occurrences.len() > 1 {
+            errors.push(ResolutionError::DuplicateLidKey { key, occurrences });
         }
     }
 
@@ -350,7 +358,8 @@ mod tests {
         let err = resolve_placeholders(body, &map).unwrap_err();
         assert!(err.iter().any(|e| matches!(
             e,
-            ResolutionError::DuplicateLidKey { key, count } if key == "cta" && *count == 2
+            ResolutionError::DuplicateLidKey { key, occurrences }
+                if key == "cta" && occurrences.len() == 2
         )));
     }
 

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -151,6 +151,13 @@ pub enum ResolutionError {
         key: String,
         start: usize,
     },
+    /// Same `lid` key referenced more than once in a single body / field.
+    /// RFC §5 edge case: lid is a per-click-context ID so re-use is
+    /// conceptually wrong — abort rather than substitute the same value.
+    DuplicateLidKey {
+        key: String,
+        count: usize,
+    },
 }
 
 /// Flat key for the resolver's lookup table.
@@ -171,6 +178,20 @@ pub fn resolve_placeholders(
 ) -> Result<String, Vec<ResolutionError>> {
     let placeholders = extract_placeholders(body);
     let mut errors = Vec::new();
+
+    // RFC §5: lid re-use within one body is conceptually wrong. Detect
+    // and surface as an aggregated failure (deterministic key order).
+    let mut lid_counts: BTreeMap<String, usize> = BTreeMap::new();
+    for ph in &placeholders {
+        if matches!(ph.ty, PlaceholderType::Lid) {
+            *lid_counts.entry(ph.key.clone()).or_insert(0) += 1;
+        }
+    }
+    for (key, count) in lid_counts {
+        if count > 1 {
+            errors.push(ResolutionError::DuplicateLidKey { key, count });
+        }
+    }
 
     for ph in &placeholders {
         let key: LookupKey = (ph.ty, ph.key.clone());
@@ -287,6 +308,7 @@ mod tests {
             .iter()
             .map(|e| match e {
                 ResolutionError::UnknownKey { ty, key, .. } => (*ty, key.clone()),
+                ResolutionError::DuplicateLidKey { .. } => unreachable!(),
             })
             .collect();
         assert!(keys.contains(&(PlaceholderType::CbId, "b".to_string())));
@@ -302,6 +324,27 @@ mod tests {
             end: 0,
         };
         assert_eq!(ph.literal(), "__BRAZESYNC.cb_id.cb_hero__");
+    }
+
+    #[test]
+    fn duplicate_lid_aborts_with_dedicated_error() {
+        // RFC §5: same lid key referenced twice in one body must abort.
+        let body = "<a>__BRAZESYNC.lid.cta__</a> <a>__BRAZESYNC.lid.cta__</a>";
+        let map = lookup(&[(PlaceholderType::Lid, "cta", "ai8kexrxcp03")]);
+        let err = resolve_placeholders(body, &map).unwrap_err();
+        assert!(err.iter().any(|e| matches!(
+            e,
+            ResolutionError::DuplicateLidKey { key, count } if key == "cta" && *count == 2
+        )));
+    }
+
+    #[test]
+    fn duplicate_cb_id_is_not_an_error() {
+        // cb_id / custom / global re-use is normal substitution per §5.
+        let body = "{{cb.__BRAZESYNC.cb_id.x__}} {{cb.__BRAZESYNC.cb_id.x__}}";
+        let map = lookup(&[(PlaceholderType::CbId, "x", "cb42")]);
+        let out = resolve_placeholders(body, &map).unwrap();
+        assert_eq!(out, "{{cb.cb42}} {{cb.cb42}}");
     }
 
     #[test]

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -134,9 +134,16 @@ pub fn find_suspicious_placeholders(body: &str) -> Vec<String> {
     loose_re()
         .find_iter(body)
         .filter(|m| {
+            // Exclude loose matches that overlap any strict span. The greedy
+            // loose regex can extend past a valid `__...__` envelope into
+            // adjacent text (e.g. trailing `__bold__` markdown, or two
+            // adjacent placeholders sharing `____`), producing a span that
+            // is neither equal to nor disjoint from the real placeholder.
+            // Any overlap means the region is already accounted for by the
+            // strict pass and is not suspicious.
             !strict_spans
                 .iter()
-                .any(|&(s, e)| s == m.start() && e == m.end())
+                .any(|&(s, e)| m.start() < e && s < m.end())
         })
         .map(|m| m.as_str().to_string())
         .collect()
@@ -273,6 +280,25 @@ mod tests {
     #[test]
     fn suspicious_excludes_strict_matches() {
         let body = "__BRAZESYNC.lid.ok__";
+        assert!(find_suspicious_placeholders(body).is_empty());
+    }
+
+    #[test]
+    fn suspicious_ignores_trailing_double_underscore_text() {
+        // Regression: greedy loose regex extends past a valid placeholder
+        // into `__bold__`-style adjacent text and reports a span like
+        // (0, 26) for `__BRAZESYNC.lid.foo__bar__`. That span overlaps the
+        // real strict placeholder (0, 21), so it must not be surfaced.
+        let body = "__BRAZESYNC.lid.foo__bar__";
+        assert!(find_suspicious_placeholders(body).is_empty());
+    }
+
+    #[test]
+    fn suspicious_ignores_adjacent_placeholders_sharing_underscores() {
+        // Regression: with two adjacent strict placeholders joined by an
+        // extra `__`, the loose regex finds a single match that overlaps
+        // both strict spans. Overlap means "already covered" — no warning.
+        let body = "__BRAZESYNC.lid.foo____BRAZESYNC.lid.bar__";
         assert!(find_suspicious_placeholders(body).is_empty());
     }
 


### PR DESCRIPTION
## Summary
- Wire `find_suspicious_placeholders` into pre-flight so envelope-shaped typos (`__BRAZSYNC.lid.foo__`, `__BRAZESYNC.url.foo__`, …) surface as `WARN:` instead of passing through silently (RFC §2.3).
- Detect same-lid-key re-use within one body / field and abort with a dedicated `ResolutionError::DuplicateLidKey`, aggregated into the existing pre-flight failure report (RFC §5 edge case).
- cb_id / custom / global re-use remains normal substitution as RFC §5 prescribes.

Both gaps were promised by the RFC but unimplemented after Phase 1-6. The suspicious warning was dead code (only referenced by unit tests); the duplicate-lid case used to silently substitute the same value at both call sites.

## Test plan
- [x] Unit tests added for `DuplicateLidKey` aggregation and cb_id repetition tolerance
- [x] All 517 existing tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manually verified `WARN:` lines appear before unresolved-key abort when a body contains both a typo and a missing strict key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits validation warnings for suspicious placeholder patterns that look like external tokens, including contextual location info.

* **Improvements**
  * Reduces false-positive warnings by ignoring loose-pattern matches that overlap strict placeholders.
  * Detects repeated link-ID occurrences within a single field/context and reports how many times each ID was reused, preventing ambiguous template resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->