### PR TITLE
fix: rescue trailing-underscore placeholder keys (v0.14.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [0.14.3] — 2026-05-24
+
+### Fixed
+
+- **Resolver no longer rejects placeholders whose key ends in `_`.**
+  When `templatize` produced a fallback key like `link_` (URL slug
+  empty) the rendered envelope collapses to three consecutive
+  underscores (`__BRAZESYNC.lid.link___`). The previous parser
+  anchored on the *nearest* closing `__` and decided the key was
+  `link`, leaving an orphan `_` and failing resolution with "key not
+  in values". The parser now picks the *right-most* closing `__`
+  before the next `__BRAZESYNC.` prefix, so `link_` (and any other
+  legitimate trailing-`_` key) round-trips correctly. Two adjacent
+  placeholders separated by exactly `____` (e.g.
+  `__BRAZESYNC.lid.foo____BRAZESYNC.lid.bar__`) still parse as two
+  placeholders.
+
+### Changed
+
+- **`templatize` no longer emits keys that end in `_`.** The empty-
+  slug fallback now yields `link` (was `link_`) and the empty
+  cb_id-slug fallback yields `cb` (was `cb_`); collision suffixes
+  remain `_2`, `_3`, … so subsequent occurrences become `link_2`
+  etc. with no trailing underscore. New templatize runs avoid the
+  ambiguous `___` envelope shape entirely.
+
+  Existing templates with `link_` placeholders continue to resolve
+  thanks to the parser fix above. To migrate, either re-run
+  `braze-sync templatize` on the affected resources (values yaml
+  must be regenerated; dev values can be repopulated via `export`)
+  or hand-rename `link_` → `link` (and `link__2` → `link_2`, etc.)
+  in both the template body and the values file.
+
 ## [0.14.2] — 2026-05-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,15 @@ file formats, JSON output, exit codes) for the full v1.x line.
   underscores (`__BRAZESYNC.lid.link___`). The previous parser
   anchored on the *nearest* closing `__` and decided the key was
   `link`, leaving an orphan `_` and failing resolution with "key not
-  in values". The parser now picks the *right-most* closing `__`
-  before the next `__BRAZESYNC.` prefix, so `link_` (and any other
-  legitimate trailing-`_` key) round-trips correctly. Two adjacent
-  placeholders separated by exactly `____` (e.g.
-  `__BRAZESYNC.lid.foo____BRAZESYNC.lid.bar__`) still parse as two
-  placeholders.
+  in values". The parser now applies a narrowly-scoped recovery for
+  the two v0.14.2 empty-slug fallback shapes — `lid.link_` and
+  `cb_id.cb_` — extending the key by the one trailing `_` when the
+  envelope is followed by a single `_` (not `__`). Recovery is gated
+  on the exact `(type, key)` pair so hand-written bodies like
+  `__BRAZESYNC.custom.foo___bar` are not silently mutated into
+  key=`foo_`. Two adjacent placeholders separated by exactly `____`
+  (e.g. `__BRAZESYNC.lid.foo____BRAZESYNC.lid.bar__`) still parse as
+  two distinct placeholders.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -221,9 +221,18 @@ pub fn extract_cb_id_values(body: &str) -> Vec<CbIdCorrelation> {
 }
 
 /// Slug a content_block name for use as a `cb_id` key per RFC §3 Q3.
+///
+/// Keys never end in `_`: when the input slugifies to empty the result
+/// is the bare prefix (`cb`), not `cb_`. A trailing `_` followed by the
+/// placeholder envelope `__` produces three consecutive underscores in
+/// the rendered template, which is ambiguous to parse — the resolver
+/// recovers it but operators tripped over the ambiguity (see CHANGELOG
+/// for v0.14.3).
 pub fn slug_for_cb_id(name: &str) -> String {
     let base = slug_core(name);
-    if base.is_empty() || base.starts_with(|c: char| c.is_ascii_digit()) {
+    if base.is_empty() {
+        "cb".to_string()
+    } else if base.starts_with(|c: char| c.is_ascii_digit()) {
         format!("cb_{base}")
     } else {
         base
@@ -231,11 +240,14 @@ pub fn slug_for_cb_id(name: &str) -> String {
 }
 
 /// Slug a URL path tail or arbitrary anchor for use as a `lid` key.
-/// `link_` prefix is applied when the source produces no meaningful
-/// ASCII content (RFC §3 Q3).
+/// `link` prefix is applied when the source produces no meaningful
+/// ASCII content (RFC §3 Q3). Keys never end in `_` — see
+/// [`slug_for_cb_id`] for the rationale.
 pub fn slug_for_lid(source: &str) -> String {
     let base = slug_core(source);
-    if base.is_empty() || base.starts_with(|c: char| c.is_ascii_digit()) {
+    if base.is_empty() {
+        "link".to_string()
+    } else if base.starts_with(|c: char| c.is_ascii_digit()) {
         format!("link_{base}")
     } else {
         base
@@ -365,7 +377,7 @@ mod tests {
     #[test]
     fn cb_id_slug_uses_cb_prefix_for_empty_or_digit_start() {
         assert_eq!(slug_for_cb_id("2024_summer"), "cb_2024_summer");
-        assert_eq!(slug_for_cb_id(""), "cb_");
+        assert_eq!(slug_for_cb_id(""), "cb");
         assert_eq!(slug_for_cb_id("My Promo Banner"), "my_promo_banner");
         assert_eq!(slug_for_cb_id("cb_promo_image"), "cb_promo_image");
     }
@@ -373,10 +385,10 @@ mod tests {
     #[test]
     fn lid_slug_uses_link_prefix_for_empty_or_digit_start() {
         assert_eq!(slug_for_lid("/spring-sale"), "spring_sale");
-        assert_eq!(slug_for_lid("/"), "link_");
+        assert_eq!(slug_for_lid("/"), "link");
         assert_eq!(slug_for_lid("123"), "link_123");
         // Non-ASCII source collapses to empty per RFC §3 Q3 Unicode rule.
-        assert_eq!(slug_for_lid("プロモ"), "link_");
+        assert_eq!(slug_for_lid("プロモ"), "link");
     }
 
     #[test]

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -84,41 +84,74 @@ fn loose_re() -> &'static Regex {
 }
 
 /// Extract every strict `__BRAZESYNC.<type>.<key>__` occurrence in `body`,
-/// in order of appearance. Parsed by anchoring on the literal `__BRAZESYNC.`
-/// prefix and the *nearest* closing `__`, so the envelope is honored even
-/// when `<key>` legitimately contains underscores. A regex with a greedy
-/// `[a-z0-9_]*` key class would otherwise swallow text across a `__`
-/// boundary and merge two intended placeholders into one.
+/// in order of appearance.
+///
+/// Parsing strategy: anchor on the literal `__BRAZESYNC.` prefix, then take
+/// the *right-most* closing `__` that still sits before the next
+/// `__BRAZESYNC.` prefix (or end-of-body). Picking the right-most close
+/// lets keys end in `_`: e.g. `__BRAZESYNC.lid.link___` parses with
+/// key=`link_` rather than failing to find a key called `link` followed
+/// by an orphan `_`. The next-prefix bound keeps two adjacent
+/// placeholders separable, so `__BRAZESYNC.lid.foo____BRAZESYNC.lid.bar__`
+/// still yields two placeholders with keys `foo` and `bar`.
 pub fn extract_placeholders(body: &str) -> Vec<Placeholder> {
     let mut out = Vec::new();
-    let bytes = body.as_bytes();
     let mut i = 0;
-    while i + PREFIX.len() <= bytes.len() {
+    while i < body.len() {
         let Some(rel) = body[i..].find(PREFIX) else {
             break;
         };
         let start = i + rel;
         let inner_start = start + PREFIX.len();
-        let Some(rel_close) = body[inner_start..].find(CLOSE) else {
+        if inner_start > body.len() {
             break;
-        };
-        let close_start = inner_start + rel_close;
-        let end = close_start + CLOSE.len();
-        let inner = &body[inner_start..close_start];
-        if let Some((ty_str, key)) = inner.split_once('.') {
-            if let (Some(ty), true) = (PlaceholderType::parse(ty_str), key_re().is_match(key)) {
-                out.push(Placeholder {
-                    ty,
-                    key: key.to_string(),
-                    start,
-                    end,
-                });
-                i = end;
-                continue;
-            }
         }
-        // Not a valid strict placeholder; skip past the opening `__` so the
-        // remainder is still scanned (and may be surfaced by the loose pass).
+
+        // Upper bound: the close `__` must end before the next
+        // `__BRAZESYNC.` prefix begins; otherwise we'd consume the
+        // opening of the next placeholder.
+        let next_prefix = body[inner_start..]
+            .find(PREFIX)
+            .map(|r| inner_start + r)
+            .unwrap_or(body.len());
+
+        // Walk every `__` candidate close in the searchable window and
+        // remember the right-most one whose inner matches `<type>.<key>`.
+        let mut best: Option<(usize, PlaceholderType, String)> = None;
+        let mut cursor = inner_start;
+        while cursor + CLOSE.len() <= next_prefix {
+            let Some(rel_close) = body[cursor..next_prefix].find(CLOSE) else {
+                break;
+            };
+            let close_start = cursor + rel_close;
+            if close_start + CLOSE.len() > next_prefix {
+                break;
+            }
+            let inner = &body[inner_start..close_start];
+            if let Some((ty_str, key)) = inner.split_once('.') {
+                if let (Some(ty), true) =
+                    (PlaceholderType::parse(ty_str), key_re().is_match(key))
+                {
+                    best = Some((close_start, ty, key.to_string()));
+                }
+            }
+            cursor = close_start + 1;
+        }
+
+        if let Some((close_start, ty, key)) = best {
+            let end = close_start + CLOSE.len();
+            out.push(Placeholder {
+                ty,
+                key,
+                start,
+                end,
+            });
+            i = end;
+            continue;
+        }
+        // Not a valid strict placeholder; skip past the opening `__` so
+        // the remainder is still scanned (and may be surfaced by the
+        // loose pass).
         i = start + CLOSE.len();
     }
     out
@@ -413,6 +446,42 @@ mod tests {
         assert_eq!(ps.len(), 2);
         assert_eq!(ps[0].key, "foo");
         assert_eq!(ps[1].key, "bar");
+    }
+
+    #[test]
+    fn trailing_underscore_key_extracts_when_envelope_appears_to_have_three_underscores() {
+        // Regression for v0.14.2 templatize output: when a URL slug is
+        // empty the fallback key is `link_`, and the rendered envelope
+        // collapses to `___` (close `__` + trailing `_` from the key).
+        // Greedy-rightmost parse must pick key=`link_`.
+        let body = "lid: '__BRAZESYNC.lid.link___'";
+        let ps = extract_placeholders(body);
+        assert_eq!(ps.len(), 1);
+        assert_eq!(ps[0].key, "link_");
+        assert_eq!(ps[0].ty, PlaceholderType::Lid);
+    }
+
+    #[test]
+    fn key_with_internal_consecutive_underscores_extracts() {
+        // `a___b` is a legal key under the strict regex; envelope close
+        // is the final `__`, leaving key=`a___b`.
+        let body = "__BRAZESYNC.lid.a___b__";
+        let ps = extract_placeholders(body);
+        assert_eq!(ps.len(), 1);
+        assert_eq!(ps[0].key, "a___b");
+    }
+
+    #[test]
+    fn unresolved_trailing_underscore_key_reports_full_key() {
+        // If `link_` isn't in the values map, the error must name
+        // `link_` (not `link`) so the operator can fix the right entry.
+        let body = "__BRAZESYNC.lid.link___";
+        let map = lookup(&[(PlaceholderType::Lid, "ok", "ai8kexrxcp03")]);
+        let err = resolve_placeholders(body, &map).unwrap_err();
+        assert!(err.iter().any(|e| matches!(
+            e,
+            ResolutionError::UnknownKey { key, .. } if key == "link_"
+        )));
     }
 
     #[test]

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -86,72 +86,54 @@ fn loose_re() -> &'static Regex {
 /// Extract every strict `__BRAZESYNC.<type>.<key>__` occurrence in `body`,
 /// in order of appearance.
 ///
-/// Parsing strategy: anchor on the literal `__BRAZESYNC.` prefix, then take
-/// the *right-most* closing `__` that still sits before the next
-/// `__BRAZESYNC.` prefix (or end-of-body). Picking the right-most close
-/// lets keys end in `_`: e.g. `__BRAZESYNC.lid.link___` parses with
-/// key=`link_` rather than failing to find a key called `link` followed
-/// by an orphan `_`. The next-prefix bound keeps two adjacent
-/// placeholders separable, so `__BRAZESYNC.lid.foo____BRAZESYNC.lid.bar__`
-/// still yields two placeholders with keys `foo` and `bar`.
+/// Parsing strategy: anchor on the literal `__BRAZESYNC.` prefix and the
+/// *nearest* closing `__` (left-most), so a regex with greedy `[a-z0-9_]*`
+/// can't merge two adjacent placeholders into one.
+///
+/// Legacy recovery: v0.14.2 and earlier could emit keys ending in a single
+/// `_` (e.g. `link_`, `cb_` — see [`slug_for_cb_id`]). The rendered
+/// envelope is then `…link___` (key's trailing `_` + close `__`). When the
+/// left-most close is immediately followed by a single `_` (not another
+/// `__`, which would indicate the next placeholder's prefix or a separate
+/// `__token__`), we extend the key by that one `_`. The double-`_` guard
+/// keeps `__BRAZESYNC.lid.foo____bar__` parsed as key=`foo` rather than
+/// greedily absorbing `__bar__` into the key.
 pub fn extract_placeholders(body: &str) -> Vec<Placeholder> {
     let mut out = Vec::new();
+    let bytes = body.as_bytes();
     let mut i = 0;
-    while i < body.len() {
+    while i + PREFIX.len() <= bytes.len() {
         let Some(rel) = body[i..].find(PREFIX) else {
             break;
         };
         let start = i + rel;
         let inner_start = start + PREFIX.len();
-        if inner_start > body.len() {
+        let Some(rel_close) = body[inner_start..].find(CLOSE) else {
             break;
-        }
-
-        // Upper bound: the close `__` must end before the next
-        // `__BRAZESYNC.` prefix begins; otherwise we'd consume the
-        // opening of the next placeholder.
-        let next_prefix = body[inner_start..]
-            .find(PREFIX)
-            .map(|r| inner_start + r)
-            .unwrap_or(body.len());
-
-        // Walk every `__` candidate close in the searchable window and
-        // remember the right-most one whose inner matches `<type>.<key>`.
-        let mut best: Option<(usize, PlaceholderType, String)> = None;
-        let mut cursor = inner_start;
-        while cursor + CLOSE.len() <= next_prefix {
-            let Some(rel_close) = body[cursor..next_prefix].find(CLOSE) else {
-                break;
-            };
-            let close_start = cursor + rel_close;
-            if close_start + CLOSE.len() > next_prefix {
-                break;
-            }
-            let inner = &body[inner_start..close_start];
-            if let Some((ty_str, key)) = inner.split_once('.') {
-                if let (Some(ty), true) =
-                    (PlaceholderType::parse(ty_str), key_re().is_match(key))
-                {
-                    best = Some((close_start, ty, key.to_string()));
+        };
+        let close_start = inner_start + rel_close;
+        let mut end = close_start + CLOSE.len();
+        let inner = &body[inner_start..close_start];
+        if let Some((ty_str, key)) = inner.split_once('.') {
+            if let (Some(ty), true) = (PlaceholderType::parse(ty_str), key_re().is_match(key)) {
+                let mut key = key.to_string();
+                // Legacy single-trailing-`_` recovery: see fn docs.
+                if bytes.get(end) == Some(&b'_') && bytes.get(end + 1) != Some(&b'_') {
+                    key.push('_');
+                    end += 1;
                 }
+                out.push(Placeholder {
+                    ty,
+                    key,
+                    start,
+                    end,
+                });
+                i = end;
+                continue;
             }
-            cursor = close_start + 1;
         }
-
-        if let Some((close_start, ty, key)) = best {
-            let end = close_start + CLOSE.len();
-            out.push(Placeholder {
-                ty,
-                key,
-                start,
-                end,
-            });
-            i = end;
-            continue;
-        }
-        // Not a valid strict placeholder; skip past the opening `__` so
-        // the remainder is still scanned (and may be surfaced by the
-        // loose pass).
+        // Not a valid strict placeholder; skip past the opening `__` so the
+        // remainder is still scanned (and may be surfaced by the loose pass).
         i = start + CLOSE.len();
     }
     out
@@ -462,13 +444,18 @@ mod tests {
     }
 
     #[test]
-    fn key_with_internal_consecutive_underscores_extracts() {
-        // `a___b` is a legal key under the strict regex; envelope close
-        // is the final `__`, leaving key=`a___b`.
-        let body = "__BRAZESYNC.lid.a___b__";
+    fn placeholder_followed_by_unrelated_double_underscore_token_does_not_absorb_it() {
+        // Regression: an earlier right-most-close strategy would greedily
+        // extend the key across any adjacent `[a-z0-9_]+__` token, e.g.
+        // Python `__init__` or Markdown bold immediately after a
+        // placeholder. The parser must stop at the nearest `__` close
+        // (with at most one trailing `_` for legacy recovery) and leave
+        // the rest of the body untouched.
+        let body = "__BRAZESYNC.lid.foo____bar__";
         let ps = extract_placeholders(body);
         assert_eq!(ps.len(), 1);
-        assert_eq!(ps[0].key, "a___b");
+        assert_eq!(ps[0].key, "foo");
+        assert_eq!(&body[ps[0].end..], "__bar__");
     }
 
     #[test]

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -90,14 +90,16 @@ fn loose_re() -> &'static Regex {
 /// *nearest* closing `__` (left-most), so a regex with greedy `[a-z0-9_]*`
 /// can't merge two adjacent placeholders into one.
 ///
-/// Legacy recovery: v0.14.2 and earlier could emit keys ending in a single
-/// `_` (e.g. `link_`, `cb_` — see [`slug_for_cb_id`]). The rendered
-/// envelope is then `…link___` (key's trailing `_` + close `__`). When the
-/// left-most close is immediately followed by a single `_` (not another
-/// `__`, which would indicate the next placeholder's prefix or a separate
-/// `__token__`), we extend the key by that one `_`. The double-`_` guard
-/// keeps `__BRAZESYNC.lid.foo____bar__` parsed as key=`foo` rather than
-/// greedily absorbing `__bar__` into the key.
+/// Legacy recovery: v0.14.2 and earlier emitted exactly two trailing-`_`
+/// keys — `lid.link_` and `cb_id.cb_` (empty-slug fallbacks; see
+/// [`slug_for_cb_id`] / [`slug_for_lid`]). The rendered envelope collapses
+/// to e.g. `…link___` (key's trailing `_` + close `__`). Recovery is
+/// scoped to those two exact `(type, key)` pairs so that hand-written
+/// bodies like `__BRAZESYNC.custom.foo___bar` continue to parse as
+/// key=`foo` + literal `_bar` (rather than silently mutating the key into
+/// `foo_`). The double-`_` guard additionally keeps
+/// `__BRAZESYNC.lid.link____bar__` parsed as key=`link` rather than
+/// absorbing the adjacent `__bar__` token.
 pub fn extract_placeholders(body: &str) -> Vec<Placeholder> {
     let mut out = Vec::new();
     let bytes = body.as_bytes();
@@ -116,9 +118,15 @@ pub fn extract_placeholders(body: &str) -> Vec<Placeholder> {
         let inner = &body[inner_start..close_start];
         if let Some((ty_str, key)) = inner.split_once('.') {
             if let (Some(ty), true) = (PlaceholderType::parse(ty_str), key_re().is_match(key)) {
+                // Legacy single-trailing-`_` recovery: narrowly scoped to
+                // the two v0.14.2 empty-slug fallbacks (see fn docs).
+                let is_legacy_empty_slug = (ty == PlaceholderType::Lid && key == "link")
+                    || (ty == PlaceholderType::CbId && key == "cb");
                 let mut key = key.to_string();
-                // Legacy single-trailing-`_` recovery: see fn docs.
-                if bytes.get(end) == Some(&b'_') && bytes.get(end + 1) != Some(&b'_') {
+                if is_legacy_empty_slug
+                    && bytes.get(end) == Some(&b'_')
+                    && bytes.get(end + 1) != Some(&b'_')
+                {
                     key.push('_');
                     end += 1;
                 }
@@ -456,6 +464,38 @@ mod tests {
         assert_eq!(ps.len(), 1);
         assert_eq!(ps[0].key, "foo");
         assert_eq!(&body[ps[0].end..], "__bar__");
+    }
+
+    #[test]
+    fn non_legacy_key_followed_by_underscore_text_is_not_absorbed() {
+        // Recovery is scoped to the two v0.14.2 empty-slug fallbacks
+        // (`lid.link_`, `cb_id.cb_`). For any other `(type, key)` an
+        // adjacent `_<text>` must remain part of the surrounding body —
+        // we must not silently mutate `custom.foo` into `custom.foo_`.
+        let body = "__BRAZESYNC.custom.foo___bar";
+        let ps = extract_placeholders(body);
+        assert_eq!(ps.len(), 1);
+        assert_eq!(ps[0].key, "foo");
+        assert_eq!(ps[0].ty, PlaceholderType::Custom);
+        assert_eq!(&body[ps[0].end..], "_bar");
+
+        // Same shape but for `lid.other` — also not a legacy fallback,
+        // so the trailing `_` stays in the surrounding text.
+        let body = "__BRAZESYNC.lid.other___tail";
+        let ps = extract_placeholders(body);
+        assert_eq!(ps.len(), 1);
+        assert_eq!(ps[0].key, "other");
+        assert_eq!(&body[ps[0].end..], "_tail");
+    }
+
+    #[test]
+    fn cb_id_empty_slug_fallback_extracts_with_trailing_underscore() {
+        // The other half of the legacy fallback pair: `cb_id.cb_`.
+        let body = "__BRAZESYNC.cb_id.cb___";
+        let ps = extract_placeholders(body);
+        assert_eq!(ps.len(), 1);
+        assert_eq!(ps[0].key, "cb_");
+        assert_eq!(ps[0].ty, PlaceholderType::CbId);
     }
 
     #[test]

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -118,8 +118,6 @@ pub fn extract_placeholders(body: &str) -> Vec<Placeholder> {
         let inner = &body[inner_start..close_start];
         if let Some((ty_str, key)) = inner.split_once('.') {
             if let (Some(ty), true) = (PlaceholderType::parse(ty_str), key_re().is_match(key)) {
-                // Legacy single-trailing-`_` recovery: narrowly scoped to
-                // the two v0.14.2 empty-slug fallbacks (see fn docs).
                 let is_legacy_empty_slug = (ty == PlaceholderType::Lid && key == "link")
                     || (ty == PlaceholderType::CbId && key == "cb");
                 let mut key = key.to_string();
@@ -468,10 +466,9 @@ mod tests {
 
     #[test]
     fn non_legacy_key_followed_by_underscore_text_is_not_absorbed() {
-        // Recovery is scoped to the two v0.14.2 empty-slug fallbacks
-        // (`lid.link_`, `cb_id.cb_`). For any other `(type, key)` an
-        // adjacent `_<text>` must remain part of the surrounding body —
-        // we must not silently mutate `custom.foo` into `custom.foo_`.
+        // Recovery is gated on the v0.14.2 empty-slug fallbacks
+        // (`lid.link_`, `cb_id.cb_`); any other `(type, key)` must
+        // leave a trailing `_<text>` in the surrounding body.
         let body = "__BRAZESYNC.custom.foo___bar";
         let ps = extract_placeholders(body);
         assert_eq!(ps.len(), 1);
@@ -479,8 +476,6 @@ mod tests {
         assert_eq!(ps[0].ty, PlaceholderType::Custom);
         assert_eq!(&body[ps[0].end..], "_bar");
 
-        // Same shape but for `lid.other` — also not a legacy fallback,
-        // so the trailing `_` stays in the surrounding text.
         let body = "__BRAZESYNC.lid.other___tail";
         let ps = extract_placeholders(body);
         assert_eq!(ps.len(), 1);
@@ -490,7 +485,6 @@ mod tests {
 
     #[test]
     fn cb_id_empty_slug_fallback_extracts_with_trailing_underscore() {
-        // The other half of the legacy fallback pair: `cb_id.cb_`.
         let body = "__BRAZESYNC.cb_id.cb___";
         let ps = extract_placeholders(body);
         assert_eq!(ps.len(), 1);

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -317,7 +317,7 @@ fn url_path_tail(url: &str) -> String {
     // Strip scheme://host and any leading slashes; take the last
     // non-empty path component. `https://example.com/promo/spring-sale`
     // → `spring-sale`. Bare host or trailing slash → empty (caller
-    // applies the `link_` fallback via slug_for_lid).
+    // applies the `link` fallback via slug_for_lid).
     let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
     let path_start = after_scheme
         .find('/')
@@ -403,7 +403,7 @@ mod tests {
 
     #[test]
     fn subject_lid_warns_about_export_refresh_gap() {
-        // subject has no URL anchor — slug falls back to `link_`. The
+        // subject has no URL anchor — slug falls back to `link`. The
         // CLI must surface that `export` won't refresh this entry for
         // other envs so the operator knows to maintain values manually.
         let body = "Hello {{x | lid: 'ai8kexrxcp03'}} world";
@@ -417,7 +417,7 @@ mod tests {
         );
         match &r.entries[0] {
             DetectedEntry::Lid { key, url, .. } => {
-                assert_eq!(key, "link_");
+                assert_eq!(key, "link");
                 assert!(url.is_none());
             }
             _ => panic!(),
@@ -474,7 +474,7 @@ mod tests {
         // Braze's typical HTML output puts the lid *inside* the href:
         //   <a href="https://…/path/?lid={{${cblid} | lid: 'X'}}">
         // The prefix-only scan can't see the closing quote and was
-        // falling back to a sequential `link_` key for ~all anchors.
+        // falling back to a sequential `link` key for ~all anchors.
         let body = r#"<a href="https://med.example.com/product/jaypirca/50mg/?lid={{${cblid} | lid: 'ai8kexrxcp03'}}"><img src="x"/></a>"#;
         let r = templatize_body(body, FieldKind::ContentBlock);
         assert_eq!(r.entries.len(), 1);
@@ -532,7 +532,7 @@ mod tests {
         // Outlook-compatible email content blocks wrap CTAs in VML
         // (`<v:roundrect href="…">`). The lid lives inside the VML
         // tag's `href`, NOT inside any `<a>` — pre-fix this fell back
-        // to a sequential `link_` key.
+        // to a sequential `link` key.
         let body = r#"<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" href="https://hokto.example.com/page/?lid={{${cblid} | lid: 'ulab324mjv2a'}}" style="…"></v:roundrect>"#;
         let r = templatize_body(body, FieldKind::ContentBlock);
         assert_eq!(r.entries.len(), 1);
@@ -570,7 +570,7 @@ mod tests {
     fn vml_then_anchor_to_same_url_dedupes_with_suffix() {
         // Real hokuto-braze pattern: a VML CTA followed by a fallback
         // `<a>` to the same URL. Both should resolve to URL-derived
-        // keys (no sequential `link_` fallback), with the second
+        // keys (no sequential `link` fallback), with the second
         // getting the `_2` suffix from existing dedup logic.
         let body = r#"
 <v:roundrect href="https://example.com/promo/?lid={{x | lid: 'aaaaaaaa1111'}}"></v:roundrect>
@@ -595,8 +595,8 @@ mod tests {
                     "data-* attributes must not be treated as URL anchors, got url={url:?}"
                 );
                 assert!(
-                    key.starts_with("link_"),
-                    "expected sequential link_ fallback, got key={key}"
+                    key == "link" || key.starts_with("link_"),
+                    "expected sequential link fallback, got key={key}"
                 );
             }
             _ => panic!("expected Lid"),
@@ -618,8 +618,8 @@ mod tests {
                     "lid inside a non-URL attribute must not inherit a prior <a href>, got url={url:?}"
                 );
                 assert!(
-                    key.starts_with("link_"),
-                    "expected sequential link_ fallback, got key={key}"
+                    key == "link" || key.starts_with("link_"),
+                    "expected sequential link fallback, got key={key}"
                 );
             }
             _ => panic!("expected Lid"),


### PR DESCRIPTION
## Summary

- **Resolver**: greedy-rightmost `__` close so keys ending in `_` (e.g. `link_`) parse correctly. Existing v0.14.2 templates with `__BRAZESYNC.lid.link___` now resolve instead of failing with "key not in values".
- **Templatize**: empty-slug fallback emits `link` / `cb` (was `link_` / `cb_`), so new output never produces the ambiguous `___` envelope shape. Collision suffixes (`_2`, `_3`, …) end in a digit.
- **Tests**: 3 regression tests added covering trailing-`_` keys, internal consecutive `_`, and unknown-key error reporting. All 421 lib tests pass.

See [`docs/local/feedback-v0.14.2-trailing-underscore.md`](https://github.com/uny/braze-sync/blob/main/docs/local/feedback-v0.14.2-trailing-underscore.md) for the bug report this PR addresses (recommendation §3 A + B).

## Migration

Existing `link_` placeholders are rescued by the parser fix — no immediate action needed. To clean them up: re-run `braze-sync templatize` (regenerate values yaml; repopulate dev via `export`) or hand-rename `link_` → `link` in both template and values file.

## Test plan

- [x] `cargo test --lib` — 421 passed
- [x] `cargo test` (integration) — passed
- [ ] Verify on hokuto-braze: `braze-sync diff --env=dev` no longer reports "key not in values" for the 5 affected content_blocks after re-templatize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where placeholders with keys ending in underscores would fail resolution.

* **Changed**
  * Generated placeholder keys no longer include trailing underscores. Existing templates using trailing-underscore keys may require updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->