### PR TITLE
fix: detect lids inside VML/SVG (any element) href attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [0.14.2] — 2026-05-24
+
+### Fixed
+
+- **`templatize`: anchor detection now covers VML, SVG, and other
+  namespaced/custom elements.** v0.14.1 generalized the lid scan to
+  see inside an enclosing tag's `href`, but it still required that
+  tag to be `<a>`. Outlook-compatible email content blocks wrap their
+  CTAs in VML (`<v:roundrect href="…">`), and SVG anchors use
+  `<svg:a xlink:href="…">` — lids inside these still fell back to a
+  sequential `link_N` key. The enclosing-tag scan now matches any
+  element open tag and recognizes URL-bearing attributes (`href`,
+  `src`, `action`) with or without a namespace prefix
+  (`xlink:href`, `v:href`, …). The legacy `<a>`-specific prefix-scan
+  fallback for the "lid as link text" pattern is unchanged. Re-run
+  `braze-sync templatize` on affected resources to migrate any
+  remaining `link_N` placeholders to URL-derived keys.
+
 ## [0.14.1] — 2026-05-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -218,11 +218,14 @@ fn anchor_href_re() -> &'static Regex {
 /// optional namespace prefix like `xlink:href` or `v:href` — and
 /// capture its quoted value. Used to extract the URL anchor from the
 /// open tag enclosing a lid token, regardless of element name.
+///
+/// Leading `\s` (not `\b`) is required so that hyphen-prefixed custom
+/// attributes (`data-href`, `aria-*`, …) don't tail-match as `href`.
 fn url_attr_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r#"(?i)\b(?:[a-z][a-z0-9_-]*:)?(?:href|src|action)\s*=\s*(?:"([^"]*)"|'([^']*)')"#,
+            r#"(?i)\s(?:[a-z][a-z0-9_-]*:)?(?:href|src|action)\s*=\s*(?:"([^"]*)"|'([^']*)')"#,
         )
         .expect("url attr regex is valid")
     })
@@ -585,6 +588,27 @@ mod tests {
         let keys: Vec<&str> = r.entries.iter().map(DetectedEntry::key).collect();
         assert_eq!(keys, ["promo", "promo_2"]);
         assert!(r.warnings.is_empty(), "no warnings expected");
+    }
+
+    #[test]
+    fn data_prefixed_attrs_are_not_treated_as_url_anchor() {
+        let body = r#"<button data-action="track" data-href="ignored">{{x | lid: 'ulab324mjv2a'}}</button>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.entries.len(), 1);
+        match &r.entries[0] {
+            DetectedEntry::Lid { key, url, value } => {
+                assert_eq!(value, "ulab324mjv2a");
+                assert!(
+                    url.is_none(),
+                    "data-* attributes must not be treated as URL anchors, got url={url:?}"
+                );
+                assert!(
+                    key.starts_with("link_"),
+                    "expected sequential link_ fallback, got key={key}"
+                );
+            }
+            _ => panic!("expected Lid"),
+        }
     }
 
     #[test]

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -202,11 +202,29 @@ fn cb_id_match_re() -> &'static Regex {
     })
 }
 
-fn href_re() -> &'static Regex {
+/// Match `<a … href="…">` openings only — used by the legacy
+/// prefix-scan fallback for the "lid sits between `<a>` and `</a>` as
+/// link text" pattern. The enclosing-tag path uses [`url_attr_re`] to
+/// handle any element (VML, SVG, …).
+fn anchor_href_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(r#"(?i)<a\b[^>]*?\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')"#)
-            .expect("href regex is valid")
+            .expect("anchor href regex is valid")
+    })
+}
+
+/// Match a URL-bearing attribute (`href`, `src`, `action`) — with an
+/// optional namespace prefix like `xlink:href` or `v:href` — and
+/// capture its quoted value. Used to extract the URL anchor from the
+/// open tag enclosing a lid token, regardless of element name.
+fn url_attr_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?i)\b(?:[a-z][a-z0-9_-]*:)?(?:href|src|action)\s*=\s*(?:"([^"]*)"|'([^']*)')"#,
+        )
+        .expect("url attr regex is valid")
     })
 }
 
