### PR TITLE
fix: detect lids inside href attribute values during templatize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [0.14.1] — 2026-05-24
+
+### Fixed
+
+- **`templatize`: anchor detection now sees lids inside `href`
+  attribute values.** Braze's default HTML output puts the lid query
+  parameter — and its `| lid: '…'` token — *inside* the anchor's
+  `href` (e.g. `<a href="…/path/?lid={{${cblid} | lid: 'X'}}">`).
+  The prefix-only scan couldn't see the closing quote of the
+  enclosing tag and was silently falling back to sequential
+  `link_N` keys for nearly every anchor in real Braze projects.
+  Detection now first looks for an enclosing `<a …>` open tag and
+  uses its `href` as the URL anchor; the legacy "lid sits between
+  `<a>` and `</a>` as link text" pattern remains supported as a
+  fallback. Existing `__BRAZESYNC.lid.link_N__` placeholders from
+  v0.14.0 templatize runs are not rewritten automatically — re-run
+  `braze-sync templatize` on affected resources to migrate them to
+  URL-derived keys.
+
 ## [0.14.0] — 2026-05-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -486,6 +486,24 @@ mod tests {
     }
 
     #[test]
+    fn enclosing_anchor_without_href_falls_back_to_prior_href() {
+        // The lid lives inside an `<a>` open tag that has no `href`
+        // (e.g. `<a name="…">`). `enclosing_anchor_href` finds the
+        // enclosing tag but returns None because there's no href to
+        // extract — the legacy prefix scan must still pick up the
+        // earlier `<a href>` so we don't regress that pattern.
+        let body = r#"<a href="https://example.com/earlier/path">x</a> <a name="anchor">text {{x | lid: 'ai8kexrxcp03'}}</a>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.entries.len(), 1);
+        match &r.entries[0] {
+            DetectedEntry::Lid { url, .. } => {
+                assert_eq!(url.as_deref(), Some("https://example.com/earlier/path"));
+            }
+            _ => panic!("expected Lid"),
+        }
+    }
+
+    #[test]
     fn url_path_tail_uses_last_nonempty_segment() {
         assert_eq!(
             url_path_tail("https://example.com/promo/spring-sale"),

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -232,15 +232,23 @@ fn name_lid_for_field(
 }
 
 fn preceding_url(body: &str, lid_token_offset: usize, field: FieldKind) -> Option<String> {
-    let prefix = &body[..lid_token_offset];
     let raw = if field.supports_html_anchor() {
-        // Use the LAST href before the lid token.
-        href_re()
-            .captures_iter(prefix)
-            .last()
-            .and_then(|cap| cap.get(1).or(cap.get(2)))
-            .map(|m| m.as_str().to_string())
+        // Braze's common case puts `{{ ... | lid: '…' }}` *inside* the
+        // href attribute value (e.g. `href="…?lid={{…|lid:'X'}}"`).
+        // Try the enclosing `<a …>` open tag first; only when the lid
+        // lives outside any open tag do we fall back to the last
+        // `<a href>` before the token (legacy pattern where lid sits
+        // between the `<a>` and `</a>` as link text).
+        enclosing_anchor_href(body, lid_token_offset).or_else(|| {
+            let prefix = &body[..lid_token_offset];
+            href_re()
+                .captures_iter(prefix)
+                .last()
+                .and_then(|cap| cap.get(1).or(cap.get(2)))
+                .map(|m| m.as_str().to_string())
+        })
     } else if field.supports_plaintext_anchor() {
+        let prefix = &body[..lid_token_offset];
         plaintext_url_re()
             .find_iter(prefix)
             .last()
@@ -249,6 +257,36 @@ fn preceding_url(body: &str, lid_token_offset: usize, field: FieldKind) -> Optio
         None
     };
     raw.map(|r| normalize_url(&r))
+}
+
+/// Find an `<a …>` open tag that *contains* `lid_token_offset` and
+/// return its `href` attribute value (unnormalized). Returns `None`
+/// when the offset isn't inside any open tag or the enclosing tag has
+/// no href.
+///
+/// Open tags are detected by `<a\b … >` with `>` being the first
+/// unmatched `>` after `<a` — same trust assumption as `href_re` (no
+/// raw `>` inside attribute values).
+fn enclosing_anchor_href(body: &str, lid_token_offset: usize) -> Option<String> {
+    let re = anchor_open_tag_re();
+    for m in re.find_iter(body) {
+        if m.start() > lid_token_offset {
+            break;
+        }
+        if m.end() > lid_token_offset {
+            let tag = &body[m.start()..m.end()];
+            return href_re()
+                .captures(tag)
+                .and_then(|cap| cap.get(1).or(cap.get(2)))
+                .map(|x| x.as_str().to_string());
+        }
+    }
+    None
+}
+
+fn anchor_open_tag_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r#"(?i)<a\b[^>]*>"#).expect("anchor open tag regex is valid"))
 }
 
 fn url_path_tail(url: &str) -> String {
@@ -405,6 +443,46 @@ mod tests {
         let r = templatize_body(body, FieldKind::EmailHtmlBody);
         assert_eq!(r.entries.len(), 1);
         assert!(!r.warnings.is_empty());
+    }
+
+    #[test]
+    fn lid_inside_href_attribute_value_uses_enclosing_anchor() {
+        // Braze's typical HTML output puts the lid *inside* the href:
+        //   <a href="https://…/path/?lid={{${cblid} | lid: 'X'}}">
+        // The prefix-only scan can't see the closing quote and was
+        // falling back to a sequential `link_` key for ~all anchors.
+        let body = r#"<a href="https://med.example.com/product/jaypirca/50mg/?lid={{${cblid} | lid: 'ai8kexrxcp03'}}"><img src="x"/></a>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.entries.len(), 1);
+        match &r.entries[0] {
+            DetectedEntry::Lid { key, url, .. } => {
+                assert_eq!(key, "link_50mg");
+                assert_eq!(
+                    url.as_deref(),
+                    Some("https://med.example.com/product/jaypirca/50mg/")
+                );
+            }
+            _ => panic!("expected Lid"),
+        }
+        assert!(
+            r.warnings.is_empty(),
+            "no-anchor warning should not fire when href encloses the lid"
+        );
+    }
+
+    #[test]
+    fn enclosing_anchor_takes_precedence_over_earlier_unrelated_href() {
+        // Even if an earlier, fully-closed <a href> exists, the lid
+        // that lives inside a *different* later <a …> tag should use
+        // that later tag's href, not the prior one.
+        let body = r#"<a href="https://example.com/old">old</a> then <a href="https://example.com/new/path/?lid={{x | lid: 'ai8kexrxcp03'}}">new</a>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        match &r.entries[0] {
+            DetectedEntry::Lid { url, .. } => {
+                assert_eq!(url.as_deref(), Some("https://example.com/new/path/"));
+            }
+            _ => panic!(),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes `templatize` silently falling back to sequential `link_N` keys for nearly every anchor on real Braze projects.
- Root cause: `preceding_url` scanned `&body[..lid_token_offset]`, so the closing quote of an enclosing `<a href="…?lid={{…|lid:'X'}}">` was never visible and the `href` regex couldn't match.
- Fix: try an enclosing `<a …>` open tag first and use its `href`; fall back to the legacy "lid between `<a>` and `</a>`" pattern.
- `correlation.rs` works on full bodies, not prefixes, so it already handled this case — no change there (verified).
- Existing `__BRAZESYNC.lid.link_N__` placeholders from v0.14.0 are not auto-migrated; re-run `templatize` on affected resources to pick up the URL-derived keys.

## Test plan

- [x] `cargo test` — full suite passes
- [x] New unit test: lid inside `href="…?lid={{…|lid:'X'}}"` resolves to the URL-derived key
- [x] New unit test: enclosing tag takes precedence over earlier, unrelated `<a href>`
- [x] New unit test: enclosing `<a>` without `href` falls back to the legacy prefix scan
- [ ] Re-run `braze-sync templatize --from-env=prod --dry-run` against a real project and confirm `no URL anchor` warnings drop to ~0

🤖 Generated with [Claude Code](https://claude.com/claude-code)