### PR TITLE
Release v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps to v0.14.0 for the per-env values feature implemented across PRs #38–#44.
- CHANGELOG entry already landed in #44.

## Recovery context

The v0.14.0 tag was created on 92d4050 (PR #44 merge) before this bump, so the existing Release workflow run failed with `crate braze-sync@0.13.0 already exists`. After this PR merges, the v0.14.0 tag should be force-moved to the new HEAD so the Release workflow can re-run against the correct Cargo.toml version.

## Test plan

- [x] `cargo build` succeeds at the new version (Cargo.lock updated to 0.14.0)
- [ ] After merge: `git push --force origin v0.14.0` from the new main HEAD, then the Release workflow re-runs and `cargo publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)