### PR TITLE
docs: per-env values guide + v0.14.0 CHANGELOG (Phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [0.14.0] — 2026-05-24
+
+### Added
+
+- **Per-env values: template + values separation.** Resource bodies in
+  Git become env-agnostic templates that reference per-env values via
+  `__BRAZESYNC.<type>.<key>__` placeholders, resolved at apply time
+  against `values/<env>.yaml`. `<type>` ∈ `lid` | `cb_id` | `custom` |
+  `global`; the double-underscore-plus-dot envelope is verbatim-safe in
+  Liquid, HTML, and JSON contexts. `lid` and `cb_id` are field-scoped
+  on email_template (a per-occurrence ID can't span fields); `custom`
+  is resource-scoped; `global` reads from a shared `globals.custom`
+  namespace so values like `api_host` aren't duplicated across every
+  resource. See [`docs/per-env-values.md`](docs/per-env-values.md).
+- **`braze-sync templatize --from-env=<env>`.** One-shot migration
+  that walks every local resource, rewrites raw `lid` literals and
+  content_block include IDs into placeholders, writes the canonical
+  env's `values/<env>.yaml`, and generates `value: null` skeleton
+  files for every other configured environment. Idempotent on bodies
+  that already contain placeholders; pair with `--dry-run` to preview.
+- **Pre-flight values resolution.** `apply`, `diff`, and `export`
+  resolve placeholders against `values/<env>.yaml` before any HTTP
+  write. Failures are aggregated across every selected resource and
+  reported in one shot (Terraform-style) — apply exits with **zero**
+  Braze API calls if any placeholder is unresolved. A separate
+  `WARN:` line surfaces envelope-shaped typos (`__BRAZSYNC.lid.foo__`,
+  `__BRAZESYNC.url.foo__`) so they can't pass silently.
+- **`export` correlation.** `export` no longer overwrites templated
+  bodies; instead it refreshes the matching `values/<env>.yaml`
+  entries, using HTML `<a href>` URLs, plaintext bare URLs, subject /
+  preheader Liquid-identifier anchors, and content_block-include
+  `${NAME}` syntactic anchors to keep key↔value pairing stable across
+  commits. Orphan keys (no placeholder references them) are flagged
+  with warnings rather than auto-deleted; ambiguous URL/anchor
+  matches fall back to source order with a warning.
+- **Plan-lock integration.** `diff --plan-out` now records a
+  per-resource blake3 hash over the values subset that resource
+  actually consumes; `apply --plan` recomputes it and exits **7**
+  (`PlanDrift`) if the values file was edited for any plan-frozen
+  resource between plan generation and apply. Body-only edits that
+  don't change the placeholder set still pass — the v0.13 plan-lock
+  tolerance for benign body edits is preserved. A `globals.custom`
+  edit invalidates every consumer; regenerate the plan.
+- **`environments.<env>.values_file` config field.** Optional path
+  override; defaults to `values/<env_name>.yaml` relative to the
+  config directory.
+
+### Migration / breaking notes
+
+- Repos with multi-env Braze workspaces and dashboard-edited `lid`
+  values should run `braze-sync templatize` once before the first
+  v0.14 apply, otherwise `apply --env=prod` will keep pushing the
+  raw `lid` from Git over Prod's real value. The flow is documented
+  in [`docs/per-env-values.md`](docs/per-env-values.md).
+- Repos without any `__BRAZESYNC.` placeholder are unaffected — the
+  resolver is a no-op when no template references it. The
+  `feat-preserve-remote-patterns` proposal is superseded by this work.
+
 ## [0.13.0] — 2026-05-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ synchronize it to Braze with the same workflow you'd use for
 detection in CI, and an `--allow-destructive` gate that has to be
 crossed explicitly before anything is dropped.
 
-## Status: v0.12.0 (5 resources + init)
+## Status: v0.14.0 (5 resources + init + per-env values)
 
 braze-sync manages Braze **configuration** as code. The five managed
 resource kinds are:
@@ -32,6 +32,7 @@ use the Braze REST API or data pipelines directly. See
 | `braze-sync diff` | Shows drift between local files and Braze |
 | `braze-sync apply` | Applies local intent to Braze (dry-run by default) |
 | `braze-sync validate` | Local-only structural and naming checks (no API call) |
+| `braze-sync templatize` | One-shot migration to per-env values (see [docs/per-env-values.md](docs/per-env-values.md)) |
 
 ### Content Block specifics
 
@@ -204,6 +205,7 @@ across all v1.x releases.
 | `4` | Authentication failed (invalid API key) |
 | `5` | Rate limit retries exhausted |
 | `6` | Destructive change blocked (pass `--allow-destructive`) |
+| `7` | Plan/apply mismatch (`apply --plan` integrity check, includes per-env values drift) |
 
 ## Output formats
 
@@ -247,6 +249,7 @@ only need a content hash.
 - [CI integration](docs/integration.md) — drift detection and apply-on-merge workflows.
 - [Orphan tracking](docs/orphan-tracking.md) — how Content Blocks and Email Templates are handled when Braze has no DELETE.
 - [Custom Attribute registry mode](docs/registry-mode.md) — why attributes work differently and what `apply` actually does.
+- [Per-env values](docs/per-env-values.md) — template + values separation for env-specific `lid` / `cb_id` / custom values (v0.14.0).
 
 ## License
 

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -1,0 +1,217 @@
+# Per-env values: template + values separation
+
+When braze-sync pushes from Git to multiple environments (Dev / Prod / …),
+some values inside a resource body are **structurally identical but
+literally different per workspace**. The canonical example is the
+auto-numbered Link Aliasing `lid` Braze assigns when a click-tracked
+link is created — Dev's `lid` is not Prod's `lid`, but the surrounding
+HTML and Liquid is the same.
+
+Pre-v0.14, braze-sync had no way to express "the structure is shared,
+the value differs per env": pushing Dev's body to Prod overwrote Prod's
+`lid` and broke click tracking on the Prod side. v0.14 introduces a
+**template + values** model — analogous to Helm `values.yaml` or
+Terraform `*.tfvars` — so the body in Git stays env-agnostic and the
+per-env values live in `values/<env>.yaml`.
+
+## Quick start
+
+If you're upgrading an existing repo, run the one-shot migration:
+
+```bash
+braze-sync templatize --from-env=prod         # preview
+braze-sync templatize --from-env=prod --dry-run=false
+```
+
+This walks every `content_blocks/*.liquid` and `email_templates/*`,
+rewrites raw `lid` values and content_block include IDs into
+`__BRAZESYNC.<type>.<key>__` placeholders, writes
+`values/prod.yaml` with the canonical env's values, and writes
+**skeleton** `values/<env>.yaml` files (with `value: null`) for every
+other configured environment.
+
+For each non-canonical env, run `export` to populate real values:
+
+```bash
+braze-sync export --env=dev
+braze-sync export --env=staging
+```
+
+After that, `diff` / `apply` work as before — placeholders are resolved
+against `values/<env>.yaml` before any HTTP write.
+
+## Placeholder syntax
+
+```
+__BRAZESYNC.<type>.<key>__
+```
+
+- `<type>` ∈ `lid` | `cb_id` | `custom` | `global`
+- `<key>` matches `[a-z][a-z0-9_]*` (snake_case)
+
+Example template body:
+
+```liquid
+<a href="https://example.com/spring-sale">{{ ${cblid} | lid: '__BRAZESYNC.lid.spring_sale__' }}click</a>
+{{ content_blocks.${cb_promo_image} | id: '__BRAZESYNC.cb_id.cb_promo_image__' }}
+<script src="https://__BRAZESYNC.custom.api_host__/widget.js"></script>
+```
+
+The double-underscore envelope and dot namespace are picked so the
+token is verbatim-safe in Liquid, HTML, and JSON contexts and won't
+silently expand in Braze's Liquid engine if a value is ever forgotten.
+
+A typo with the wrong envelope (`__BRAZSYNC.…__`) or an unknown type
+(`__BRAZESYNC.url.foo__`) surfaces as a `WARN:` line at pre-flight so
+it doesn't slip through silently.
+
+## values/&lt;env&gt;.yaml schema
+
+```yaml
+version: 1
+
+# Shared across every resource. Reference as __BRAZESYNC.global.<key>__.
+globals:
+  custom:
+    api_host:
+      value: api-prod.example.com
+
+content_block:
+  cb_promo_banner:
+    lid:
+      spring_sale:
+        value: ai8kexrxcp03
+        url: https://example.com/spring-sale     # export correlation anchor
+    cb_id:
+      cb_promo_image:
+        value: cb42                              # key = referenced block slug
+    custom:
+      banner_variant:
+        value: A
+
+email_template:
+  welcome:
+    custom:                                       # resource-scoped only
+      user_segment_id:
+        value: seg_prod_42
+    subject:
+      lid:                                        # lid / cb_id are field-scoped
+        promo_subject:
+          value: lidsubj42
+          anchor: "{{promo_code}}"                # anchor for URL-less fields
+    body_html:
+      lid:
+        cta:
+          value: lidhtml42
+          url: https://example.com/welcome/cta
+      cb_id:
+        cb_promo_image:
+          value: cb42
+```
+
+### Namespace rules
+
+| Placeholder | Resolves against |
+|---|---|
+| `__BRAZESYNC.global.<key>__` | `globals.custom.<key>` (cross-resource) |
+| `__BRAZESYNC.custom.<key>__` | The resource's own `custom.<key>` |
+| `__BRAZESYNC.lid.<key>__` (content_block) | `content_block.<name>.lid.<key>` |
+| `__BRAZESYNC.cb_id.<key>__` (content_block) | `content_block.<name>.cb_id.<key>` |
+| `__BRAZESYNC.lid.<key>__` (email_template) | The field-scoped `<name>.<field>.lid.<key>` |
+| `__BRAZESYNC.cb_id.<key>__` (email_template) | The field-scoped `<name>.<field>.cb_id.<key>` |
+
+Lookup is exact — there is **no fallback** between resource-local and
+global namespaces. Choose the namespace in the placeholder.
+
+### `value: null` (skeleton)
+
+`templatize` writes `value: null` for envs other than the canonical
+one. This signals "needs export"; shape validation skips these entries
+and pre-flight aborts apply with a hint to run `braze-sync export`.
+
+## Config
+
+Optional override per environment:
+
+```yaml
+environments:
+  prod:
+    api_endpoint: https://rest.iad-01.braze.com
+    api_key_env: BRAZE_PROD_API_KEY
+    values_file: values/prod.yaml         # optional; this is the default
+```
+
+Omitted → defaults to `values/<env_name>.yaml` relative to the config
+directory.
+
+## How it ties into existing commands
+
+- **`diff`** resolves placeholders before comparing against remote, so
+  `diff --env=dev` and `diff --env=prod` each show the right
+  per-env contents. A body that differs only by `lid` reads as in-sync.
+- **`apply`** resolves placeholders before POST. Any unresolved
+  placeholder aborts pre-flight before a single Braze write is issued
+  (failures are aggregated across every resource and reported together,
+  Terraform-style).
+- **`export`** preserves the templated body in Git and writes back only
+  the values entries, using URL anchors (HTML), bare-URL anchors
+  (plaintext), Liquid-identifier anchors (subject / preheader), or
+  `${NAME}` syntactic anchors (cb_id include form) to keep
+  key↔remote-value correlation stable across commits.
+- **`templatize`** is the one-shot migration; idempotent on
+  already-templatized bodies and skips them by default.
+
+## Plan/apply lock interaction (v0.13.0 → v0.14.0)
+
+`diff --plan-out=plan.json` now also records a per-resource
+**values-input hash** — a blake3 digest over the
+`<type>.<key> → value` subset that resource actually consumes. `apply
+--plan=plan.json` recomputes it and exits **7** (`PlanDrift`) if the
+values file was edited between plan and apply for a resource the plan
+froze. Editing values keys that no resource in the plan consumes does
+not trip the lock; neither do body-only edits that don't change the
+placeholder set, so the plan-lock tolerance for benign body edits
+(`docs/local/feat-apply-plan-locking.md` §3.2) is preserved.
+
+A single `globals.custom.<key>` edit invalidates the hash of **every**
+resource that uses that global. If apply aborts for many resources at
+once, regenerate the plan:
+
+```bash
+braze-sync diff --env=prod --plan-out=plan.json
+```
+
+## Known limitations (v0.14.0)
+
+These are documented as deferred from the RFC and may be lifted in
+later patches:
+
+- **No `--show-template` diff mode.** `diff` always compares the
+  resolved body against remote. There is no flag yet to view the
+  templated body alongside.
+- **Non-ASCII slug naming is silent.** `templatize` / `export` slugify
+  URL paths and content_block names; non-ASCII sources (e.g. Japanese
+  link text) collapse to `link_` / `cb_` plus an index without an
+  explicit warning. The generated keys are valid but lose meaning —
+  rename them in `values/<env>.yaml` after the first run.
+- **cb_id slug collisions are silent.** If two distinct content_block
+  names slug to the same key, the second gets a `_2` / `_3` suffix
+  with no warning. Inspect the generated values file after migration
+  if you suspect collisions.
+- **No automatic key sync on rename.** Renaming a key in
+  `values/<env>.yaml` does not rewrite placeholders in templates. Edit
+  both sides manually for now.
+- **No values-file secret separation.** The values file is plain YAML
+  intended for Git. `braze-sync` has no Helm-secrets style encrypted
+  overlay; keep secrets out of the file. (API keys still live in env
+  vars as before.)
+
+## Migration checklist
+
+1. Upgrade to v0.14.0.
+2. `braze-sync templatize --from-env=<canonical>` (preview first).
+3. `braze-sync export --env=<other-env>` for each remaining env.
+4. Review the generated `values/*.yaml` in a PR alongside the
+   templatized bodies.
+5. CI: `braze-sync diff --env=<env> --fail-on-drift` should report
+   `0 diff` on each env if migration was clean.

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -19,8 +19,8 @@ per-env values live in `values/<env>.yaml`.
 If you're upgrading an existing repo, run the one-shot migration:
 
 ```bash
-braze-sync templatize --from-env=prod         # preview
-braze-sync templatize --from-env=prod --dry-run=false
+braze-sync templatize --from-env=prod --dry-run    # preview
+braze-sync templatize --from-env=prod              # actually rewrite
 ```
 
 This walks every `content_blocks/*.liquid` and `email_templates/*`,
@@ -42,7 +42,7 @@ against `values/<env>.yaml` before any HTTP write.
 
 ## Placeholder syntax
 
-```
+```text
 __BRAZESYNC.<type>.<key>__
 ```
 
@@ -170,8 +170,8 @@ directory.
 values file was edited between plan and apply for a resource the plan
 froze. Editing values keys that no resource in the plan consumes does
 not trip the lock; neither do body-only edits that don't change the
-placeholder set, so the plan-lock tolerance for benign body edits
-(`docs/local/feat-apply-plan-locking.md` §3.2) is preserved.
+placeholder set, so the v0.13 plan-lock tolerance for benign body
+edits is preserved.
 
 A single `globals.custom.<key>` edit invalidates the hash of **every**
 resource that uses that global. If apply aborts for many resources at


### PR DESCRIPTION
## Summary
- New `docs/per-env-values.md`: tutorial + schema reference + plan-lock interaction + known limitations + migration checklist.
- README: status bump to v0.14.0, `templatize` in the command table, exit code 7 documented, link to the new doc.
- CHANGELOG: v0.14.0 entry for values resolver, `templatize` CLI, pre-flight aggregation, export correlation refresh, plan-lock values-input hashes, and `values_file` config — with migration notes for multi-env repos.

Closes the Phase 7 line item from the per-env-values RFC. After this lands, a separate "Release v0.14.0" PR bumps `Cargo.toml`.

## Test plan
- [x] `cargo build` succeeds
- [ ] Manually skim the rendered `docs/per-env-values.md` on GitHub for layout
- [ ] Confirm CHANGELOG entry date matches the eventual release date in the Release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-environment template+values support using placeholder-separated bodies and values.
  * Added a one-shot templatize migration command.
  * Pre-flight placeholder resolution for diff/apply/export that aborts remote calls on unresolved placeholders.
  * Export now refreshes per-env value entries and warns about orphan/ambiguous keys.
  * Plan/apply drift detection with recomputed per-resource hashes (exit code 7).
  * Per-environment values_file config override.

* **Documentation**
  * Comprehensive guide, migration checklist, and CI expectations for per-environment values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->