### PR TITLE
feat!: anonymous __BRAZESYNC__ placeholder (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [0.16.0] — 2026-05-25
+
+### Changed (breaking)
+
+- **Placeholder syntax simplified to anonymous `__BRAZESYNC__`**. The
+  v0.15 form `__BRAZESYNC.<type>.<key>__` is removed. Type (lid vs
+  cb_id) is inferred from the surrounding `| lid:` / `| id:` filter
+  context, and the key is no longer needed (correlation has always
+  been done by URL / `${NAME}` / positional — the key was an internal
+  identifier with no role in matching).
+
+  ```liquid
+  # Before (v0.15)
+  | lid: '__BRAZESYNC.lid.spring_sale__'
+  | id:  '__BRAZESYNC.cb_id.promo_banner__'
+
+  # After (v0.16)
+  | lid: '__BRAZESYNC__'
+  | id:  '__BRAZESYNC__'
+  ```
+
+  **Migration**: re-run `braze-sync templatize` on each workspace
+  before upgrading. The old envelope is detected and surfaced as a
+  fatal `RetiredNamespace` error so partial migrations fail loudly
+  rather than ship broken templates. No `--modernize` / dual-parser
+  compat path is provided.
+
+- **New-resource lid fallback** now derives from the URL path tail
+  (e.g. `https://example.com/spring-sale` → `spring_sale`) rather than
+  from the placeholder key. URL-less placeholders fall back to
+  positional `lid_1`, `lid_2`, …
+
+- **`DuplicateLidKey` error removed.** Anonymous placeholders have no
+  keys, so the per-key duplicate detection no longer applies.
+  Ambiguous URL anchors still produce a positional-FIFO warning.
+
+### Removed
+
+- `Placeholder.key`, `PlaceholderType::parse`,
+  `ResolutionError::UnknownKey`, `ResolutionError::DuplicateLidKey`,
+  `LookupKey`, `resolve_placeholders`. Resolution is now offset-based
+  and lives entirely in `crate::values::braze_managed::prepare_field`.
+
 ## [0.15.0] — 2026-05-25
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -1,4 +1,4 @@
-# Braze-managed placeholders (`__BRAZESYNC.lid.*__`, `__BRAZESYNC.cb_id.*__`)
+# Braze-managed placeholders (`__BRAZESYNC__`)
 
 When braze-sync pushes from Git to multiple environments, two values
 inside a resource body are **structurally identical but literally
@@ -14,45 +14,52 @@ Both are **Braze-owned**: each workspace assigns its own values on
 first save, the dashboard may reassign them after manual edits, and
 nothing the operator does in Git can guarantee a specific value.
 braze-sync therefore treats them as **runtime-resolved** — the local
-Git body carries a stable `__BRAZESYNC.*__` placeholder, and resolution
+Git body carries a stable `__BRAZESYNC__` placeholder, and resolution
 happens at apply/diff time by reading the live remote body via the
 Braze API.
 
 ## Placeholder syntax
 
 ```text
-__BRAZESYNC.<type>.<key>__
+__BRAZESYNC__
 ```
 
-- `<type>` ∈ `lid` | `cb_id`
-- `<key>` matches `[a-z][a-z0-9_]*` (snake_case)
+A single anonymous token represents both `lid` and `cb_id`
+placeholders. The type is inferred from the surrounding filter syntax:
+
+- `| lid: '__BRAZESYNC__'` → `lid`
+- `| id:  '__BRAZESYNC__'` → `cb_id`
 
 Example template body (this is what `braze-sync templatize` produces):
 
 ```liquid
-<a href="https://example.com/spring-sale">{{ ${cblid} | lid: '__BRAZESYNC.lid.spring_sale__' }}click</a>
-{{ content_blocks.${cb_promo_image} | id: '__BRAZESYNC.cb_id.cb_promo_image__' }}
+<a href="https://example.com/spring-sale">{{ ${cblid} | lid: '__BRAZESYNC__' }}click</a>
+{{ content_blocks.${cb_promo_image} | id: '__BRAZESYNC__' }}
 ```
 
-The double-underscore envelope and dot namespace are picked so the
-token is verbatim-safe in Liquid, HTML, and JSON contexts.
+The double-underscore envelope is picked so the token is verbatim-safe
+in Liquid, HTML, and JSON contexts. A `__BRAZESYNC__` outside a
+recognized `| lid:` / `| id:` argument fails resolution with an
+`UnknownContext` error so the typo doesn't slip through silently.
 
-A typo with the wrong envelope (`__BRAZSYNC.…__`) or a retired/unknown
-type (`__BRAZESYNC.custom.foo__`) surfaces as a `WARN:` line so it
-doesn't slip through silently.
+The v0.15 form `__BRAZESYNC.<type>.<key>__` is **retired**. It is
+detected on parse and surfaces as a `RetiredNamespace` error pointing
+operators at `braze-sync templatize`.
 
 ## How resolution works
 
 For every `apply` and `diff`:
 
 1. braze-sync `GET`s the live remote body for the resource.
-2. For each `__BRAZESYNC.lid.<key>__` in the local template, it
-   identifies the **URL anchor** (the surrounding `<a href>`,
-   VML/SVG `href`, or bare URL in plaintext) and pairs it with the
-   matching anchor in the remote body to lift the live `lid` value.
-3. For each `__BRAZESYNC.cb_id.<key>__`, it identifies the surrounding
-   `{{content_blocks.${NAME}}}` include and looks up the live `cb_id`
-   under the same `${NAME}` in the remote body.
+2. For each `__BRAZESYNC__` in a `| lid:` argument, it identifies the
+   **URL anchor** (the surrounding `<a href>`, VML/SVG `href`, or
+   bare URL in plaintext) and pairs it with the matching anchor in
+   the remote body to lift the live `lid` value. Multiple
+   placeholders sharing one URL consume distinct remote values in
+   template appearance order.
+3. For each `__BRAZESYNC__` in a `| id:` argument inside a
+   `{{content_blocks.${NAME} ...}}` include, it looks up the live
+   `cb_id` under the same `${NAME}` in the remote body.
 4. The resolved body is what diff compares against remote and what
    apply POSTs.
 
@@ -65,15 +72,15 @@ structure changes show up.
 When a resource doesn't exist in Braze yet, there is no remote body to
 correlate against. braze-sync applies a controlled fallback:
 
-- **`lid`**: the placeholder key is used verbatim as the lid value
-  (e.g. `__BRAZESYNC.lid.spring_sale__` → `spring_sale`). Braze
-  accepts arbitrary strings and may reassign on first dashboard open;
-  the next apply picks up the reassigned value via the
-  remote-resolution path above.
-- **`cb_id`**: the `| id: '__BRAZESYNC.cb_id.<key>__'` filter is
-  stripped entirely, leaving the documented form
-  `{{content_blocks.${NAME}}}`. Braze derives an internal `cb_id` on
-  save.
+- **`lid`**: derived from the URL path tail of the surrounding anchor,
+  slug-normalized (e.g. `https://example.com/spring-sale` →
+  `spring_sale`). Repeated slugs are disambiguated with `_2`, `_3`, …
+  URL-less placeholders fall back to positional `lid_1`, `lid_2`, …
+  Braze may reassign on first dashboard open; the next apply picks up
+  the reassigned value via the remote-resolution path above.
+- **`cb_id`**: the `| id: '__BRAZESYNC__'` filter is stripped
+  entirely, leaving the documented form `{{content_blocks.${NAME}}}`.
+  Braze derives an internal `cb_id` on save.
 
 ## How it ties into existing commands
 
@@ -86,39 +93,37 @@ correlate against. braze-sync applies a controlled fallback:
   `cb_id` are never round-tripped through Git.
 - **`templatize`** is the one-shot migration that detects raw
   `| lid: 'X'` and `{{content_blocks.${NAME} | id: 'cbN'}}` literals
-  in your existing files and rewrites them to `__BRAZESYNC.*__`
-  placeholders. Idempotent; safe to re-run.
+  in your existing files and rewrites them to `__BRAZESYNC__`.
+  Idempotent; safe to re-run.
 
-## Migration from v0.14.x
+## Migration from v0.15.x
 
-v0.14.x stored `lid` / `cb_id` values in per-env `values/<env>.yaml`.
-v0.15 removes that mechanism entirely: bodies templatized in v0.14
-keep working (the placeholder envelope is unchanged), and stale
-`values/<env>.yaml` files can simply be deleted — no command in
-v0.15 reads them.
+v0.15.x used the keyed form `__BRAZESYNC.<type>.<key>__`. v0.16
+removes it entirely. Re-run `braze-sync templatize` against each
+workspace before upgrading — that regenerates bodies with the new
+anonymous token. The v0.15 envelope is surfaced as a fatal error if
+it ever reaches resolve, so a partial migration fails loudly rather
+than shipping broken templates.
 
 ```bash
-# Confirm everything still resolves cleanly after upgrading:
-braze-sync diff --env=prod
-braze-sync diff --env=dev
-
-# Delete the now-unused values directory once diff is happy:
-rm -rf values/
+# On v0.15 (or earlier), re-templatize from the raw remote body to
+# emit the v0.16 anonymous form:
+braze-sync export --env=prod        # pull raw remote bodies
+braze-sync templatize               # rewrite to __BRAZESYNC__
 ```
 
 ## Known limitations
 
 - **Subject / preheader `lid` is resolved positionally.** Those fields
-  have no URL anchor, so the Nth `__BRAZESYNC.lid.*__` placeholder is
-  paired with the Nth `| lid: '…'` value in the remote field. If the
-  placeholder count and remote value count differ, the resolver emits
-  a warning and any leftover placeholders fail at resolve time.
+  have no URL anchor, so the Nth `__BRAZESYNC__` is paired with the
+  Nth `| lid: '…'` value in the remote field. If the placeholder
+  count and remote value count differ, the resolver emits a warning
+  and any leftover placeholders fail at resolve time.
 - **Two placeholders sharing one URL** are resolved positionally
-  (template appearance order → remote appearance order). When a URL has
-  multiple remote occurrences *and* multiple template placeholders, the
-  resolver emits an ambiguity warning so a dashboard-side link reorder
-  cannot silently miscorrelate. Use distinct keys per occurrence when
-  the mapping must be deterministic regardless of remote order.
+  (template appearance order → remote appearance order). When a URL
+  has multiple remote occurrences *and* multiple template
+  placeholders, the resolver emits an ambiguity warning so a
+  dashboard-side link reorder cannot silently miscorrelate.
 - **Structural drift between local and remote** (e.g. the dashboard
   removed a tracked link your template still references) aborts the
   apply with a clear error pointing at the unresolvable placeholder.

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -106,9 +106,8 @@ it ever reaches resolve, so a partial migration fails loudly rather
 than shipping broken templates.
 
 ```bash
-# On v0.15 (or earlier), re-templatize from the raw remote body to
-# emit the v0.16 anonymous form:
-braze-sync export --env=prod        # pull raw remote bodies
+# On v0.15 (or earlier), repeat per env to emit the v0.16 anonymous form:
+braze-sync export --env=<env>       # pull raw remote bodies for that env
 braze-sync templatize               # rewrite to __BRAZESYNC__
 ```
 

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -272,7 +272,7 @@ pub(crate) async fn compute_content_block_plan(
         .try_collect()
         .await?;
 
-    // Resolve `__BRAZESYNC.*__` placeholders now that the remote body
+    // Resolve `__BRAZESYNC__` placeholders now that the remote body
     // is in hand. lid / cb_id values come from the remote (or fallback
     // for new resources).
     drop(local_by_name);

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -272,10 +272,7 @@ async fn export_email_templates(
             let subject_has = has_placeholders(&local.subject);
             let body_html_has = has_placeholders(&local.body_html);
             let body_plain_has = has_placeholders(&local.body_plaintext);
-            let preheader_has = local
-                .preheader
-                .as_deref()
-                .is_some_and(has_placeholders);
+            let preheader_has = local.preheader.as_deref().is_some_and(has_placeholders);
             if subject_has {
                 to_save.subject = local.subject.clone();
             }

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -7,7 +7,7 @@ use crate::fs::{catalog_io, content_block_io, custom_attribute_io, email_templat
 use crate::resource::{
     ContentBlock, CustomAttributeRegistry, EmailTemplate, ResourceKind, Tag, TagRegistry,
 };
-use crate::values::extract_placeholders;
+use crate::values::has_placeholders;
 use anyhow::Context as _;
 use clap::Args;
 use futures::stream::{StreamExt, TryStreamExt};
@@ -165,7 +165,7 @@ async fn export_catalog_schemas(
 /// `--name`, the list still happens (to translate name → id) but only
 /// the matching block's body is fetched.
 ///
-/// When a local template with `__BRAZESYNC.*__` placeholders exists for
+/// When a local template with `__BRAZESYNC__` placeholders exists for
 /// a given name, the local body is preserved verbatim (templatized
 /// form is the source of truth). v0.15: no values-file writeback —
 /// lid / cb_id are resolved from the remote body at apply/diff time.
@@ -212,7 +212,7 @@ async fn export_content_blocks(
         };
         let mut to_save = remote.clone();
         if let Some(local) = local.as_ref() {
-            if !extract_placeholders(&local.content).is_empty() {
+            if has_placeholders(&local.content) {
                 to_save.content = local.content.clone();
             }
         }
@@ -223,7 +223,7 @@ async fn export_content_blocks(
 
 /// Same list-then-fetch pattern as content blocks. Per-field placeholder
 /// preservation: each of `subject`, `body_html`, `body_plaintext`,
-/// `preheader` is independently checked for `__BRAZESYNC.*__` content
+/// `preheader` is independently checked for `__BRAZESYNC__` content
 /// and, when present, kept from the local template instead of being
 /// overwritten by the remote body.
 async fn export_email_templates(
@@ -269,13 +269,13 @@ async fn export_email_templates(
         };
         let mut to_save = remote.clone();
         if let Some(local) = local.as_ref() {
-            let subject_has = !extract_placeholders(&local.subject).is_empty();
-            let body_html_has = !extract_placeholders(&local.body_html).is_empty();
-            let body_plain_has = !extract_placeholders(&local.body_plaintext).is_empty();
+            let subject_has = has_placeholders(&local.subject);
+            let body_html_has = has_placeholders(&local.body_html);
+            let body_plain_has = has_placeholders(&local.body_plaintext);
             let preheader_has = local
                 .preheader
                 .as_deref()
-                .is_some_and(|p| !extract_placeholders(p).is_empty());
+                .is_some_and(has_placeholders);
             if subject_has {
                 to_save.subject = local.subject.clone();
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -84,7 +84,7 @@ pub enum Command {
     Apply(apply::ApplyArgs),
     /// Validate local files (no Braze API access required)
     Validate(validate::ValidateArgs),
-    /// Rewrite raw lid/cb_id literals to `__BRAZESYNC.*__` placeholders.
+    /// Rewrite raw lid/cb_id literals to `__BRAZESYNC__` placeholders.
     /// Local-only; no Braze API access required.
     Templatize(templatize::TemplatizeArgs),
 }

--- a/src/cli/templatize.rs
+++ b/src/cli/templatize.rs
@@ -1,5 +1,6 @@
 //! `braze-sync templatize` — one-shot local rewrite of raw lid/cb_id
-//! literals to `__BRAZESYNC.*__` placeholders. No Braze API calls.
+//! literals to anonymous `__BRAZESYNC__` placeholders. No Braze API
+//! calls.
 
 use std::path::Path;
 
@@ -33,7 +34,7 @@ pub async fn run(args: &TemplatizeArgs, cfg: &ConfigFile, config_dir: &Path) -> 
         for mut cb in blocks {
             let result = templatize_body(&cb.content, FieldKind::ContentBlock);
             if result.lid_rewrites + result.cb_id_rewrites == 0 {
-                if cb.content.contains("__BRAZESYNC.") {
+                if cb.content.contains("__BRAZESYNC__") {
                     summary.skipped.push(format!(
                         "content_block '{}' already templated — skipping",
                         cb.name
@@ -59,13 +60,13 @@ pub async fn run(args: &TemplatizeArgs, cfg: &ConfigFile, config_dir: &Path) -> 
         let templates = email_template_io::load_all_email_templates(&email_templates_root)
             .context("loading local email_templates for templatize")?;
         for mut et in templates {
-            let already_templated = et.subject.contains("__BRAZESYNC.")
-                || et.body_html.contains("__BRAZESYNC.")
-                || et.body_plaintext.contains("__BRAZESYNC.")
+            let already_templated = et.subject.contains("__BRAZESYNC__")
+                || et.body_html.contains("__BRAZESYNC__")
+                || et.body_plaintext.contains("__BRAZESYNC__")
                 || et
                     .preheader
                     .as_deref()
-                    .is_some_and(|p| p.contains("__BRAZESYNC."));
+                    .is_some_and(|p| p.contains("__BRAZESYNC__"));
 
             let subject_r = templatize_body(&et.subject, FieldKind::EmailSubject);
             let body_html_r = templatize_body(&et.body_html, FieldKind::EmailHtmlBody);

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -78,7 +78,14 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
         .collect();
 
     let lid_values: Vec<Option<String>> = match remote {
-        Some(remote_body) => resolve_lid_batch(&body, &placeholders, &lid_indices, remote_body, field, &mut warnings),
+        Some(remote_body) => resolve_lid_batch(
+            &body,
+            &placeholders,
+            &lid_indices,
+            remote_body,
+            field,
+            &mut warnings,
+        ),
         None => fallback_lid_batch(&body, &placeholders, &lid_indices, field),
     };
 
@@ -201,9 +208,7 @@ fn resolve_lid_batch(
         match pick {
             Some(p) => out.push(Some(p.value.clone())),
             None => {
-                warnings.push(format!(
-                    "lid: URL anchor '{url}' not found in remote body"
-                ));
+                warnings.push(format!("lid: URL anchor '{url}' not found in remote body"));
                 out.push(None);
             }
         }
@@ -335,7 +340,12 @@ fn url_path_tail(url: &str) -> String {
         .find('/')
         .map(|i| i + 1)
         .unwrap_or(after_scheme.len());
-    let path = &after_scheme[path_start..];
+    // Strip query / fragment (normalize_url already does this for the
+    // main call-path, but be safe if the function is reused).
+    let path = after_scheme[path_start..]
+        .split(['?', '#'])
+        .next()
+        .unwrap_or("");
     path.rsplit('/')
         .find(|s| !s.is_empty())
         .unwrap_or("")
@@ -359,10 +369,7 @@ fn strip_cb_id_filters(body: &str) -> (String, Vec<String>) {
             "cb_id `${{{name}}}`: new resource — stripping `| id: '…'` filter; \
              Braze will assign a cb_id on first save"
         ));
-        spans.push((
-            whole.range(),
-            format!("{{{{content_blocks.${{{name}}}}}}}"),
-        ));
+        spans.push((whole.range(), format!("{{{{content_blocks.${{{name}}}}}}}")));
     }
     let mut out = body.to_string();
     for (range, replacement) in spans.into_iter().rev() {
@@ -509,8 +516,7 @@ mod tests {
 
     #[test]
     fn cb_id_resolved_via_name() {
-        let template =
-            "{{content_blocks.${promo_banner} | id: '__BRAZESYNC__'}}";
+        let template = "{{content_blocks.${promo_banner} | id: '__BRAZESYNC__'}}";
         let remote = "{{content_blocks.${promo_banner} | id: 'cb99'}}";
         let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
         assert!(p.errors.is_empty());
@@ -519,8 +525,7 @@ mod tests {
 
     #[test]
     fn new_resource_lid_uses_url_slug_fallback() {
-        let template =
-            r#"<a href="https://x.com/spring-sale">{{x | lid: '__BRAZESYNC__'}}</a>"#;
+        let template = r#"<a href="https://x.com/spring-sale">{{x | lid: '__BRAZESYNC__'}}</a>"#;
         let p = prepare_field(template, None, FieldKind::ContentBlock);
         assert!(p.errors.is_empty());
         assert!(p.body.contains("'spring_sale'"), "got: {}", p.body);
@@ -536,8 +541,7 @@ mod tests {
 
     #[test]
     fn new_resource_strips_cb_id_filter() {
-        let template =
-            "before {{content_blocks.${promo} | id: '__BRAZESYNC__'}} after";
+        let template = "before {{content_blocks.${promo} | id: '__BRAZESYNC__'}} after";
         let p = prepare_field(template, None, FieldKind::ContentBlock);
         assert_eq!(p.body, "before {{content_blocks.${promo}}} after");
         assert!(p.warnings.iter().any(|w| w.contains("promo")));
@@ -612,5 +616,14 @@ mod tests {
             "plaintext URL slug must be used, got: {}",
             p.body
         );
+    }
+
+    #[test]
+    fn url_path_tail_strips_query_and_fragment() {
+        assert_eq!(url_path_tail("https://x.com/page/?utm=1"), "page");
+        assert_eq!(url_path_tail("https://x.com/page/#section"), "page");
+        assert_eq!(url_path_tail("https://x.com/page/?a=1#b"), "page");
+        assert_eq!(url_path_tail("https://x.com/"), "");
+        assert_eq!(url_path_tail("https://x.com/sale"), "sale");
     }
 }

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -1,10 +1,11 @@
-//! Runtime resolution of Braze-managed placeholders (`lid` / `cb_id`).
+//! Runtime resolution of anonymous `__BRAZESYNC__` placeholders.
 //!
 //! Resolved at apply/diff time from the remote body via URL / `${NAME}`
-//! anchor correlation.
+//! anchor correlation. Type (`lid` vs `cb_id`) is inferred from the
+//! surrounding `| lid:` / `| id:` filter syntax.
 //!
 //! New-resource fallback (no remote):
-//! - **lid**: placeholder key used as the value; Braze reassigns on
+//! - **lid**: URL path tail slug used as the value; Braze reassigns on
 //!   first dashboard open.
 //! - **cb_id**: `| id: '…'` filter stripped; Braze derives internally.
 
@@ -15,125 +16,140 @@ use regex_lite::Regex;
 
 use crate::values::correlation::{
     extract_cb_id_values, extract_html_lid_values, extract_lid_values_unanchored,
-    extract_plaintext_lid_values, normalize_url, CbIdCorrelation, LidCorrelation,
+    extract_plaintext_lid_values, normalize_url, slug_for_lid, CbIdCorrelation, LidCorrelation,
 };
-use crate::values::placeholder::{extract_placeholders, LookupKey, PlaceholderType};
+use crate::values::placeholder::{
+    extract_placeholders, find_suspicious_placeholders, PlaceholderType, ResolutionError, TOKEN,
+};
 use crate::values::templatize::FieldKind;
 
-/// Per-field result of preparing a templatized body for resolution.
+/// Per-field result of resolving a templatized body.
 #[derive(Debug, Clone)]
 pub struct PreparedTemplate {
-    /// Body to feed to `resolve_placeholders` after merging
-    /// `additions` into the lookup. May equal the input verbatim, or
-    /// differ when cb_id filter stripping was applied (new-resource
-    /// path).
+    /// Fully-resolved body. When `errors` is non-empty some `__BRAZESYNC__`
+    /// tokens may still be present — the caller treats the field as
+    /// failed and surfaces the errors.
     pub body: String,
-    /// `(type, key) -> value` entries to merge into the caller's
-    /// resolution lookup. Only carries lid / cb_id keys actually
-    /// referenced by `body`; never carries custom or global keys.
-    pub additions: BTreeMap<LookupKey, String>,
-    /// Non-fatal warnings — e.g. ambiguous URL matches, anchor-less
-    /// lid placeholders in subject/preheader.
+    /// Unresolved placeholders, retired-namespace tokens, etc.
+    pub errors: Vec<ResolutionError>,
+    /// Non-fatal warnings — ambiguous URL matches, count mismatches,
+    /// stripped cb_id filters on new resources.
     pub warnings: Vec<String>,
 }
 
-/// Prepare a templatized field for resolution.
+/// Resolve every `__BRAZESYNC__` in `template` against `remote`.
 ///
-/// `remote` is `None` when the resource does not yet exist in Braze
-/// (new resource on first apply). `field` selects the URL-anchor
-/// strategy (HTML href, plaintext URL, etc.).
+/// `remote = None` means the resource does not yet exist in Braze
+/// (new-resource path: lid → slug fallback, cb_id → filter stripped).
 pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> PreparedTemplate {
-    if !template.contains("__BRAZESYNC.") {
+    let mut errors: Vec<ResolutionError> = Vec::new();
+
+    // Retired v0.15 envelope detection — fatal so operators re-run
+    // `templatize`.
+    for tok in find_suspicious_placeholders(template) {
+        errors.push(ResolutionError::RetiredNamespace { token: tok });
+    }
+
+    if !template.contains(TOKEN) {
         return PreparedTemplate {
             body: template.to_string(),
-            additions: BTreeMap::new(),
+            errors,
             warnings: Vec::new(),
         };
     }
 
-    // For new resources we first strip the cb_id `| id: '…'` filter
-    // out of the template entirely. The remaining `__BRAZESYNC.lid.*__`
-    // placeholders get fallback values below.
     let (body, mut warnings) = match remote {
         Some(_) => (template.to_string(), Vec::new()),
         None => strip_cb_id_filters(template),
     };
 
-    let mut additions: BTreeMap<LookupKey, String> = BTreeMap::new();
+    // Map each `__BRAZESYNC__` occurrence in `body` to its resolved
+    // value. None entries are recorded as errors instead.
+    let placeholders = extract_placeholders(&body);
+    let mut resolved: Vec<(usize, usize, Option<String>)> = Vec::new();
 
-    match remote {
-        Some(remote_body) => {
-            resolve_lid_from_remote(&body, remote_body, field, &mut additions, &mut warnings);
-            resolve_cb_id_from_remote(&body, remote_body, &mut additions, &mut warnings);
+    // Collect lid placeholders so we can do the URL-bucket FIFO match in
+    // one pass.
+    let lid_indices: Vec<usize> = placeholders
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.ty == Some(PlaceholderType::Lid))
+        .map(|(i, _)| i)
+        .collect();
+
+    let lid_values: Vec<Option<String>> = match remote {
+        Some(remote_body) => resolve_lid_batch(&body, &placeholders, &lid_indices, remote_body, field, &mut warnings),
+        None => fallback_lid_batch(&body, &placeholders, &lid_indices),
+    };
+
+    // cb_id resolution map (offset → value or None).
+    let cb_id_resolved: BTreeMap<usize, Option<String>> = match remote {
+        Some(remote_body) => resolve_cb_id_batch(&body, &placeholders, remote_body, &mut warnings),
+        None => BTreeMap::new(),
+    };
+
+    let mut lid_iter = lid_values.into_iter();
+    for ph in &placeholders {
+        match ph.ty {
+            None => {
+                errors.push(ResolutionError::UnknownContext { start: ph.start });
+                resolved.push((ph.start, ph.end, None));
+            }
+            Some(PlaceholderType::Lid) => {
+                let v = lid_iter.next().flatten();
+                if v.is_none() {
+                    let anchor = lid_anchor_for(&body, ph.start, field);
+                    errors.push(ResolutionError::UnresolvedLid {
+                        start: ph.start,
+                        anchor,
+                    });
+                }
+                resolved.push((ph.start, ph.end, v));
+            }
+            Some(PlaceholderType::CbId) => {
+                let v = cb_id_resolved.get(&ph.start).cloned().flatten();
+                if v.is_none() {
+                    let name = cb_id_name_at(&body, ph.start);
+                    errors.push(ResolutionError::UnresolvedCbId {
+                        start: ph.start,
+                        name,
+                    });
+                }
+                resolved.push((ph.start, ph.end, v));
+            }
         }
-        None => {
-            fallback_lid_values(&body, &mut additions);
-            // cb_id placeholders no longer exist after stripping; nothing
-            // to add for cb_id in the new-resource path.
+    }
+
+    // Substitute back-to-front so byte offsets stay valid.
+    let mut out = body;
+    for (start, end, value) in resolved.into_iter().rev() {
+        if let Some(v) = value {
+            out.replace_range(start..end, &v);
         }
     }
 
     PreparedTemplate {
-        body,
-        additions,
+        body: out,
+        errors,
         warnings,
     }
 }
 
-/// Strip `| id: '__BRAZESYNC.cb_id.<key>__'` filters from a template
-/// body. Used for the new-resource fallback path so we POST the
-/// documented `{{content_blocks.${NAME}}}` form.
-///
-/// Returns the rewritten body plus one informational warning per
-/// stripped occurrence.
-fn strip_cb_id_filters(body: &str) -> (String, Vec<String>) {
-    let re = cb_id_filter_re();
-    let mut warnings: Vec<String> = Vec::new();
-    for cap in re.captures_iter(body) {
-        if let Some(key) = cap.get(1) {
-            warnings.push(format!(
-                "cb_id '{}': new resource — stripping `| id: '…'` filter; \
-                 Braze will assign a cb_id on first save",
-                key.as_str()
-            ));
-        }
-    }
-    let out = re.replace_all(body, "").to_string();
-    (out, warnings)
-}
-
-fn cb_id_filter_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        // Match `\s*| id: '__BRAZESYNC.cb_id.<key>__'` so the rendered
-        // form is `{{content_blocks.${NAME}}}` with no stray pipe.
-        Regex::new(r#"\s*\|\s*id:\s*['"]__BRAZESYNC\.cb_id\.([a-z][a-z0-9_]*)__['"]"#)
-            .expect("cb_id filter regex is valid")
-    })
-}
-
-fn fallback_lid_values(body: &str, out: &mut BTreeMap<LookupKey, String>) {
-    for ph in extract_placeholders(body) {
-        if matches!(ph.ty, PlaceholderType::Lid) {
-            out.insert((PlaceholderType::Lid, ph.key.clone()), ph.key);
-        }
-    }
-}
-
-/// Pair lid placeholders in `template` with `| lid: '…'` values in
-/// `remote` by URL anchor. Multiple placeholders sharing one anchor
-/// URL consume distinct remote occurrences in template appearance
-/// order.
-fn resolve_lid_from_remote(
-    template: &str,
+/// Resolve lid placeholders against `remote`. Returns one entry per
+/// lid placeholder in template-appearance order.
+fn resolve_lid_batch(
+    body: &str,
+    placeholders: &[crate::values::placeholder::Placeholder],
+    lid_indices: &[usize],
     remote: &str,
     field: FieldKind,
-    out: &mut BTreeMap<LookupKey, String>,
     warnings: &mut Vec<String>,
-) {
+) -> Vec<Option<String>> {
+    if lid_indices.is_empty() {
+        return Vec::new();
+    }
     if !field.supports_html_anchor() && !field.supports_plaintext_anchor() {
-        resolve_lid_positional(template, remote, field, out, warnings);
-        return;
+        return resolve_lid_positional(placeholders, lid_indices, remote, field, warnings);
     }
 
     let remote_pairs: Vec<LidCorrelation> = if field.supports_html_anchor() {
@@ -142,25 +158,20 @@ fn resolve_lid_from_remote(
         extract_plaintext_lid_values(remote)
     };
 
-    // (template_key, optional URL anchor, byte offset) in template
-    // appearance order.
-    let template_lids = collect_template_lid_anchors(template, field);
+    // Each lid placeholder's anchor URL in template-appearance order.
+    let anchors: Vec<Option<String>> = lid_indices
+        .iter()
+        .map(|&i| lid_anchor_for(body, placeholders[i].start, field))
+        .collect();
 
-    // Group remote pairs by normalized URL, FIFO so positional
-    // assignment is deterministic.
     let mut by_url: BTreeMap<String, std::collections::VecDeque<&LidCorrelation>> = BTreeMap::new();
     for p in &remote_pairs {
         by_url.entry(p.url.clone()).or_default().push_back(p);
     }
 
-    // Ambiguity warning: a URL with multiple remote occurrences AND
-    // multiple template placeholders means a Dashboard-side link
-    // reorder would silently miscorrelate. Emit once per ambiguous URL.
     let mut tmpl_per_url: BTreeMap<String, usize> = BTreeMap::new();
-    for (_, anchor, _) in &template_lids {
-        if let Some(u) = anchor {
-            *tmpl_per_url.entry(u.clone()).or_insert(0) += 1;
-        }
+    for u in anchors.iter().flatten() {
+        *tmpl_per_url.entry(u.clone()).or_insert(0) += 1;
     }
     for (url, bucket) in &by_url {
         let tmpl_count = tmpl_per_url.get(url).copied().unwrap_or(0);
@@ -175,145 +186,224 @@ fn resolve_lid_from_remote(
         }
     }
 
-    for (key, anchor, _offset) in template_lids {
+    let mut out = Vec::with_capacity(lid_indices.len());
+    for anchor in anchors {
         let Some(url) = anchor else {
-            warnings.push(format!(
-                "lid '{key}': placeholder has no URL anchor in template — \
+            warnings.push(
+                "lid placeholder has no URL anchor in template — \
                  anchor-less correlation is not supported; resolve will fail"
-            ));
+                    .to_string(),
+            );
+            out.push(None);
             continue;
         };
-        let needle = normalize_url(&url);
-        let pick = by_url
-            .get_mut(&needle)
-            .and_then(|bucket| bucket.pop_front());
-        let Some(pick) = pick else {
-            // Leave it unresolved — `resolve_placeholders` will surface
-            // the unresolved key with full context (offset, etc.).
-            warnings.push(format!(
-                "lid '{key}': URL anchor '{needle}' not found in remote body"
-            ));
-            continue;
-        };
-        out.insert((PlaceholderType::Lid, key), pick.value.clone());
+        let pick = by_url.get_mut(&url).and_then(|b| b.pop_front());
+        match pick {
+            Some(p) => out.push(Some(p.value.clone())),
+            None => {
+                warnings.push(format!(
+                    "lid: URL anchor '{url}' not found in remote body"
+                ));
+                out.push(None);
+            }
+        }
     }
+    out
 }
 
-/// Positional lid resolution for fields without URL anchors
-/// (subject / preheader). Maps the Nth template lid placeholder to the
-/// Nth `| lid: '…'` value in the remote field. Counts mismatch is a
-/// warning, not a fatal error — leftover unresolved placeholders will
-/// still surface via `resolve_placeholders` if they remain unfilled.
+/// Positional FIFO match for subject / preheader.
 fn resolve_lid_positional(
-    template: &str,
+    placeholders: &[crate::values::placeholder::Placeholder],
+    lid_indices: &[usize],
     remote: &str,
     field: FieldKind,
-    out: &mut BTreeMap<LookupKey, String>,
     warnings: &mut Vec<String>,
-) {
-    let template_keys: Vec<String> = extract_placeholders(template)
-        .into_iter()
-        .filter(|p| matches!(p.ty, PlaceholderType::Lid))
-        .map(|p| p.key)
-        .collect();
-    if template_keys.is_empty() {
-        return;
-    }
+) -> Vec<Option<String>> {
     let remote_values = extract_lid_values_unanchored(remote);
     let field_label = match field {
         FieldKind::EmailSubject => "subject",
         FieldKind::EmailPreheader => "preheader",
         _ => "field",
     };
-    if remote_values.len() != template_keys.len() {
+    if remote_values.len() != lid_indices.len() {
         warnings.push(format!(
             "{field_label} has {} lid placeholder(s) but remote body has {} lid value(s); \
              positional match may misalign — review rendered output",
-            template_keys.len(),
+            lid_indices.len(),
             remote_values.len()
         ));
     }
-    for (key, value) in template_keys.into_iter().zip(remote_values) {
-        out.insert((PlaceholderType::Lid, key), value);
-    }
-}
-
-/// Pair cb_id placeholders in `template` with `${NAME}` includes in
-/// `remote` by Liquid name. Same `${NAME}` referenced twice in the
-/// template shares one remote cb_id value.
-fn resolve_cb_id_from_remote(
-    template: &str,
-    remote: &str,
-    out: &mut BTreeMap<LookupKey, String>,
-    warnings: &mut Vec<String>,
-) {
-    let remote_pairs = extract_cb_id_values(remote);
-    let remote_by_name: BTreeMap<&str, &CbIdCorrelation> =
-        remote_pairs.iter().map(|p| (p.name.as_str(), p)).collect();
-
-    for (key, name) in collect_template_cb_id_names(template) {
-        match remote_by_name.get(name.as_str()) {
-            Some(pick) => {
-                out.insert((PlaceholderType::CbId, key), pick.value.clone());
-            }
-            None => {
-                warnings.push(format!(
-                    "cb_id '{key}': `${{{name}}}` include not found in remote body"
-                ));
-            }
-        }
-    }
-}
-
-/// Walk a templatized body and emit `(key, optional URL anchor, offset)`
-/// for every `__BRAZESYNC.lid.<key>__`. URL anchor extraction mirrors
-/// templatize's `preceding_url` logic but is rerun here because the
-/// templatized body has the same surrounding HTML/text as the original.
-fn collect_template_lid_anchors(
-    body: &str,
-    field: FieldKind,
-) -> Vec<(String, Option<String>, usize)> {
-    let mut out = Vec::new();
-    for ph in extract_placeholders(body) {
-        if !matches!(ph.ty, PlaceholderType::Lid) {
-            continue;
-        }
-        let anchor = lid_anchor_for(body, ph.start, field);
-        out.push((ph.key, anchor, ph.start));
+    let _ = placeholders;
+    let mut out = Vec::with_capacity(lid_indices.len());
+    let mut iter = remote_values.into_iter();
+    for _ in lid_indices {
+        out.push(iter.next());
     }
     out
 }
 
-/// Walk a templatized body and emit `(key, name)` for every
-/// `{{content_blocks.${NAME} | id: '__BRAZESYNC.cb_id.<key>__'}}`.
-fn collect_template_cb_id_names(body: &str) -> Vec<(String, String)> {
+/// Pair cb_id placeholders with remote `${NAME} | id: 'cbN'` matches by
+/// `${NAME}`. Returns an offset → value map.
+fn resolve_cb_id_batch(
+    body: &str,
+    placeholders: &[crate::values::placeholder::Placeholder],
+    remote: &str,
+    warnings: &mut Vec<String>,
+) -> BTreeMap<usize, Option<String>> {
+    let remote_pairs = extract_cb_id_values(remote);
+    let remote_by_name: BTreeMap<&str, &CbIdCorrelation> =
+        remote_pairs.iter().map(|p| (p.name.as_str(), p)).collect();
+
+    let mut out: BTreeMap<usize, Option<String>> = BTreeMap::new();
+    for ph in placeholders {
+        if ph.ty != Some(PlaceholderType::CbId) {
+            continue;
+        }
+        let name = match cb_id_name_at(body, ph.start) {
+            Some(n) => n,
+            None => {
+                warnings.push(format!(
+                    "cb_id: `__BRAZESYNC__` at byte {} not inside `{{{{content_blocks.${{NAME}} | id: '…'}}}}` — cannot correlate",
+                    ph.start
+                ));
+                out.insert(ph.start, None);
+                continue;
+            }
+        };
+        match remote_by_name.get(name.as_str()) {
+            Some(pick) => {
+                out.insert(ph.start, Some(pick.value.clone()));
+            }
+            None => {
+                warnings.push(format!(
+                    "cb_id: `${{{name}}}` include not found in remote body"
+                ));
+                out.insert(ph.start, None);
+            }
+        }
+    }
+    out
+}
+
+/// Generate fallback lid values for the new-resource path. Uses URL
+/// path tail slug; collisions are disambiguated with `_2`, `_3`, ….
+fn fallback_lid_batch(
+    body: &str,
+    placeholders: &[crate::values::placeholder::Placeholder],
+    lid_indices: &[usize],
+) -> Vec<Option<String>> {
+    let mut used: BTreeMap<String, usize> = BTreeMap::new();
+    let mut seq = 0usize;
+    let mut out = Vec::with_capacity(lid_indices.len());
+    for &i in lid_indices {
+        let anchor = lid_anchor_for(body, placeholders[i].start, FieldKind::ContentBlock);
+        let base = match anchor.as_deref() {
+            Some(u) => {
+                let tail = url_path_tail(u);
+                let slug = slug_for_lid(&tail);
+                if slug.is_empty() {
+                    seq += 1;
+                    format!("lid_{seq}")
+                } else {
+                    slug
+                }
+            }
+            None => {
+                seq += 1;
+                format!("lid_{seq}")
+            }
+        };
+        out.push(Some(unique(base, &mut used)));
+    }
+    out
+}
+
+fn unique(base: String, used: &mut BTreeMap<String, usize>) -> String {
+    let count = used.entry(base.clone()).or_insert(0);
+    *count += 1;
+    if *count == 1 {
+        base
+    } else {
+        format!("{base}_{count}")
+    }
+}
+
+fn url_path_tail(url: &str) -> String {
+    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    let path_start = after_scheme
+        .find('/')
+        .map(|i| i + 1)
+        .unwrap_or(after_scheme.len());
+    let path = &after_scheme[path_start..];
+    path.rsplit('/')
+        .find(|s| !s.is_empty())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Strip `| id: '__BRAZESYNC__'` filters from a template body. Used
+/// for the new-resource fallback so we POST the documented
+/// `{{content_blocks.${NAME}}}` form.
+fn strip_cb_id_filters(body: &str) -> (String, Vec<String>) {
+    let re = cb_id_filter_re();
+    let mut warnings: Vec<String> = Vec::new();
+    let mut spans: Vec<(std::ops::Range<usize>, String)> = Vec::new();
+    for cap in re.captures_iter(body) {
+        let whole = cap.get(0).expect("group 0 always present");
+        let name = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        warnings.push(format!(
+            "cb_id `${{{name}}}`: new resource — stripping `| id: '…'` filter; \
+             Braze will assign a cb_id on first save"
+        ));
+        spans.push((
+            whole.range(),
+            format!("{{{{content_blocks.${{{name}}}}}}}"),
+        ));
+    }
+    let mut out = body.to_string();
+    for (range, replacement) in spans.into_iter().rev() {
+        out.replace_range(range, &replacement);
+    }
+    (out, warnings)
+}
+
+fn cb_id_filter_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // Captures `${NAME}` so we can re-emit the documented form
+        // (`{{content_blocks.${NAME}}}`) without the cb_id filter.
+        Regex::new(
+            r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*['"]__BRAZESYNC__['"]\s*\}\}"#,
+        )
+        .expect("cb_id filter regex is valid")
+    })
+}
+
+/// Look up the `${NAME}` enclosing a cb_id `__BRAZESYNC__` token.
+fn cb_id_name_at(body: &str, offset: usize) -> Option<String> {
     let re = cb_id_template_re();
-    re.captures_iter(body)
-        .filter_map(|cap| {
-            let name = cap.get(1)?.as_str().to_string();
-            let key = cap.get(2)?.as_str().to_string();
-            Some((key, name))
-        })
-        .collect()
+    for cap in re.captures_iter(body) {
+        let whole = cap.get(0)?;
+        if whole.start() <= offset && offset < whole.end() {
+            return cap.get(1).map(|m| m.as_str().to_string());
+        }
+    }
+    None
 }
 
 fn cb_id_template_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*['"]__BRAZESYNC\.cb_id\.([a-z][a-z0-9_]*)__['"]\s*\}\}"#,
+            r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*['"]__BRAZESYNC__['"]\s*\}\}"#,
         )
         .expect("cb_id template regex is valid")
     })
 }
 
-/// Find the URL anchor for a lid placeholder at `offset` in `body`.
-///
-/// Same precedence as templatize:
-/// - HTML / content_block: enclosing element's URL attribute wins;
-///   else nearest prior `<a href>`.
-/// - Plaintext: nearest prior `https?://…`.
-/// - Subject / preheader: no URL anchor (returns None).
 fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<String> {
     if field.supports_html_anchor() {
         if let Some(tag) = enclosing_open_tag(body, offset) {
@@ -323,9 +413,6 @@ fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<String>
             {
                 return Some(normalize_url(url.as_str()));
             }
-            // Inside a non-URL open tag (e.g. `<a name>` or `<custom data-x>`):
-            // do NOT fall through to a prior `<a href>` (matches the
-            // templatize semantics that tests pin).
             return None;
         }
         let prefix = &body[..offset];
@@ -393,120 +480,124 @@ mod tests {
 
     #[test]
     fn no_placeholders_returns_body_verbatim() {
-        let p = prepare_field(
-            "<p>hello</p>",
-            Some("<p>hello</p>"),
-            FieldKind::ContentBlock,
-        );
-        assert_eq!(p.body, "<p>hello</p>");
-        assert!(p.additions.is_empty());
+        let p = prepare_field("<p>hi</p>", Some("<p>hi</p>"), FieldKind::ContentBlock);
+        assert_eq!(p.body, "<p>hi</p>");
+        assert!(p.errors.is_empty());
     }
 
     #[test]
     fn html_lid_resolved_via_url_anchor() {
-        let template = r#"<a href="https://example.com/cta">__BRAZESYNC.lid.cta__</a>"#;
+        let template = r#"<a href="https://example.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#;
         let remote = r#"<a href="https://example.com/cta">{{x | lid: 'newlidvalue1'}}</a>"#;
         let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
-        assert_eq!(
-            p.additions
-                .get(&(PlaceholderType::Lid, "cta".to_string()))
-                .map(String::as_str),
-            Some("newlidvalue1")
-        );
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.body.contains("'newlidvalue1'"));
     }
 
     #[test]
     fn two_lid_placeholders_sharing_one_url_consume_distinct_remote_values() {
-        let template = r#"<a href="https://x.com/a">__BRAZESYNC.lid.a__</a>
-<a href="https://x.com/a">__BRAZESYNC.lid.b__</a>"#;
+        let template = r#"<a href="https://x.com/a">{{x | lid: '__BRAZESYNC__'}}</a>
+<a href="https://x.com/a">{{x | lid: '__BRAZESYNC__'}}</a>"#;
         let remote = r#"<a href="https://x.com/a">{{x | lid: 'firstvalu1a'}}</a>
 <a href="https://x.com/a">{{x | lid: 'secondval2b'}}</a>"#;
         let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
-        assert_eq!(
-            p.additions[&(PlaceholderType::Lid, "a".into())],
-            "firstvalu1a"
-        );
-        assert_eq!(
-            p.additions[&(PlaceholderType::Lid, "b".into())],
-            "secondval2b"
-        );
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.body.contains("'firstvalu1a'"));
+        assert!(p.body.contains("'secondval2b'"));
     }
 
     #[test]
     fn cb_id_resolved_via_name() {
         let template =
-            "{{content_blocks.${promo_banner} | id: '__BRAZESYNC.cb_id.promo_banner__'}}";
+            "{{content_blocks.${promo_banner} | id: '__BRAZESYNC__'}}";
         let remote = "{{content_blocks.${promo_banner} | id: 'cb99'}}";
         let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
-        assert_eq!(
-            p.additions
-                .get(&(PlaceholderType::CbId, "promo_banner".to_string()))
-                .map(String::as_str),
-            Some("cb99")
-        );
+        assert!(p.errors.is_empty());
+        assert!(p.body.contains("'cb99'"));
     }
 
     #[test]
-    fn new_resource_lid_falls_back_to_placeholder_key() {
-        let template = r#"<a href="https://x.com/cta">__BRAZESYNC.lid.spring_sale__</a>"#;
+    fn new_resource_lid_uses_url_slug_fallback() {
+        let template =
+            r#"<a href="https://x.com/spring-sale">{{x | lid: '__BRAZESYNC__'}}</a>"#;
         let p = prepare_field(template, None, FieldKind::ContentBlock);
-        assert_eq!(
-            p.additions
-                .get(&(PlaceholderType::Lid, "spring_sale".to_string()))
-                .map(String::as_str),
-            Some("spring_sale")
-        );
+        assert!(p.errors.is_empty());
+        assert!(p.body.contains("'spring_sale'"), "got: {}", p.body);
+    }
+
+    #[test]
+    fn new_resource_lid_without_anchor_uses_sequential() {
+        let template = "no anchor {{x | lid: '__BRAZESYNC__'}} mid {{x | lid: '__BRAZESYNC__'}}";
+        let p = prepare_field(template, None, FieldKind::EmailSubject);
+        assert!(p.body.contains("'lid_1'"));
+        assert!(p.body.contains("'lid_2'"));
     }
 
     #[test]
     fn new_resource_strips_cb_id_filter() {
-        let template = "before {{content_blocks.${promo} | id: '__BRAZESYNC.cb_id.promo__'}} after";
+        let template =
+            "before {{content_blocks.${promo} | id: '__BRAZESYNC__'}} after";
         let p = prepare_field(template, None, FieldKind::ContentBlock);
-        assert_eq!(
-            p.body, "before {{content_blocks.${promo}}} after",
-            "cb_id filter must be stripped for new resources"
-        );
-        assert!(
-            !p.additions
-                .contains_key(&(PlaceholderType::CbId, "promo".into())),
-            "no cb_id addition needed once filter is stripped"
-        );
+        assert_eq!(p.body, "before {{content_blocks.${promo}}} after");
         assert!(p.warnings.iter().any(|w| w.contains("promo")));
     }
 
     #[test]
-    fn lid_without_remote_match_emits_warning_and_no_addition() {
-        let template = r#"<a href="https://x.com/cta">__BRAZESYNC.lid.cta__</a>"#;
+    fn lid_without_remote_match_surfaces_error() {
+        let template = r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#;
         let remote = r#"<p>no anchor</p>"#;
         let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
-        assert!(!p
-            .additions
-            .contains_key(&(PlaceholderType::Lid, "cta".to_string())));
-        assert!(p.warnings.iter().any(|w| w.contains("not found")));
+        assert!(p
+            .errors
+            .iter()
+            .any(|e| matches!(e, ResolutionError::UnresolvedLid { .. })));
+    }
+
+    #[test]
+    fn retired_envelope_is_fatal() {
+        let template = "stuff __BRAZESYNC.lid.foo__ stuff";
+        let p = prepare_field(template, None, FieldKind::ContentBlock);
+        assert!(p
+            .errors
+            .iter()
+            .any(|e| matches!(e, ResolutionError::RetiredNamespace { .. })));
+    }
+
+    #[test]
+    fn unknown_context_is_fatal() {
+        let template = "bare __BRAZESYNC__ token";
+        let p = prepare_field(template, Some(""), FieldKind::ContentBlock);
+        assert!(p
+            .errors
+            .iter()
+            .any(|e| matches!(e, ResolutionError::UnknownContext { .. })));
     }
 
     #[test]
     fn vml_href_anchors_lid() {
-        // Real templatized form: the lid placeholder is INSIDE the
-        // open-tag's href attribute value (matches what templatize
-        // emits for `<v:roundrect href="…?lid={{x | lid: 'X'}}">`).
-        let template = r#"<v:roundrect href="https://x.com/page/?lid={{x | lid: '__BRAZESYNC.lid.page__'}}">label</v:roundrect>"#;
+        let template = r#"<v:roundrect href="https://x.com/page/?lid={{x | lid: '__BRAZESYNC__'}}">label</v:roundrect>"#;
         let remote = r#"<v:roundrect href="https://x.com/page/?lid={{x | lid: 'liveeeeeeee1'}}">label</v:roundrect>"#;
         let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
-        assert_eq!(
-            p.additions[&(PlaceholderType::Lid, "page".into())],
-            "liveeeeeeee1"
-        );
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.body.contains("'liveeeeeeee1'"));
     }
 
     #[test]
     fn plaintext_url_anchor_matches() {
-        let template = "Visit https://x.com/cta __BRAZESYNC.lid.cta__ now";
+        let template = "Visit https://x.com/cta {{x | lid: '__BRAZESYNC__'}} now";
         let remote = "Visit https://x.com/cta {{x | lid: 'liveeeeeeee1'}} now";
         let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
-        assert_eq!(
-            p.additions[&(PlaceholderType::Lid, "cta".into())],
-            "liveeeeeeee1"
-        );
+        assert!(p.errors.is_empty());
+        assert!(p.body.contains("'liveeeeeeee1'"));
+    }
+
+    #[test]
+    fn subject_lid_resolves_positionally() {
+        let template = "{{x | lid: '__BRAZESYNC__'}} A {{y | lid: '__BRAZESYNC__'}}";
+        let remote = "{{x | lid: 'firstval123'}} A {{y | lid: 'secondval2b'}}";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailSubject);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.body.contains("'firstval123'"));
+        assert!(p.body.contains("'secondval2b'"));
     }
 }

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -79,7 +79,7 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
 
     let lid_values: Vec<Option<String>> = match remote {
         Some(remote_body) => resolve_lid_batch(&body, &placeholders, &lid_indices, remote_body, field, &mut warnings),
-        None => fallback_lid_batch(&body, &placeholders, &lid_indices),
+        None => fallback_lid_batch(&body, &placeholders, &lid_indices, field),
     };
 
     // cb_id resolution map (offset → value or None).
@@ -175,7 +175,7 @@ fn resolve_lid_batch(
     }
     for (url, bucket) in &by_url {
         let tmpl_count = tmpl_per_url.get(url).copied().unwrap_or(0);
-        if bucket.len() > 1 && tmpl_count > 1 {
+        if bucket.len() > 1 || (tmpl_count > 0 && bucket.len() != tmpl_count) {
             warnings.push(format!(
                 "URL '{url}' has {} remote lid occurrences and {tmpl_count} \
                  template placeholders — using positional FIFO match. \
@@ -291,12 +291,13 @@ fn fallback_lid_batch(
     body: &str,
     placeholders: &[crate::values::placeholder::Placeholder],
     lid_indices: &[usize],
+    field: FieldKind,
 ) -> Vec<Option<String>> {
     let mut used: BTreeMap<String, usize> = BTreeMap::new();
     let mut seq = 0usize;
     let mut out = Vec::with_capacity(lid_indices.len());
     for &i in lid_indices {
-        let anchor = lid_anchor_for(body, placeholders[i].start, FieldKind::ContentBlock);
+        let anchor = lid_anchor_for(body, placeholders[i].start, field);
         let base = match anchor.as_deref() {
             Some(u) => {
                 let tail = url_path_tail(u);
@@ -599,5 +600,17 @@ mod tests {
         assert!(p.errors.is_empty(), "{:?}", p.errors);
         assert!(p.body.contains("'firstval123'"));
         assert!(p.body.contains("'secondval2b'"));
+    }
+
+    #[test]
+    fn new_resource_plaintext_lid_uses_url_slug() {
+        let template = "Visit https://x.com/spring-sale {{x | lid: '__BRAZESYNC__'}} now";
+        let p = prepare_field(template, None, FieldKind::EmailPlainBody);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(
+            p.body.contains("'spring_sale'"),
+            "plaintext URL slug must be used, got: {}",
+            p.body
+        );
     }
 }

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -266,10 +266,7 @@ mod tests {
 
     #[test]
     fn new_resource_cb_id_filter_is_stripped() {
-        let mut block = cb(
-            "page",
-            "{{content_blocks.${promo} | id: '__BRAZESYNC__'}}",
-        );
+        let mut block = cb("page", "{{content_blocks.${promo} | id: '__BRAZESYNC__'}}");
         resolve_content_block_with_remote(&mut block, None).unwrap();
         assert_eq!(block.content, "{{content_blocks.${promo}}}");
     }
@@ -277,11 +274,9 @@ mod tests {
     #[test]
     fn email_template_resolves_per_field() {
         let mut t = et("welcome");
-        t.body_html =
-            r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#.into();
+        t.body_html = r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#.into();
         let mut remote = et("welcome");
-        remote.body_html =
-            r#"<a href="https://x.com/cta">{{x | lid: 'newhtmllidx'}}</a>"#.into();
+        remote.body_html = r#"<a href="https://x.com/cta">{{x | lid: 'newhtmllidx'}}</a>"#.into();
         resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap();
         assert!(t.body_html.contains("'newhtmllidx'"));
     }

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -2,7 +2,7 @@
 
 use crate::resource::{ContentBlock, EmailTemplate};
 use crate::values::braze_managed::prepare_field;
-use crate::values::placeholder::{has_placeholders, ResolutionError};
+use crate::values::placeholder::ResolutionError;
 use crate::values::templatize::FieldKind;
 
 /// One resource's worth of placeholder failures, ready to be folded
@@ -131,7 +131,7 @@ pub fn resolve_email_template_with_remote(
 /// Cheap pre-filter: a body needs resolution if it carries the strict
 /// token *or* a retired-namespace token we need to surface as an error.
 fn needs_resolve(body: &str) -> bool {
-    has_placeholders(body) || body.contains("__BRAZESYNC.") || body.contains("__BRAZSYNC")
+    body.contains("__BRAZESYNC") || body.contains("__BRAZSYNC")
 }
 
 fn emit_prep_warnings(
@@ -319,5 +319,15 @@ mod tests {
             .errors
             .iter()
             .any(|e| matches!(e, ResolutionError::RetiredNamespace { .. })));
+    }
+
+    #[test]
+    fn typo_suffixed_token_is_detected() {
+        let mut block = cb("typo", "hello __BRAZESYNCTEST__ world");
+        let err = resolve_content_block_with_remote(&mut block, None).unwrap_err();
+        assert!(
+            !err.errors.is_empty(),
+            "typo-suffixed token must not pass silently"
+        );
     }
 }

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -1,16 +1,12 @@
 //! Wiring layer between [`crate::values`] and the diff / apply pipeline.
 
-use std::collections::BTreeMap;
-
 use crate::resource::{ContentBlock, EmailTemplate};
 use crate::values::braze_managed::prepare_field;
-use crate::values::placeholder::{
-    find_suspicious_placeholders, resolve_placeholders, LookupKey, ResolutionError,
-};
+use crate::values::placeholder::{has_placeholders, ResolutionError};
 use crate::values::templatize::FieldKind;
 
-/// One resource's worth of placeholder failures, ready to be folded into
-/// a top-level error message.
+/// One resource's worth of placeholder failures, ready to be folded
+/// into a top-level error message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolutionFailure {
     pub resource_kind: &'static str,
@@ -20,17 +16,16 @@ pub struct ResolutionFailure {
     pub errors: Vec<ResolutionError>,
 }
 
-/// Resolve every `__BRAZESYNC.*__` in `cb.content`.
+/// Resolve every `__BRAZESYNC__` in `cb.content`.
 ///
 /// `remote` provides the live lid / cb_id values; pass `None` for new
-/// resources (lid falls back to the placeholder key, cb_id filter is
-/// stripped — see [`prepare_field`]).
+/// resources (lid → URL slug, cb_id filter stripped — see
+/// [`prepare_field`]).
 pub fn resolve_content_block_with_remote(
     cb: &mut ContentBlock,
     remote: Option<&ContentBlock>,
 ) -> std::result::Result<(), ResolutionFailure> {
-    warn_suspicious("content_block", &cb.name, None, &cb.content)?;
-    if !body_has_placeholders(&cb.content) {
+    if !needs_resolve(&cb.content) {
         return Ok(());
     }
     let prep = prepare_field(
@@ -39,19 +34,16 @@ pub fn resolve_content_block_with_remote(
         FieldKind::ContentBlock,
     );
     emit_prep_warnings("content_block", &cb.name, None, &prep.warnings);
-    let lookup: BTreeMap<LookupKey, String> = prep.additions;
-    match resolve_placeholders(&prep.body, &lookup) {
-        Ok(resolved) => {
-            cb.content = resolved;
-            Ok(())
-        }
-        Err(errors) => Err(ResolutionFailure {
+    if !prep.errors.is_empty() {
+        return Err(ResolutionFailure {
             resource_kind: "content_block",
             resource_name: cb.name.clone(),
             field: None,
-            errors,
-        }),
+            errors: prep.errors,
+        });
     }
+    cb.content = prep.body;
+    Ok(())
 }
 
 /// Resolve placeholders across every Liquid-bearing field of `et`.
@@ -64,10 +56,7 @@ pub fn resolve_email_template_with_remote(
     macro_rules! resolve_field {
         ($field_name:expr, $field_kind:expr, $accessor:expr, $remote_accessor:expr) => {{
             let body: &str = $accessor;
-            if let Err(f) = warn_suspicious("email_template", &et.name, Some($field_name), body) {
-                failures.push(f);
-            }
-            if body_has_placeholders(body) {
+            if needs_resolve(body) {
                 let prep = prepare_field(body, $remote_accessor, $field_kind);
                 emit_prep_warnings(
                     "email_template",
@@ -75,17 +64,16 @@ pub fn resolve_email_template_with_remote(
                     Some($field_name),
                     &prep.warnings,
                 );
-                match resolve_placeholders(&prep.body, &prep.additions) {
-                    Ok(resolved) => Some(resolved),
-                    Err(errors) => {
-                        failures.push(ResolutionFailure {
-                            resource_kind: "email_template",
-                            resource_name: et.name.clone(),
-                            field: Some($field_name),
-                            errors,
-                        });
-                        None
-                    }
+                if !prep.errors.is_empty() {
+                    failures.push(ResolutionFailure {
+                        resource_kind: "email_template",
+                        resource_name: et.name.clone(),
+                        field: Some($field_name),
+                        errors: prep.errors,
+                    });
+                    None
+                } else {
+                    Some(prep.body)
                 }
             } else {
                 None
@@ -140,15 +128,12 @@ pub fn resolve_email_template_with_remote(
     Ok(())
 }
 
-fn body_has_placeholders(body: &str) -> bool {
-    body.contains("__BRAZESYNC.")
+/// Cheap pre-filter: a body needs resolution if it carries the strict
+/// token *or* a retired-namespace token we need to surface as an error.
+fn needs_resolve(body: &str) -> bool {
+    has_placeholders(body) || body.contains("__BRAZESYNC.") || body.contains("__BRAZSYNC")
 }
 
-/// Surface diagnostic warnings collected by [`prepare_field`] to stderr
-/// with a resource-qualified scope. Silent dead-letter previously hid
-/// the most actionable info (which URL anchor failed, which subject lid
-/// fell back, which cb_id filter was stripped) — without this the user
-/// only sees a generic "unresolved placeholder" failure downstream.
 fn emit_prep_warnings(
     kind: &'static str,
     name: &str,
@@ -164,43 +149,6 @@ fn emit_prep_warnings(
     };
     for w in warnings {
         eprintln!("warning: {scope}: {w}");
-    }
-}
-
-fn warn_suspicious(
-    kind: &'static str,
-    name: &str,
-    field: Option<&'static str>,
-    body: &str,
-) -> Result<(), ResolutionFailure> {
-    if !body.contains("__") {
-        return Ok(());
-    }
-    let suspects = find_suspicious_placeholders(body);
-    if suspects.is_empty() {
-        return Ok(());
-    }
-    let scope = match field {
-        Some(f) => format!("{kind} '{name}' ({f})"),
-        None => format!("{kind} '{name}'"),
-    };
-    let mut retired: Vec<ResolutionError> = Vec::new();
-    for s in &suspects {
-        if s.starts_with("__BRAZESYNC.") {
-            retired.push(ResolutionError::RetiredNamespace { token: s.clone() });
-        } else {
-            eprintln!("warning: {scope}: suspicious placeholder-like token {s}");
-        }
-    }
-    if retired.is_empty() {
-        Ok(())
-    } else {
-        Err(ResolutionFailure {
-            resource_kind: kind,
-            resource_name: name.to_string(),
-            field,
-            errors: retired,
-        })
     }
 }
 
@@ -220,30 +168,31 @@ pub fn format_failures(failures: &[ResolutionFailure]) -> crate::error::Error {
         msg.push('\n');
         for e in &f.errors {
             match e {
-                ResolutionError::UnknownKey { ty, key, start } => {
+                ResolutionError::UnresolvedLid { start, anchor } => {
+                    let where_ = anchor
+                        .as_deref()
+                        .map(|u| format!("URL '{u}'"))
+                        .unwrap_or_else(|| "no URL anchor".to_string());
                     msg.push_str(&format!(
-                        "    - offset {}: __BRAZESYNC.{}.{}__ (no anchor match in remote body)\n",
-                        start,
-                        ty.as_str(),
-                        key,
+                        "    - offset {start}: lid `__BRAZESYNC__` ({where_}) — no anchor match in remote body\n",
                     ));
                 }
-                ResolutionError::DuplicateLidKey { key, occurrences } => {
-                    let offsets = occurrences
-                        .iter()
-                        .map(|o| o.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ");
+                ResolutionError::UnresolvedCbId { start, name } => {
+                    let n = name.as_deref().unwrap_or("<unknown>");
                     msg.push_str(&format!(
-                        "    - __BRAZESYNC.lid.{key}__ referenced {} times (offsets {offsets}); \
-                         lid IDs are per-click-context — use a distinct key per occurrence\n",
-                        occurrences.len(),
+                        "    - offset {start}: cb_id `__BRAZESYNC__` (`${{{n}}}`) — no `${{{n}}}` include in remote body\n",
+                    ));
+                }
+                ResolutionError::UnknownContext { start } => {
+                    msg.push_str(&format!(
+                        "    - offset {start}: `__BRAZESYNC__` outside `| lid:` / `| id:` argument — cannot infer type\n",
                     ));
                 }
                 ResolutionError::RetiredNamespace { token } => {
                     msg.push_str(&format!(
-                        "    - {token}: retired placeholder namespace \
-                         (custom/global removed in v0.15; use literal values)\n",
+                        "    - {token}: retired placeholder syntax \
+                         (v0.15 `__BRAZESYNC.<type>.<key>__` was removed in v0.16; \
+                         re-run `braze-sync templatize` to regenerate)\n",
                     ));
                 }
             }
@@ -291,31 +240,35 @@ mod tests {
     fn content_block_resolves_lid_from_remote() {
         let mut block = cb(
             "promo",
-            r#"<a href="https://x.com/cta">__BRAZESYNC.lid.cta__</a>"#,
+            r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#,
         );
         let remote = cb(
             "promo",
             r#"<a href="https://x.com/cta">{{x | lid: 'newlidvalue1'}}</a>"#,
         );
         resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
-        assert!(block.content.contains(">newlidvalue1<"));
+        assert!(block.content.contains("'newlidvalue1'"));
     }
 
     #[test]
-    fn new_resource_lid_fallback_uses_placeholder_key() {
+    fn new_resource_lid_uses_url_slug() {
         let mut block = cb(
             "promo",
-            r#"<a href="https://x.com/spring">__BRAZESYNC.lid.spring_sale__</a>"#,
+            r#"<a href="https://x.com/spring-sale">{{x | lid: '__BRAZESYNC__'}}</a>"#,
         );
         resolve_content_block_with_remote(&mut block, None).unwrap();
-        assert!(block.content.contains(">spring_sale<"));
+        assert!(
+            block.content.contains("'spring_sale'"),
+            "got: {}",
+            block.content
+        );
     }
 
     #[test]
     fn new_resource_cb_id_filter_is_stripped() {
         let mut block = cb(
             "page",
-            "{{content_blocks.${promo} | id: '__BRAZESYNC.cb_id.promo__'}}",
+            "{{content_blocks.${promo} | id: '__BRAZESYNC__'}}",
         );
         resolve_content_block_with_remote(&mut block, None).unwrap();
         assert_eq!(block.content, "{{content_blocks.${promo}}}");
@@ -324,28 +277,34 @@ mod tests {
     #[test]
     fn email_template_resolves_per_field() {
         let mut t = et("welcome");
-        t.body_html = r#"<a href="https://x.com/cta">__BRAZESYNC.lid.cta__</a>"#.into();
+        t.body_html =
+            r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#.into();
         let mut remote = et("welcome");
-        remote.body_html = r#"<a href="https://x.com/cta">{{x | lid: 'newhtmllidx'}}</a>"#.into();
+        remote.body_html =
+            r#"<a href="https://x.com/cta">{{x | lid: 'newhtmllidx'}}</a>"#.into();
         resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap();
-        assert!(t.body_html.contains(">newhtmllidx<"));
+        assert!(t.body_html.contains("'newhtmllidx'"));
     }
 
     #[test]
     fn missing_remote_anchor_surfaces_as_failure() {
         let mut block = cb(
             "promo",
-            r#"<a href="https://x.com/cta">__BRAZESYNC.lid.cta__</a>"#,
+            r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#,
         );
         let remote = cb("promo", "<p>no anchor here</p>");
         let err = resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap_err();
         assert_eq!(err.errors.len(), 1);
+        assert!(matches!(
+            err.errors[0],
+            ResolutionError::UnresolvedLid { .. }
+        ));
     }
 
     #[test]
     fn subject_lid_resolves_positionally_from_remote() {
         let mut t = et("promo");
-        t.subject = "Spring sale {{x | lid: '__BRAZESYNC.lid.subject_lid__'}}".into();
+        t.subject = "Spring sale {{x | lid: '__BRAZESYNC__'}}".into();
         let mut remote = et("promo");
         remote.subject = "Spring sale {{x | lid: 'subjectlid1'}}".into();
         resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap();
@@ -353,42 +312,12 @@ mod tests {
     }
 
     #[test]
-    fn subject_lid_count_mismatch_still_resolves_overlap() {
-        let mut t = et("promo");
-        t.subject = "{{x | lid: '__BRAZESYNC.lid.a__'}} {{y | lid: '__BRAZESYNC.lid.b__'}}".into();
-        let mut remote = et("promo");
-        remote.subject = "{{x | lid: 'firstvalue'}}".into();
-        // First placeholder resolves positionally, second remains
-        // unresolved → fatal at resolve_placeholders.
-        let err = resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap_err();
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].field, Some("subject"));
-    }
-
-    #[test]
-    fn retired_namespace_is_fatal() {
-        let mut block = cb("legacy", "hello __BRAZESYNC.custom.foo__ world");
+    fn retired_v015_envelope_is_fatal() {
+        let mut block = cb("legacy", "hello __BRAZESYNC.lid.foo__ world");
         let err = resolve_content_block_with_remote(&mut block, None).unwrap_err();
-        assert!(err.errors.iter().any(|e| matches!(
-            e,
-            ResolutionError::RetiredNamespace { token }
-                if token.contains("custom.foo")
-        )));
-    }
-
-    #[test]
-    fn typo_namespace_is_warning_not_fatal() {
-        let mut block = cb("typo", "hello __BRAZSYNC.lid.foo__ world");
-        resolve_content_block_with_remote(&mut block, None).unwrap();
-    }
-
-    #[test]
-    fn double_quoted_cb_id_filter_stripped_on_new_resource() {
-        let mut block = cb(
-            "page",
-            r#"{{content_blocks.${promo} | id: "__BRAZESYNC.cb_id.promo__"}}"#,
-        );
-        resolve_content_block_with_remote(&mut block, None).unwrap();
-        assert_eq!(block.content, "{{content_blocks.${promo}}}");
+        assert!(err
+            .errors
+            .iter()
+            .any(|e| matches!(e, ResolutionError::RetiredNamespace { .. })));
     }
 }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -1,8 +1,7 @@
-//! Braze-managed placeholder resolution (`__BRAZESYNC.lid.…__`,
-//! `__BRAZESYNC.cb_id.…__`).
+//! Anonymous Braze-managed placeholder resolution (`__BRAZESYNC__`).
 //!
 //! Resolved at apply/diff time from the freshly-fetched remote body
-//! via URL / `${NAME}` anchor correlation.
+//! via URL / `${NAME}` / positional anchor correlation.
 
 pub mod braze_managed;
 pub mod correlation;
@@ -20,6 +19,6 @@ pub use integration::{
     ResolutionFailure,
 };
 pub use placeholder::{
-    extract_placeholders, find_suspicious_placeholders, resolve_placeholders, LookupKey,
-    Placeholder, PlaceholderType, ResolutionError,
+    extract_placeholders, find_suspicious_placeholders, has_placeholders, Placeholder,
+    PlaceholderType, ResolutionError, TOKEN,
 };

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -48,10 +48,7 @@ pub enum ResolutionError {
     },
     /// cb_id `__BRAZESYNC__` could not be matched to a remote
     /// `${NAME} | id: 'cbN'`.
-    UnresolvedCbId {
-        start: usize,
-        name: Option<String>,
-    },
+    UnresolvedCbId { start: usize, name: Option<String> },
     /// `__BRAZESYNC__` appeared outside any recognized
     /// `| lid:` / `| id:` argument position.
     UnknownContext { start: usize },
@@ -119,9 +116,7 @@ fn retired_envelope_re() -> &'static Regex {
 /// strict token itself and the retired envelope shape.
 fn typo_token_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"__BRAZE?SYNC[A-Z]*__").expect("typo token regex is valid")
-    })
+    RE.get_or_init(|| Regex::new(r"__BRAZE?SYNC[A-Z]*__").expect("typo token regex is valid"))
 }
 
 /// Find any token resembling a placeholder that is NOT the strict

--- a/src/values/placeholder.rs
+++ b/src/values/placeholder.rs
@@ -1,18 +1,11 @@
-//! Placeholder extraction and resolution for `__BRAZESYNC.<type>.<key>__`.
+//! Anonymous Braze-managed placeholder: `__BRAZESYNC__`.
 //!
-//! v0.15 model: only Braze-managed types (`lid`, `cb_id`) are
-//! recognized. Both resolve at apply/diff time from the live remote
-//! body via URL / `${NAME}` anchor correlation (see
-//! [`crate::values::braze_managed`]).
-//!
-//! Syntax:
-//!   - Double-underscore envelope: `__BRAZESYNC.…__`
-//!   - Dot namespace
-//!   - `<type>` ∈ {`lid`, `cb_id`}
-//!   - `<key>` matches `^[a-z][a-z0-9_]*$`
+//! v0.16 model: a single anonymous token represents both `lid` and
+//! `cb_id` placeholders. Type is inferred from the surrounding
+//! `| lid: '…'` / `| id: '…'` syntax. Resolution is offset-based and
+//! lives in [`crate::values::braze_managed`].
 
 use regex_lite::Regex;
-use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -28,392 +21,207 @@ impl PlaceholderType {
             PlaceholderType::CbId => "cb_id",
         }
     }
-
-    fn parse(s: &str) -> Option<Self> {
-        match s {
-            "lid" => Some(Self::Lid),
-            "cb_id" => Some(Self::CbId),
-            _ => None,
-        }
-    }
 }
 
-/// One placeholder occurrence within a body string.
+/// One `__BRAZESYNC__` occurrence with its inferred type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Placeholder {
-    pub ty: PlaceholderType,
-    pub key: String,
-    /// Byte offset where the literal `__BRAZESYNC.…__` token begins.
+    /// `None` when the token is not in a recognized `| lid:` / `| id:`
+    /// argument position — caller treats this as a fatal context error.
+    pub ty: Option<PlaceholderType>,
+    /// Byte offset where the literal `__BRAZESYNC__` token begins.
     pub start: usize,
     /// Byte offset (exclusive) where it ends.
     pub end: usize,
 }
 
-impl Placeholder {
-    /// The textual form, useful for error messages: `__BRAZESYNC.lid.foo__`.
-    pub fn literal(&self) -> String {
-        format!("__BRAZESYNC.{}.{}__", self.ty.as_str(), self.key)
+pub const TOKEN: &str = "__BRAZESYNC__";
+
+/// Resolution errors. All offset-based — no keys exist in the v0.16
+/// model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolutionError {
+    /// lid `__BRAZESYNC__` could not be resolved from the remote body.
+    UnresolvedLid {
+        start: usize,
+        anchor: Option<String>,
+    },
+    /// cb_id `__BRAZESYNC__` could not be matched to a remote
+    /// `${NAME} | id: 'cbN'`.
+    UnresolvedCbId {
+        start: usize,
+        name: Option<String>,
+    },
+    /// `__BRAZESYNC__` appeared outside any recognized
+    /// `| lid:` / `| id:` argument position.
+    UnknownContext { start: usize },
+    /// Token uses the retired `__BRAZESYNC.<…>__` envelope (legacy v0.15
+    /// syntax, or `custom`/`global` namespaces removed earlier). Surface
+    /// as fatal so operators re-run `templatize`.
+    RetiredNamespace { token: String },
+}
+
+fn lid_prefix_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r#"\|\s*lid:\s*['"]$"#).expect("lid prefix regex is valid"))
+}
+
+fn cb_id_prefix_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r#"\|\s*id:\s*['"]$"#).expect("cb_id prefix regex is valid"))
+}
+
+/// Decide which type a `__BRAZESYNC__` token represents based on the
+/// text immediately preceding it.
+pub fn infer_type(prefix: &str) -> Option<PlaceholderType> {
+    if lid_prefix_re().is_match(prefix) {
+        return Some(PlaceholderType::Lid);
     }
+    if cb_id_prefix_re().is_match(prefix) {
+        return Some(PlaceholderType::CbId);
+    }
+    None
 }
 
-const PREFIX: &str = "__BRAZESYNC.";
-const CLOSE: &str = "__";
-
-fn key_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"^[a-z][a-z0-9_]*$").expect("key regex is valid"))
-}
-
-/// Loose envelope-only regex. Catches typos like `__BRAZSYNC.…__` or
-/// unknown / retired types (`__BRAZESYNC.url.foo__`,
-/// `__BRAZESYNC.custom.foo__`) so they surface as warnings rather than
-/// silently passing through. Inner classes allow `_` so typo-shaped
-/// placeholders whose key contains an underscore are still caught.
-fn loose_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"__BRAZE?SYNC\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+__")
-            .expect("loose placeholder regex is valid")
-    })
-}
-
+/// Extract every `__BRAZESYNC__` occurrence in `body` with its inferred
+/// type.
 pub fn extract_placeholders(body: &str) -> Vec<Placeholder> {
     let mut out = Vec::new();
     let mut i = 0;
-    while i + PREFIX.len() <= body.len() {
-        let Some(rel) = body[i..].find(PREFIX) else {
-            break;
-        };
+    while let Some(rel) = body[i..].find(TOKEN) {
         let start = i + rel;
-        let inner_start = start + PREFIX.len();
-        let Some(rel_close) = body[inner_start..].find(CLOSE) else {
-            break;
-        };
-        let close_start = inner_start + rel_close;
-        let end = close_start + CLOSE.len();
-        let inner = &body[inner_start..close_start];
-        if let Some((ty_str, key)) = inner.split_once('.') {
-            if let (Some(ty), true) = (PlaceholderType::parse(ty_str), key_re().is_match(key)) {
-                out.push(Placeholder {
-                    ty,
-                    key: key.to_string(),
-                    start,
-                    end,
-                });
-                i = end;
-                continue;
-            }
-        }
-        // Not a valid strict placeholder; skip past the opening `__` so the
-        // remainder is still scanned (and may be surfaced by the loose pass).
-        i = start + CLOSE.len();
+        let end = start + TOKEN.len();
+        let ty = infer_type(&body[..start]);
+        out.push(Placeholder { ty, start, end });
+        i = end;
     }
     out
 }
 
-/// Find loose envelope matches that don't satisfy the strict pattern.
+/// Cheap check used by callers that only need to know whether
+/// resolution must run at all.
+pub fn has_placeholders(body: &str) -> bool {
+    body.contains(TOKEN)
+}
+
+/// Loose envelope regex for the **retired** v0.15 syntax. We surface
+/// these as errors so operators re-run `templatize` rather than
+/// silently shipping unresolvable templates.
+fn retired_envelope_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"__BRAZE?SYNC\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+__")
+            .expect("retired envelope regex is valid")
+    })
+}
+
+/// Loose typo regex (e.g. `__BRAZSYNC__`, missing E). Excludes the
+/// strict token itself and the retired envelope shape.
+fn typo_token_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"__BRAZE?SYNC[A-Z]*__").expect("typo token regex is valid")
+    })
+}
+
+/// Find any token resembling a placeholder that is NOT the strict
+/// `__BRAZESYNC__`. Returns retired-envelope and typo-shaped strings.
 pub fn find_suspicious_placeholders(body: &str) -> Vec<String> {
-    let strict_spans: Vec<(usize, usize)> = extract_placeholders(body)
-        .into_iter()
-        .map(|p| (p.start, p.end))
-        .collect();
-    loose_re()
-        .find_iter(body)
-        .filter(|m| {
-            // Overlap (not equality) — the greedy loose regex can extend past
-            // a valid envelope into adjacent `__...__` text. See regression
-            // tests below.
-            !strict_spans
-                .iter()
-                .any(|&(s, e)| m.start() < e && s < m.end())
-        })
-        .map(|m| m.as_str().to_string())
-        .collect()
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ResolutionError {
-    UnknownKey {
-        ty: PlaceholderType,
-        key: String,
-        start: usize,
-    },
-    /// lid is per-click-context — reuse of the same key is an error.
-    DuplicateLidKey {
-        key: String,
-        occurrences: Vec<usize>,
-    },
-    /// Token uses the `__BRAZESYNC.` prefix but with a retired namespace
-    /// (e.g. `custom`, `global`) that is no longer resolved.
-    RetiredNamespace { token: String },
-}
-
-pub type LookupKey = (PlaceholderType, String);
-
-/// Resolve every placeholder in `body` against `lookup`. Returns the
-/// resolved body on success, or every unresolved placeholder on failure.
-pub fn resolve_placeholders(
-    body: &str,
-    lookup: &BTreeMap<LookupKey, String>,
-) -> Result<String, Vec<ResolutionError>> {
-    let placeholders = extract_placeholders(body);
-    let mut errors = Vec::new();
-
-    let mut lid_occurrences: BTreeMap<String, Vec<usize>> = BTreeMap::new();
-    for ph in &placeholders {
-        if matches!(ph.ty, PlaceholderType::Lid) {
-            lid_occurrences
-                .entry(ph.key.clone())
-                .or_default()
-                .push(ph.start);
+    let mut out = Vec::new();
+    for m in retired_envelope_re().find_iter(body) {
+        out.push(m.as_str().to_string());
+    }
+    for m in typo_token_re().find_iter(body) {
+        let s = m.as_str();
+        if s == TOKEN {
+            continue;
         }
-    }
-    for (key, occurrences) in lid_occurrences {
-        if occurrences.len() > 1 {
-            errors.push(ResolutionError::DuplicateLidKey { key, occurrences });
+        // Skip if already covered by a retired-envelope hit at the same
+        // start offset.
+        if out.iter().any(|o: &String| o.starts_with(s)) {
+            continue;
         }
+        out.push(s.to_string());
     }
-
-    for ph in &placeholders {
-        let key: LookupKey = (ph.ty, ph.key.clone());
-        if !lookup.contains_key(&key) {
-            errors.push(ResolutionError::UnknownKey {
-                ty: ph.ty,
-                key: ph.key.clone(),
-                start: ph.start,
-            });
-        }
-    }
-
-    if !errors.is_empty() {
-        return Err(errors);
-    }
-
-    // Substitute back-to-front so byte offsets remain stable across edits.
-    let mut out = body.to_string();
-    for ph in placeholders.iter().rev() {
-        let key: LookupKey = (ph.ty, ph.key.clone());
-        let value = lookup
-            .get(&key)
-            .expect("missing key would have been caught above");
-        out.replace_range(ph.start..ph.end, value);
-    }
-    Ok(out)
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn lookup(pairs: &[(PlaceholderType, &str, &str)]) -> BTreeMap<LookupKey, String> {
-        pairs
-            .iter()
-            .map(|(t, k, v)| ((*t, (*k).to_string()), (*v).to_string()))
-            .collect()
-    }
-
     #[test]
-    fn extracts_strict_placeholders_in_order() {
-        let body = "head __BRAZESYNC.lid.spring_sale__ mid __BRAZESYNC.cb_id.cb_hero__ tail";
-        let found = extract_placeholders(body);
-        assert_eq!(found.len(), 2);
-        assert_eq!(found[0].ty, PlaceholderType::Lid);
-        assert_eq!(found[0].key, "spring_sale");
-        assert_eq!(found[1].ty, PlaceholderType::CbId);
-        assert_eq!(found[1].key, "cb_hero");
-        assert!(found[0].start < found[1].start);
-    }
-
-    #[test]
-    fn rejects_unknown_type_in_strict_pass() {
-        let body = "x __BRAZESYNC.url.foo__ y";
-        assert!(extract_placeholders(body).is_empty());
-    }
-
-    #[test]
-    fn rejects_uppercase_key_in_strict_pass() {
-        let body = "x __BRAZESYNC.lid.Foo__ y";
-        assert!(extract_placeholders(body).is_empty());
-    }
-
-    #[test]
-    fn rejects_digit_leading_key_in_strict_pass() {
-        let body = "x __BRAZESYNC.lid.1foo__ y";
-        assert!(extract_placeholders(body).is_empty());
-    }
-
-    #[test]
-    fn suspicious_picks_up_typos_and_unknown_types() {
-        let body = "x __BRAZSYNC.lid.foo__ y __BRAZESYNC.url.bar__ z";
-        let warns = find_suspicious_placeholders(body);
-        assert_eq!(warns.len(), 2);
-        assert!(warns.iter().any(|s| s.contains("BRAZSYNC")));
-        assert!(warns.iter().any(|s| s.contains(".url.")));
-    }
-
-    #[test]
-    fn suspicious_excludes_strict_matches() {
-        let body = "__BRAZESYNC.lid.ok__";
-        assert!(find_suspicious_placeholders(body).is_empty());
-    }
-
-    #[test]
-    fn suspicious_ignores_trailing_double_underscore_text() {
-        // Regression: greedy loose regex extends past a valid placeholder
-        // into `__bold__`-style adjacent text and reports a span like
-        // (0, 26) for `__BRAZESYNC.lid.foo__bar__`. That span overlaps the
-        // real strict placeholder (0, 21), so it must not be surfaced.
-        let body = "__BRAZESYNC.lid.foo__bar__";
-        assert!(find_suspicious_placeholders(body).is_empty());
-    }
-
-    #[test]
-    fn suspicious_ignores_adjacent_placeholders_sharing_underscores() {
-        // Regression: with two adjacent strict placeholders joined by an
-        // extra `__`, the loose regex finds a single match that overlaps
-        // both strict spans. Overlap means "already covered" — no warning.
-        let body = "__BRAZESYNC.lid.foo____BRAZESYNC.lid.bar__";
-        assert!(find_suspicious_placeholders(body).is_empty());
-    }
-
-    #[test]
-    fn resolves_when_all_keys_present() {
-        let body = "before __BRAZESYNC.lid.cta__ middle __BRAZESYNC.cb_id.shared__ end";
-        let map = lookup(&[
-            (PlaceholderType::Lid, "cta", "ai8kexrxcp03"),
-            (PlaceholderType::CbId, "shared", "cb42"),
-        ]);
-        let resolved = resolve_placeholders(body, &map).unwrap();
-        assert_eq!(resolved, "before ai8kexrxcp03 middle cb42 end");
-    }
-
-    #[test]
-    fn resolves_repeated_cb_id_to_same_value() {
-        let body = "{{__BRAZESYNC.cb_id.shared__}}/a {{__BRAZESYNC.cb_id.shared__}}/b";
-        let map = lookup(&[(PlaceholderType::CbId, "shared", "cb42")]);
-        let resolved = resolve_placeholders(body, &map).unwrap();
-        assert_eq!(resolved, "{{cb42}}/a {{cb42}}/b");
-    }
-
-    #[test]
-    fn aggregates_unresolved_keys() {
-        let body = "__BRAZESYNC.lid.a__ __BRAZESYNC.cb_id.b__ __BRAZESYNC.cb_id.c__";
-        let map = lookup(&[(PlaceholderType::Lid, "a", "ai8kexrxcp03")]);
-        let err = resolve_placeholders(body, &map).unwrap_err();
-        assert_eq!(err.len(), 2);
-        let keys: Vec<_> = err
-            .iter()
-            .map(|e| match e {
-                ResolutionError::UnknownKey { ty, key, .. } => (*ty, key.clone()),
-                _ => unreachable!(),
-            })
-            .collect();
-        assert!(keys.contains(&(PlaceholderType::CbId, "b".to_string())));
-        assert!(keys.contains(&(PlaceholderType::CbId, "c".to_string())));
-    }
-
-    #[test]
-    fn placeholder_literal_round_trips() {
-        let ph = Placeholder {
-            ty: PlaceholderType::CbId,
-            key: "cb_hero".into(),
-            start: 0,
-            end: 0,
-        };
-        assert_eq!(ph.literal(), "__BRAZESYNC.cb_id.cb_hero__");
-    }
-
-    #[test]
-    fn duplicate_lid_aborts_with_dedicated_error() {
-        let body = "<a>__BRAZESYNC.lid.cta__</a> <a>__BRAZESYNC.lid.cta__</a>";
-        let map = lookup(&[(PlaceholderType::Lid, "cta", "ai8kexrxcp03")]);
-        let err = resolve_placeholders(body, &map).unwrap_err();
-        assert!(err.iter().any(|e| matches!(
-            e,
-            ResolutionError::DuplicateLidKey { key, occurrences }
-                if key == "cta" && occurrences.len() == 2
-        )));
-    }
-
-    #[test]
-    fn duplicate_cb_id_is_not_an_error() {
-        // cb_id re-use is normal (same block referenced twice).
-        let body = "{{cb.__BRAZESYNC.cb_id.x__}} {{cb.__BRAZESYNC.cb_id.x__}}";
-        let map = lookup(&[(PlaceholderType::CbId, "x", "cb42")]);
-        let out = resolve_placeholders(body, &map).unwrap();
-        assert_eq!(out, "{{cb.cb42}} {{cb.cb42}}");
-    }
-
-    #[test]
-    fn body_without_placeholders_passes_through() {
-        let body = "no placeholders here";
-        let map = BTreeMap::new();
-        assert_eq!(resolve_placeholders(body, &map).unwrap(), body);
-    }
-
-    #[test]
-    fn suspicious_catches_typo_with_underscore_key() {
-        // Regression: loose regex used to use `[^_\s]+` which excluded
-        // underscores, silently letting `__BRAZSYNC.lid.spring_sale__`
-        // (missing `E`, underscored key) through without a warning.
-        let body = "__BRAZSYNC.lid.spring_sale__";
-        let warns = find_suspicious_placeholders(body);
-        assert_eq!(warns, vec!["__BRAZSYNC.lid.spring_sale__".to_string()]);
-    }
-
-    #[test]
-    fn does_not_swallow_text_across_envelope_boundary() {
-        // Regression: a regex with a greedy `[a-z0-9_]*` key class merged
-        // `__BRAZESYNC.lid.foo__hello__BRAZESYNC.lid.bar__` into one
-        // placeholder with key=`foo__hello`. The parser must stop at the
-        // nearest `__` so both placeholders are recovered.
-        let body = "__BRAZESYNC.lid.foo__hello__BRAZESYNC.lid.bar__";
-        let ps = extract_placeholders(body);
-        assert_eq!(ps.len(), 2);
-        assert_eq!(ps[0].key, "foo");
-        assert_eq!(ps[1].key, "bar");
-        assert_eq!(&body[ps[0].start..ps[0].end], "__BRAZESYNC.lid.foo__");
-        assert_eq!(&body[ps[1].start..ps[1].end], "__BRAZESYNC.lid.bar__");
-    }
-
-    #[test]
-    fn adjacent_placeholders_share_no_underscore() {
-        // `____` between two placeholders: prior greedy regex captured
-        // key=`foo__`. The parser should treat the inner `__` as the close.
-        let body = "__BRAZESYNC.lid.foo____BRAZESYNC.lid.bar__";
-        let ps = extract_placeholders(body);
-        assert_eq!(ps.len(), 2);
-        assert_eq!(ps[0].key, "foo");
-        assert_eq!(ps[1].key, "bar");
-    }
-
-    #[test]
-    fn stops_at_nearest_close_envelope() {
-        let body = "__BRAZESYNC.lid.foo____bar__";
+    fn extracts_anonymous_lid_token() {
+        let body = "x | lid: '__BRAZESYNC__' y";
         let ps = extract_placeholders(body);
         assert_eq!(ps.len(), 1);
-        assert_eq!(ps[0].key, "foo");
-        assert_eq!(&body[ps[0].end..], "__bar__");
+        assert_eq!(ps[0].ty, Some(PlaceholderType::Lid));
     }
 
     #[test]
-    fn triple_underscore_parses_as_key_plus_trailing() {
-        // `__BRAZESYNC.lid.link___` → key=`link`, remaining `_`
-        let body = "__BRAZESYNC.lid.link___";
+    fn extracts_anonymous_cb_id_token() {
+        let body = "x | id: '__BRAZESYNC__' y";
         let ps = extract_placeholders(body);
         assert_eq!(ps.len(), 1);
-        assert_eq!(ps[0].key, "link");
-        assert_eq!(&body[ps[0].end..], "_");
+        assert_eq!(ps[0].ty, Some(PlaceholderType::CbId));
     }
 
     #[test]
-    fn underscored_keys_still_extract() {
-        // Sanity: legitimate underscored keys are not broken by the
-        // boundary-respecting parser.
-        let body = "__BRAZESYNC.lid.spring_sale__ x __BRAZESYNC.cb_id.promo_banner__";
+    fn double_quoted_context_recognized() {
+        let body = r#"| lid: "__BRAZESYNC__""#;
+        let ps = extract_placeholders(body);
+        assert_eq!(ps[0].ty, Some(PlaceholderType::Lid));
+    }
+
+    #[test]
+    fn token_without_filter_context_has_none_type() {
+        let body = "bare __BRAZESYNC__ token";
+        let ps = extract_placeholders(body);
+        assert_eq!(ps.len(), 1);
+        assert!(ps[0].ty.is_none());
+    }
+
+    #[test]
+    fn token_outside_quotes_has_none_type() {
+        let body = "| lid: __BRAZESYNC__";
+        let ps = extract_placeholders(body);
+        assert!(ps[0].ty.is_none());
+    }
+
+    #[test]
+    fn multiple_tokens_in_order() {
+        let body = "a | lid: '__BRAZESYNC__' b | id: '__BRAZESYNC__' c";
         let ps = extract_placeholders(body);
         assert_eq!(ps.len(), 2);
-        assert_eq!(ps[0].key, "spring_sale");
-        assert_eq!(ps[1].key, "promo_banner");
+        assert_eq!(ps[0].ty, Some(PlaceholderType::Lid));
+        assert_eq!(ps[1].ty, Some(PlaceholderType::CbId));
+        assert!(ps[0].start < ps[1].start);
+    }
+
+    #[test]
+    fn retired_envelope_is_suspicious() {
+        let body = "stuff __BRAZESYNC.lid.foo__ stuff";
+        let warns = find_suspicious_placeholders(body);
+        assert_eq!(warns, vec!["__BRAZESYNC.lid.foo__".to_string()]);
+    }
+
+    #[test]
+    fn retired_custom_namespace_is_suspicious() {
+        let body = "x __BRAZESYNC.custom.foo__ y";
+        let warns = find_suspicious_placeholders(body);
+        assert_eq!(warns, vec!["__BRAZESYNC.custom.foo__".to_string()]);
+    }
+
+    #[test]
+    fn typo_token_is_suspicious() {
+        let body = "x __BRAZSYNC__ y";
+        let warns = find_suspicious_placeholders(body);
+        assert!(warns.iter().any(|w| w.contains("BRAZSYNC")));
+    }
+
+    #[test]
+    fn strict_token_is_not_suspicious() {
+        let body = "x __BRAZESYNC__ y";
+        assert!(find_suspicious_placeholders(body).is_empty());
     }
 }

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -4,22 +4,15 @@
 //! a body string + field kind and return the rewritten body plus any
 //! warnings the operator should see.
 //!
-//! v0.15 model: templatization rewrites raw `| lid: 'X'` and
-//! `{{content_blocks.${NAME} | id: 'cbN'}}` to `__BRAZESYNC.*__`
-//! placeholders. The raw values are NOT persisted anywhere — at
-//! apply/diff time they are re-fetched from the remote body (see
-//! [`crate::values::braze_managed`]).
+//! v0.16 model: raw `| lid: 'X'` and `{{content_blocks.${NAME} | id: 'cbN'}}`
+//! are rewritten to the anonymous token `__BRAZESYNC__`. The raw values
+//! are NOT persisted — they are re-fetched from the remote body at
+//! apply/diff time (see [`crate::values::braze_managed`]).
 
 use regex_lite::Regex;
-use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
-use crate::values::correlation::{normalize_url, slug_for_cb_id, slug_for_lid};
-
-/// Which Liquid context the body belongs to. Determines:
-/// - what kind of URL anchor lid detection should look for (HTML vs raw)
-/// - whether lid detection without a URL anchor should produce a
-///   sequential `link_N` key (deferred for subject/preheader)
+/// Which Liquid context the body belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FieldKind {
     ContentBlock,
@@ -48,79 +41,45 @@ pub struct TemplatizedField {
     /// were rewritten.
     pub cb_id_rewrites: usize,
     /// Warnings the CLI should surface (e.g. lid in subject/preheader
-    /// where we don't have a robust anchor).
+    /// where the resolver falls back to positional FIFO).
     pub warnings: Vec<String>,
 }
 
-/// Detect every `| lid: '<value>'` and `{{content_blocks.${NAME} | id: 'cbN'}}`
-/// in `body`, rewrite to `__BRAZESYNC.<type>.<key>__` placeholders,
-/// and return the rewritten body plus a count of each rewrite kind.
-/// Idempotent by construction: the detection regexes require raw
-/// literals (`[a-z0-9]{8,}` for lid, `cb[0-9]+` for cb_id), so an
-/// already-templated `__BRAZESYNC.*__` placeholder never re-matches.
+/// Rewrite every raw `| lid: 'X'` and `{{content_blocks.${NAME} | id: 'cbN'}}`
+/// to the anonymous `__BRAZESYNC__` token. Idempotent: the detection
+/// regexes require raw literals (`[a-z0-9]{8,}` for lid, `cb[0-9]+` for
+/// cb_id), so an already-templated `__BRAZESYNC__` never re-matches.
 pub fn templatize_body(body: &str, field: FieldKind) -> TemplatizedField {
     let mut spans: Vec<DetectionSpan> = Vec::new();
-    let mut used_lid_keys: BTreeMap<String, usize> = BTreeMap::new();
-    let mut used_cb_id_keys: BTreeMap<String, usize> = BTreeMap::new();
-    // Repeated `${NAME}` cb_id references reuse the same key.
-    let mut cb_id_name_to_key: BTreeMap<String, String> = BTreeMap::new();
     let mut warnings: Vec<String> = Vec::new();
     let mut lid_rewrites = 0usize;
     let mut cb_id_rewrites = 0usize;
 
-    // --- lid detection ---
     for m in lid_match_re().captures_iter(body) {
         let whole = m.get(0).expect("group 0 always present");
-        let value = m
-            .get(1)
-            .or(m.get(2))
-            .map(|g| g.as_str().to_string())
-            .expect("one of the value alternates matches");
-
-        let (url, key) = name_lid_for_field(body, whole.start(), field, &mut used_lid_keys);
-        if url.is_none() && !matches!(field, FieldKind::EmailSubject | FieldKind::EmailPreheader) {
+        if matches!(field, FieldKind::EmailSubject | FieldKind::EmailPreheader) {
             warnings.push(format!(
-                "lid '{value}' at byte {} has no URL anchor; using sequential key '{key}'",
+                "lid detected in subject/preheader at byte {}; resolved \
+                 positionally at apply/diff time (Nth placeholder = Nth remote lid). \
+                 Verify rendered output if the field contains multiple lid values.",
                 whole.start()
             ));
         }
-        if matches!(field, FieldKind::EmailSubject | FieldKind::EmailPreheader) {
-            warnings.push(format!(
-                "lid '{value}' detected in subject/preheader (key '{key}'); \
-                 resolved positionally at apply/diff time (Nth placeholder = Nth remote lid). \
-                 Verify rendered output if the field contains multiple lid values."
-            ));
-        }
         spans.push(DetectionSpan {
             range: whole.range(),
-            replacement: format!("| lid: '__BRAZESYNC.lid.{key}__'"),
+            replacement: "| lid: '__BRAZESYNC__'".to_string(),
         });
         lid_rewrites += 1;
-        let _ = value; // value no longer persisted; surface in warning above when relevant.
     }
 
-    // --- cb_id detection ---
     for m in cb_id_match_re().captures_iter(body) {
         let whole = m.get(0).expect("group 0 always present");
-        let name = m.get(1).expect("name capture present").as_str().to_string();
-        let _value = m
-            .get(2)
-            .or(m.get(3))
-            .map(|g| g.as_str().to_string())
-            .expect("cbN capture present");
-        let key = match cb_id_name_to_key.get(&name) {
-            Some(prior) => prior.clone(),
-            None => {
-                let k = unique_key(slug_for_cb_id(&name), &mut used_cb_id_keys);
-                cb_id_name_to_key.insert(name.clone(), k.clone());
-                k
-            }
-        };
-        let replacement =
-            format!("{{{{content_blocks.${{{name}}} | id: '__BRAZESYNC.cb_id.{key}__'}}}}");
+        let name = m.get(1).expect("name capture present").as_str();
         spans.push(DetectionSpan {
             range: whole.range(),
-            replacement,
+            replacement: format!(
+                "{{{{content_blocks.${{{name}}} | id: '__BRAZESYNC__'}}}}"
+            ),
         });
         cb_id_rewrites += 1;
     }
@@ -147,7 +106,7 @@ struct DetectionSpan {
 fn lid_match_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r#"\|\s*lid:\s*(?:"([a-z0-9]{8,})"|'([a-z0-9]{8,})')"#)
+        Regex::new(r#"\|\s*lid:\s*(?:"[a-z0-9]{8,}"|'[a-z0-9]{8,}')"#)
             .expect("lid match regex is valid")
     })
 }
@@ -156,122 +115,10 @@ fn cb_id_match_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*(?:"(cb[0-9]+)"|'(cb[0-9]+)')\s*\}\}"#,
+            r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*(?:"cb[0-9]+"|'cb[0-9]+')\s*\}\}"#,
         )
         .expect("cb_id match regex is valid")
     })
-}
-
-fn anchor_href_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r#"(?i)<a\b[^>]*?\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')"#)
-            .expect("anchor href regex is valid")
-    })
-}
-
-fn url_attr_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(
-            r#"(?i)\s(?:[a-z][a-z0-9_-]*:)?(?:href|src|action)\s*=\s*(?:"([^"]*)"|'([^']*)')"#,
-        )
-        .expect("url attr regex is valid")
-    })
-}
-
-fn plaintext_url_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r#"https?://[^\s<>"']+"#).expect("plaintext URL regex is valid"))
-}
-
-fn name_lid_for_field(
-    body: &str,
-    lid_token_offset: usize,
-    field: FieldKind,
-    used: &mut BTreeMap<String, usize>,
-) -> (Option<String>, String) {
-    let url = preceding_url(body, lid_token_offset, field);
-    let key_source: String = match (&url, field) {
-        (Some(u), _) => url_path_tail(u),
-        (None, FieldKind::EmailSubject) => "subject_lid".to_string(),
-        (None, FieldKind::EmailPreheader) => "preheader_lid".to_string(),
-        (None, _) => String::new(),
-    };
-    let slug = slug_for_lid(&key_source);
-    let key = unique_key(slug, used);
-    (url, key)
-}
-
-fn preceding_url(body: &str, lid_token_offset: usize, field: FieldKind) -> Option<String> {
-    let raw = if field.supports_html_anchor() {
-        match enclosing_open_tag(body, lid_token_offset) {
-            Some(tag) => url_attr_re()
-                .captures(tag)
-                .and_then(|cap| cap.get(1).or(cap.get(2)))
-                .map(|x| x.as_str().to_string()),
-            None => {
-                let prefix = &body[..lid_token_offset];
-                anchor_href_re()
-                    .captures_iter(prefix)
-                    .last()
-                    .and_then(|cap| cap.get(1).or(cap.get(2)))
-                    .map(|m| m.as_str().to_string())
-            }
-        }
-    } else if field.supports_plaintext_anchor() {
-        let prefix = &body[..lid_token_offset];
-        plaintext_url_re()
-            .find_iter(prefix)
-            .last()
-            .map(|m| m.as_str().to_string())
-    } else {
-        None
-    };
-    raw.map(|r| normalize_url(&r))
-}
-
-fn enclosing_open_tag(body: &str, lid_token_offset: usize) -> Option<&str> {
-    let re = element_open_tag_re();
-    for m in re.find_iter(body) {
-        if m.start() > lid_token_offset {
-            break;
-        }
-        if m.end() > lid_token_offset {
-            return Some(&body[m.start()..m.end()]);
-        }
-    }
-    None
-}
-
-fn element_open_tag_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r#"(?i)<[a-z][a-z0-9_.:-]*\b[^>]*>"#).expect("element open tag regex is valid")
-    })
-}
-
-fn url_path_tail(url: &str) -> String {
-    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
-    let path_start = after_scheme
-        .find('/')
-        .map(|i| i + 1)
-        .unwrap_or(after_scheme.len());
-    let path = &after_scheme[path_start..];
-    path.rsplit('/')
-        .find(|s| !s.is_empty())
-        .unwrap_or("")
-        .to_string()
-}
-
-fn unique_key(base: String, used: &mut BTreeMap<String, usize>) -> String {
-    let count = used.entry(base.clone()).or_insert(0);
-    *count += 1;
-    if *count == 1 {
-        base
-    } else {
-        format!("{base}_{count}")
-    }
 }
 
 #[cfg(test)]
@@ -280,17 +127,17 @@ mod tests {
 
     #[test]
     fn idempotent_on_already_templatized_body() {
-        let body = "<p>__BRAZESYNC.lid.cta__ kept verbatim</p>";
+        let body = "<p>__BRAZESYNC__ kept verbatim</p>";
         let r = templatize_body(body, FieldKind::ContentBlock);
         assert_eq!(r.new_body, body);
         assert_eq!(r.lid_rewrites, 0);
     }
 
     #[test]
-    fn rewrites_html_lid_with_url_anchor() {
+    fn rewrites_html_lid() {
         let body = r#"<a href="https://example.com/spring-sale">{{x | lid: 'ai8kexrxcp03'}}</a>"#;
         let r = templatize_body(body, FieldKind::ContentBlock);
-        assert!(r.new_body.contains("__BRAZESYNC.lid.spring_sale__"));
+        assert!(r.new_body.contains("| lid: '__BRAZESYNC__'"));
         assert_eq!(r.lid_rewrites, 1);
     }
 
@@ -298,69 +145,49 @@ mod tests {
     fn rewrites_cb_id_include() {
         let body = "{{content_blocks.${promo_banner} | id: 'cb42'}}";
         let r = templatize_body(body, FieldKind::ContentBlock);
-        assert!(r.new_body.contains("__BRAZESYNC.cb_id.promo_banner__"));
-        assert!(r.new_body.contains("${promo_banner}"));
+        assert!(
+            r.new_body
+                .contains("{{content_blocks.${promo_banner} | id: '__BRAZESYNC__'}}"),
+            "got: {}",
+            r.new_body
+        );
         assert_eq!(r.cb_id_rewrites, 1);
     }
 
     #[test]
-    fn dedupes_duplicate_url_with_sequential_suffix() {
+    fn multiple_lids_in_one_field_all_become_anonymous() {
         let body = r#"
 <a href="https://example.com/cta">{{x | lid: 'ai8kexrxcp03'}}A</a>
 <a href="https://example.com/cta">{{x | lid: 'bj9lfsysxq14'}}B</a>"#;
         let r = templatize_body(body, FieldKind::ContentBlock);
-        assert!(r.new_body.contains("__BRAZESYNC.lid.cta__"));
-        assert!(r.new_body.contains("__BRAZESYNC.lid.cta_2__"));
+        let n = r.new_body.matches("| lid: '__BRAZESYNC__'").count();
+        assert_eq!(n, 2);
     }
 
     #[test]
-    fn plaintext_url_anchor_works() {
+    fn plaintext_url_lid_rewritten() {
         let body = "Click https://example.com/promo {{x | lid: 'ai8kexrxcp03'}} now.";
         let r = templatize_body(body, FieldKind::EmailPlainBody);
-        assert!(r.new_body.contains("__BRAZESYNC.lid.promo__"));
+        assert!(r.new_body.contains("| lid: '__BRAZESYNC__'"));
     }
 
     #[test]
-    fn repeated_cb_id_name_reuses_key() {
+    fn repeated_cb_id_name_independent_replacements() {
         let body = "{{content_blocks.${promo} | id: 'cb10'}} ... \
                     {{content_blocks.${promo} | id: 'cb10'}}";
         let r = templatize_body(body, FieldKind::ContentBlock);
-        let occurrences = r.new_body.matches("__BRAZESYNC.cb_id.promo__").count();
-        assert_eq!(occurrences, 2);
+        let n = r
+            .new_body
+            .matches("{{content_blocks.${promo} | id: '__BRAZESYNC__'}}")
+            .count();
+        assert_eq!(n, 2);
     }
 
     #[test]
-    fn lid_inside_href_attribute_value_uses_enclosing_anchor() {
-        let body = r#"<a href="https://med.example.com/product/jaypirca/50mg/?lid={{${cblid} | lid: 'ai8kexrxcp03'}}"><img src="x"/></a>"#;
-        let r = templatize_body(body, FieldKind::ContentBlock);
-        assert!(r.new_body.contains("__BRAZESYNC.lid.link_50mg__"));
-        assert!(r.warnings.is_empty());
-    }
-
-    #[test]
-    fn vml_href_anchors_lid() {
-        let body = r#"<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" href="https://hokto.example.com/page/?lid={{${cblid} | lid: 'ulab324mjv2a'}}" style="…"></v:roundrect>"#;
-        let r = templatize_body(body, FieldKind::ContentBlock);
-        assert!(r.new_body.contains("__BRAZESYNC.lid.page__"));
-        assert!(r.warnings.is_empty());
-    }
-
-    #[test]
-    fn data_prefixed_attrs_are_not_treated_as_url_anchor() {
-        let body = r#"<button data-action="track" data-href="ignored">{{x | lid: 'ulab324mjv2a'}}</button>"#;
-        let r = templatize_body(body, FieldKind::ContentBlock);
-        // Falls back to sequential `link` key, no URL anchor.
-        assert!(r.new_body.contains("__BRAZESYNC.lid.link__"));
+    fn subject_lid_emits_positional_warning() {
+        let body = "{{x | lid: 'ai8kexrxcp03'}}";
+        let r = templatize_body(body, FieldKind::EmailSubject);
+        assert!(r.new_body.contains("| lid: '__BRAZESYNC__'"));
         assert!(!r.warnings.is_empty());
-    }
-
-    #[test]
-    fn url_path_tail_uses_last_nonempty_segment() {
-        assert_eq!(
-            url_path_tail("https://example.com/promo/spring-sale"),
-            "spring-sale"
-        );
-        assert_eq!(url_path_tail("https://example.com/"), "");
-        assert_eq!(url_path_tail("https://example.com"), "");
     }
 }

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -77,9 +77,7 @@ pub fn templatize_body(body: &str, field: FieldKind) -> TemplatizedField {
         let name = m.get(1).expect("name capture present").as_str();
         spans.push(DetectionSpan {
             range: whole.range(),
-            replacement: format!(
-                "{{{{content_blocks.${{{name}}} | id: '__BRAZESYNC__'}}}}"
-            ),
+            replacement: format!("{{{{content_blocks.${{{name}}} | id: '__BRAZESYNC__'}}}}"),
         });
         cb_id_rewrites += 1;
     }

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1570,8 +1570,8 @@ resources:
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn content_block_apply_resolves_lid_via_new_resource_fallback() {
     // New-resource path: remote is empty so lid resolves via fallback
-    // to the placeholder key itself. Apply must POST the *resolved*
-    // body (no `__BRAZESYNC.*__` tokens left).
+    // to the URL path tail slug. Apply must POST the *resolved* body
+    // (no `__BRAZESYNC__` tokens left).
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/content_blocks/list"))
@@ -1584,7 +1584,7 @@ async fn content_block_apply_resolves_lid_via_new_resource_fallback() {
         .and(path("/content_blocks/create"))
         .and(body_json(json!({
             "name": "promo",
-            "content": "<a href=\"https://example.com/cta\">{{x | lid: 'spring_sale'}}</a>\n",
+            "content": "<a href=\"https://example.com/cta\">{{x | lid: 'cta'}}</a>\n",
             "tags": [],
             "state": "active"
         })))
@@ -1601,7 +1601,7 @@ async fn content_block_apply_resolves_lid_via_new_resource_fallback() {
     common::write_local_content_block(
         tmp.path(),
         "promo",
-        "<a href=\"https://example.com/cta\">{{x | lid: '__BRAZESYNC.lid.spring_sale__'}}</a>\n",
+        "<a href=\"https://example.com/cta\">{{x | lid: '__BRAZESYNC__'}}</a>\n",
     );
 
     tokio::task::spawn_blocking(move || {
@@ -1654,7 +1654,7 @@ async fn content_block_apply_aborts_when_placeholder_unresolved() {
     common::write_local_content_block(
         tmp.path(),
         "promo",
-        "<a href=\"https://example.com/cta\">{{x | lid: '__BRAZESYNC.lid.cta__'}}</a>",
+        "<a href=\"https://example.com/cta\">{{x | lid: '__BRAZESYNC__'}}</a>",
     );
 
     tokio::task::spawn_blocking(move || {
@@ -1667,8 +1667,8 @@ async fn content_block_apply_aborts_when_placeholder_unresolved() {
             .failure();
         let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
         assert!(
-            stderr.contains("unresolved placeholder")
-                || stderr.contains("__BRAZESYNC.lid.cta__")
+            stderr.contains("UnresolvedLid")
+                || stderr.contains("__BRAZESYNC__")
                 || stderr.contains("anchor"),
             "expected resolution error mentioning the unresolved lid, got:\n{stderr}"
         );

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -771,7 +771,7 @@ async fn content_block_diff_no_drift_when_placeholders_resolve_to_remote() {
     write_local_content_block(
         tmp.path(),
         "promo",
-        "<a href=\"https://example.com/cta\">{{x | lid: '__BRAZESYNC.lid.cta__'}}</a>\n",
+        "<a href=\"https://example.com/cta\">{{x | lid: '__BRAZESYNC__'}}</a>\n",
     );
 
     let output = tokio::task::spawn_blocking(move || {
@@ -833,7 +833,7 @@ async fn email_template_diff_no_drift_when_placeholders_resolve_to_remote() {
         tmp.path(),
         "welcome",
         "Hi",
-        "<a href=\"https://example.com/cta\">{{x | lid: '__BRAZESYNC.lid.cta__'}}</a>",
+        "<a href=\"https://example.com/cta\">{{x | lid: '__BRAZESYNC__'}}</a>",
         "Hi",
     );
 

--- a/tests/cli_export.rs
+++ b/tests/cli_export.rs
@@ -467,7 +467,7 @@ async fn export_content_block_preserves_local_template_and_refreshes_values() {
     common::write_local_content_block(
         tmp.path(),
         "promo",
-        "<a href=\"https://example.com/cta\">{{ x | lid: '__BRAZESYNC.lid.cta__' }}go</a>",
+        "<a href=\"https://example.com/cta\">{{ x | lid: '__BRAZESYNC__' }}go</a>",
     );
 
     tokio::task::spawn_blocking(move || {
@@ -484,7 +484,7 @@ async fn export_content_block_preserves_local_template_and_refreshes_values() {
 
     let saved = fs::read_to_string(tmp.path().join("content_blocks").join("promo.liquid")).unwrap();
     assert!(
-        saved.contains("__BRAZESYNC.lid.cta__"),
+        saved.contains("__BRAZESYNC__"),
         "local template body must survive export round-trip, got:\n{saved}"
     );
     assert!(
@@ -568,7 +568,7 @@ async fn export_leaves_legacy_values_yaml_unchanged() {
     common::write_local_content_block(
         tmp.path(),
         "promo",
-        "<a href=\"https://example.com/cta\">{{ x | lid: '__BRAZESYNC.lid.cta__' }}go</a>",
+        "<a href=\"https://example.com/cta\">{{ x | lid: '__BRAZESYNC__' }}go</a>",
     );
     let legacy = r#"version: 1
 content_block:

--- a/tests/cli_templatize.rs
+++ b/tests/cli_templatize.rs
@@ -51,7 +51,7 @@ fn templatize_rewrites_body_and_writes_canonical_and_skeleton() {
 
     let body = fs::read_to_string(tmp.path().join("content_blocks").join("promo.liquid")).unwrap();
     assert!(
-        body.contains("__BRAZESYNC.lid.cta__"),
+        body.contains("| lid: '__BRAZESYNC__'"),
         "expected placeholder in rewritten body, got:\n{body}"
     );
     assert!(
@@ -99,7 +99,7 @@ fn templatize_skips_already_templated_resources() {
     write_local_content_block(
         tmp.path(),
         "promo",
-        "<a href=\"https://example.com/cta\">{{ x | lid: '__BRAZESYNC.lid.cta__' }}go</a>",
+        "<a href=\"https://example.com/cta\">{{ x | lid: '__BRAZESYNC__' }}go</a>",
     );
 
     let output = Command::cargo_bin("braze-sync")
@@ -118,7 +118,7 @@ fn templatize_skips_already_templated_resources() {
 
     // Body unchanged.
     let body = fs::read_to_string(tmp.path().join("content_blocks").join("promo.liquid")).unwrap();
-    assert!(body.contains("__BRAZESYNC.lid.cta__"));
+    assert!(body.contains("__BRAZESYNC__"));
     // No canonical values file written because no rewrite occurred.
     assert!(!tmp.path().join("values").join("prod.yaml").exists());
 }
@@ -173,11 +173,12 @@ fn templatize_repeated_cb_id_name_yields_single_key() {
         .success();
 
     let body = fs::read_to_string(tmp.path().join("content_blocks").join("duo.liquid")).unwrap();
-    let count = body.matches("__BRAZESYNC.cb_id.promo__").count();
-    assert_eq!(count, 2, "both occurrences must use the same `promo` key");
-    assert!(
-        !body.contains("__BRAZESYNC.cb_id.promo_2__"),
-        "repeated ${{promo}} must NOT create a `promo_2` key, got:\n{body}"
+    let count = body
+        .matches("{{content_blocks.${promo} | id: '__BRAZESYNC__'}}")
+        .count();
+    assert_eq!(
+        count, 2,
+        "both occurrences must rewrite to the anonymous token, got:\n{body}"
     );
 }
 
@@ -191,7 +192,7 @@ fn templatize_picks_up_remaining_raw_lid_after_partial_migration() {
     write_local_content_block(
         tmp.path(),
         "promo",
-        "<a href=\"https://example.com/cta\">{{ x | lid: '__BRAZESYNC.lid.cta__' }}A</a>\n\
+        "<a href=\"https://example.com/cta\">{{ x | lid: '__BRAZESYNC__' }}A</a>\n\
          <a href=\"https://example.com/promo\">{{ x | lid: 'rawvalue1234' }}B</a>",
     );
 
@@ -203,13 +204,10 @@ fn templatize_picks_up_remaining_raw_lid_after_partial_migration() {
         .success();
 
     let body = fs::read_to_string(tmp.path().join("content_blocks").join("promo.liquid")).unwrap();
-    assert!(
-        body.contains("__BRAZESYNC.lid.cta__"),
-        "existing placeholder must be preserved, got:\n{body}"
-    );
-    assert!(
-        body.contains("__BRAZESYNC.lid.promo__"),
-        "remaining raw lid must now be templated, got:\n{body}"
+    let count = body.matches("| lid: '__BRAZESYNC__'").count();
+    assert_eq!(
+        count, 2,
+        "both lid occurrences must end up as anonymous placeholders, got:\n{body}"
     );
     assert!(
         !body.contains("rawvalue1234"),


### PR DESCRIPTION
## Summary

- Replace keyed `__BRAZESYNC.<type>.<key>__` with the anonymous `__BRAZESYNC__`. Type is inferred from the surrounding `| lid:` / `| id:` filter; correlation continues to use URL / `${NAME}` / positional (the key never participated in matching).
- Resolution is now offset-based and lives in `braze_managed::prepare_field`. `resolve_placeholders` / `LookupKey` / `DuplicateLidKey` / `UnknownKey` are removed.
- New-resource lid fallback derives from the URL path tail slug (`_2`/`_3` for collisions; positional `lid_N` when no URL).
- v0.15 envelope is detected on parse and surfaces as fatal `RetiredNamespace` — **no compat path**.

## Breaking change & migration

The v0.15 form `__BRAZESYNC.<type>.<key>__` is removed without a dual-parser period. Before upgrading, re-run on each workspace:

```bash
braze-sync export --env=<env>   # pull raw bodies back
braze-sync templatize           # emit __BRAZESYNC__
```

Stale v0.15 tokens that reach resolve produce a fatal error pointing at `templatize`, so partial migrations fail loudly rather than ship broken templates.

## Test plan

- [x] `cargo test --no-fail-fast` — 482 tests pass (lib 381 + integration 101)
- [x] `cargo clippy --all-targets` — 0 warnings
- [ ] Smoke: re-run `templatize` on hokuto-braze, confirm bodies regenerate with anonymous tokens and a follow-up `diff --env=prod` shows no drift
- [ ] Smoke: `apply --confirm` on a new-resource path, verify POSTed body uses URL slug fallback (not the legacy key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 0.16.0

* **Breaking Changes**
  * Placeholder syntax simplified to anonymous `__BRAZESYNC__` token; type (lid/cb_id) now inferred from surrounding filter context (`| lid:` / `| id:`).
  * Migration required: rerun `braze-sync templatize` to update existing templates; old envelope syntax triggers `RetiredNamespace` error.

* **New Features**
  * URL-slug-based `lid` fallback for new resources without remote bodies.
  * Positional identifier fallback (lid_1, lid_2, …) for placeholders without URL context.

* **Documentation**
  * Updated guide with new placeholder syntax, fallback strategies, and migration instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->