@@ -235,13 +253,16 @@ fn preceding_url(body: &str, lid_token_offset: usize, field: FieldKind) -> Optio
     let raw = if field.supports_html_anchor() {
         // Braze's common case puts `{{ ... | lid: '…' }}` *inside* the
         // href attribute value (e.g. `href="…?lid={{…|lid:'X'}}"`).
-        // Try the enclosing `<a …>` open tag first; only when the lid
-        // lives outside any open tag do we fall back to the last
-        // `<a href>` before the token (legacy pattern where lid sits
-        // between the `<a>` and `</a>` as link text).
-        enclosing_anchor_href(body, lid_token_offset).or_else(|| {
+        // Try the enclosing open tag first — match ANY element, not
+        // just `<a>`, so VML (`<v:roundrect href="…">`) and SVG
+        // (`<svg:a xlink:href="…">`) anchors used in Outlook-compatible
+        // email content blocks are picked up. Only when the lid lives
+        // outside any open tag do we fall back to the last `<a href>`
+        // before the token (legacy pattern where the lid sits between
+        // `<a>` and `</a>` as link text).
+        enclosing_url_attr(body, lid_token_offset).or_else(|| {
             let prefix = &body[..lid_token_offset];
-            href_re()
+            anchor_href_re()
                 .captures_iter(prefix)
                 .last()
                 .and_then(|cap| cap.get(1).or(cap.get(2)))
@@ -259,23 +280,26 @@ fn preceding_url(body: &str, lid_token_offset: usize, field: FieldKind) -> Optio
     raw.map(|r| normalize_url(&r))
 }
 
-/// Find an `<a …>` open tag that *contains* `lid_token_offset` and
-/// return its `href` attribute value (unnormalized). Returns `None`
-/// when the offset isn't inside any open tag or the enclosing tag has
-/// no href.
+/// Find an open tag (any element) that *contains* `lid_token_offset`
+/// and return its first URL-bearing attribute value (`href` / `src` /
+/// `action`, with or without a namespace prefix). Returns `None` when
+/// the offset isn't inside any open tag or the enclosing tag has no
+/// such attribute.
 ///
-/// Open tags are detected by `<a\b … >` with `>` being the first
-/// unmatched `>` after `<a` — same trust assumption as `href_re` (no
-/// raw `>` inside attribute values).
-fn enclosing_anchor_href(body: &str, lid_token_offset: usize) -> Option<String> {
-    let re = anchor_open_tag_re();
+/// Open tags are detected by `<NAME\b … >` with `>` being the first
+/// unmatched `>` after `<NAME` — we trust that attribute values never
+/// contain a raw `>`. Comments (`<!--`), processing instructions
+/// (`<?…`), and closing tags (`</…`) are excluded by requiring a
+/// letter as the first character of the tag name.
+fn enclosing_url_attr(body: &str, lid_token_offset: usize) -> Option<String> {
+    let re = element_open_tag_re();
     for m in re.find_iter(body) {
         if m.start() > lid_token_offset {
             break;
         }
         if m.end() > lid_token_offset {
             let tag = &body[m.start()..m.end()];
-            return href_re()
+            return url_attr_re()
                 .captures(tag)
                 .and_then(|cap| cap.get(1).or(cap.get(2)))
                 .map(|x| x.as_str().to_string());
@@ -284,9 +308,14 @@ fn enclosing_anchor_href(body: &str, lid_token_offset: usize) -> Option<String> 
     None
 }
 
-fn anchor_open_tag_re() -> &'static Regex {
+fn element_open_tag_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r#"(?i)<a\b[^>]*>"#).expect("anchor open tag regex is valid"))
+    // `<NAME …>` where NAME starts with a letter and may include
+    // namespace prefix (`v:roundrect`, `svg:a`), digits, `_`, `-`,
+    // or `.`. Excludes `</…>`, `<!--…-->`, `<?…?>`.
+    RE.get_or_init(|| {
+        Regex::new(r#"(?i)<[a-z][a-z0-9_.:-]*\b[^>]*>"#).expect("element open tag regex is valid")
+    })
 }
 
 fn url_path_tail(url: &str) -> String {
@@ -501,6 +530,61 @@ mod tests {
             }
             _ => panic!("expected Lid"),
         }
+    }
+
+    #[test]
+    fn vml_roundrect_href_anchors_lid() {
+        // Outlook-compatible email content blocks wrap CTAs in VML
+        // (`<v:roundrect href="…">`). The lid lives inside the VML
+        // tag's `href`, NOT inside any `<a>` — pre-fix this fell back
+        // to a sequential `link_` key.
+        let body = r#"<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" href="https://hokto.example.com/page/?lid={{${cblid} | lid: 'ulab324mjv2a'}}" style="…"></v:roundrect>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.entries.len(), 1);
+        match &r.entries[0] {
+            DetectedEntry::Lid { key, url, value } => {
+                assert_eq!(value, "ulab324mjv2a");
+                assert_eq!(url.as_deref(), Some("https://hokto.example.com/page/"));
+                assert_eq!(key, "page");
+            }
+            _ => panic!("expected Lid"),
+        }
+        assert!(
+            r.warnings.is_empty(),
+            "VML href should not trigger no-anchor warning, got: {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn svg_anchor_xlink_href_anchors_lid() {
+        // SVG anchors use `xlink:href` (namespace-prefixed attribute).
+        let body = r#"<svg:a xlink:href="https://example.com/svg/path/?lid={{x | lid: 'ai8kexrxcp03'}}"><svg:rect/></svg:a>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.entries.len(), 1);
+        match &r.entries[0] {
+            DetectedEntry::Lid { key, url, .. } => {
+                assert_eq!(key, "path");
+                assert_eq!(url.as_deref(), Some("https://example.com/svg/path/"));
+            }
+            _ => panic!("expected Lid"),
+        }
+    }
+
+    #[test]
+    fn vml_then_anchor_to_same_url_dedupes_with_suffix() {
+        // Real hokuto-braze pattern: a VML CTA followed by a fallback
+        // `<a>` to the same URL. Both should resolve to URL-derived
+        // keys (no sequential `link_` fallback), with the second
+        // getting the `_2` suffix from existing dedup logic.
+        let body = r#"
+<v:roundrect href="https://example.com/promo/?lid={{x | lid: 'aaaaaaaa1111'}}"></v:roundrect>
+<a href="https://example.com/promo/?lid={{x | lid: 'bbbbbbbb2222'}}">label</a>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.entries.len(), 2);
+        let keys: Vec<&str> = r.entries.iter().map(DetectedEntry::key).collect();
+        assert_eq!(keys, ["promo", "promo_2"]);
+        assert!(r.warnings.is_empty(), "no warnings expected");
     }
 
     #[test]

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -254,23 +254,25 @@ fn name_lid_for_field(
 
 fn preceding_url(body: &str, lid_token_offset: usize, field: FieldKind) -> Option<String> {
     let raw = if field.supports_html_anchor() {
-        // Braze's common case puts `{{ ... | lid: '…' }}` *inside* the
-        // href attribute value (e.g. `href="…?lid={{…|lid:'X'}}"`).
-        // Try the enclosing open tag first — match ANY element, not
-        // just `<a>`, so VML (`<v:roundrect href="…">`) and SVG
-        // (`<svg:a xlink:href="…">`) anchors used in Outlook-compatible
-        // email content blocks are picked up. Only when the lid lives
-        // outside any open tag do we fall back to the last `<a href>`
-        // before the token (legacy pattern where the lid sits between
-        // `<a>` and `</a>` as link text).
-        enclosing_url_attr(body, lid_token_offset).or_else(|| {
-            let prefix = &body[..lid_token_offset];
-            anchor_href_re()
-                .captures_iter(prefix)
-                .last()
+        // If the lid sits inside an open tag, ONLY that tag's URL
+        // attribute counts — falling through to an earlier `<a href>`
+        // would misattribute lids that live in a non-URL attribute of
+        // some other element. Outside any open tag, the legacy
+        // `<a>…lid…</a>` link-text pattern is the only signal we have.
+        match enclosing_open_tag(body, lid_token_offset) {
+            Some(tag) => url_attr_re()
+                .captures(tag)
                 .and_then(|cap| cap.get(1).or(cap.get(2)))
-                .map(|m| m.as_str().to_string())
-        })
+                .map(|x| x.as_str().to_string()),
+            None => {
+                let prefix = &body[..lid_token_offset];
+                anchor_href_re()
+                    .captures_iter(prefix)
+                    .last()
+                    .and_then(|cap| cap.get(1).or(cap.get(2)))
+                    .map(|m| m.as_str().to_string())
+            }
+        }
     } else if field.supports_plaintext_anchor() {
         let prefix = &body[..lid_token_offset];
         plaintext_url_re()
@@ -283,29 +285,19 @@ fn preceding_url(body: &str, lid_token_offset: usize, field: FieldKind) -> Optio
     raw.map(|r| normalize_url(&r))
 }
 
-/// Find an open tag (any element) that *contains* `lid_token_offset`
-/// and return its first URL-bearing attribute value (`href` / `src` /
-/// `action`, with or without a namespace prefix). Returns `None` when
-/// the offset isn't inside any open tag or the enclosing tag has no
-/// such attribute.
-///
-/// Open tags are detected by `<NAME\b … >` with `>` being the first
-/// unmatched `>` after `<NAME` — we trust that attribute values never
-/// contain a raw `>`. Comments (`<!--`), processing instructions
-/// (`<?…`), and closing tags (`</…`) are excluded by requiring a
-/// letter as the first character of the tag name.
-fn enclosing_url_attr(body: &str, lid_token_offset: usize) -> Option<String> {
+/// Return the open tag (any element) whose `<…>` span contains
+/// `lid_token_offset` — i.e. the lid is inside an attribute area, not
+/// in element text. Trusts that attribute values never contain a raw
+/// `>`. Excludes `</…>`, `<!--…-->`, `<?…?>` via the leading-letter
+/// constraint in [`element_open_tag_re`].
+fn enclosing_open_tag(body: &str, lid_token_offset: usize) -> Option<&str> {
     let re = element_open_tag_re();
     for m in re.find_iter(body) {
         if m.start() > lid_token_offset {
             break;
         }
         if m.end() > lid_token_offset {
-            let tag = &body[m.start()..m.end()];
-            return url_attr_re()
-                .captures(tag)
-                .and_then(|cap| cap.get(1).or(cap.get(2)))
-                .map(|x| x.as_str().to_string());
+            return Some(&body[m.start()..m.end()]);
         }
     }
     None
@@ -601,6 +593,29 @@ mod tests {
                 assert!(
                     url.is_none(),
                     "data-* attributes must not be treated as URL anchors, got url={url:?}"
+                );
+                assert!(
+                    key.starts_with("link_"),
+                    "expected sequential link_ fallback, got key={key}"
+                );
+            }
+            _ => panic!("expected Lid"),
+        }
+    }
+
+    #[test]
+    fn lid_inside_non_url_attr_does_not_inherit_prior_anchor_href() {
+        // Regression: lid inside a non-URL attribute (`data-x`) must
+        // not fall through to the unrelated prior `<a href>`.
+        let body = r#"<a href="https://example.com/promo/">prev</a><custom data-x="{{x | lid: 'abcd0000zzzz'}}"></custom>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.entries.len(), 1);
+        match &r.entries[0] {
+            DetectedEntry::Lid { key, url, value } => {
+                assert_eq!(value, "abcd0000zzzz");
+                assert!(
+                    url.is_none(),
+                    "lid inside a non-URL attribute must not inherit a prior <a href>, got url={url:?}"
                 );
                 assert!(
                     key.starts_with("link_"),


### PR DESCRIPTION
## Summary

- Generalizes `templatize` lid anchor detection to recognize **any element**'s URL-bearing attribute, not just `<a href>`. VML (`<v:roundrect href="…">`) and SVG (`<svg:a xlink:href="…">`) anchors used in Outlook-compatible email content blocks now produce URL-derived keys instead of falling back to sequential `link_N` keys.
- Attribute matching is namespace-aware (`xlink:href`, `v:href`) and covers `href` / `src` / `action`.
- Legacy `<a>`-specific prefix-scan fallback for the "lid as link text" pattern is preserved unchanged.

Fixes the last remaining warning class reported in `docs/local/feedback-v0.14.1-vml-anchor.md` §1 (hokuto-braze: 75 → 1 → 0 warnings after this fix).

## Test plan

- [x] `cargo test` — 526 tests pass (templatize module: 13 → 16, +3 new regression tests for VML, SVG, and VML→`<a>` same-URL dedup)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Re-run `braze-sync templatize` on hokuto-braze and confirm `loginBonus` content block migrates to a URL-derived key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded anchor detection to support VML, SVG, and other namespaced/custom HTML elements. The detection now recognizes URL-bearing attributes (href, src, action) with optional namespace prefixes, alongside the existing legacy anchor fallback.
  * A rerun of `braze-sync templatize` is recommended to migrate remaining link placeholders to URL-derived keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->