### PR TITLE
fix: resolve unmatched lid placeholders with fallback (v0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,26 @@ file formats, JSON output, exit codes) for the full v1.x line.
   for the remaining failure mode — a lid placeholder with no URL
   anchor at all. Fixes #52.
 
+- **`diff` and `apply` now print a "Notice" block summarizing any
+  drift-fallback `lid` assignments**, scoped per resource (and field
+  for email_template), with the URL anchor → fallback value mapping.
+  Surfaces what would otherwise hide inside warning noise so an
+  operator running blind `apply --confirm` still sees which links the
+  local template introduced that the remote didn't carry.
+  Brand-new-resource fallbacks are intentionally not listed (they're
+  the expected path).
+
+### Fixed
+
+- **Fallback `lid` values can no longer collide with remote-resolved
+  values.** Previously, if the remote happened to assign lid
+  `'checkout'` to one URL and the local template introduced a new
+  `/checkout` link, the fallback URL-slug `'checkout'` would land in
+  the POSTed body alongside the real one — corrupting Braze's
+  per-link analytics. The fallback generator now seeds its dedupe
+  map with every remote lid value so collisions get the standard
+  `_2`, `_3`, … suffix.
+
 ## [0.16.0] — 2026-05-25
 
 ### Changed (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [0.16.1] — 2026-05-25
+
+### Changed
+
+- **Unmatched `lid` placeholders now resolve via fallback instead of
+  aborting.** When the local template carries more `lid` placeholders
+  than the remote body has `lid` values (e.g. a `footer` content
+  block has 9 links in Prod structure but only 5 in Dev), the
+  unmatched placeholders now resolve to the URL path-tail slug —
+  identical to the new-resource path — and a warning is emitted per
+  unmatched anchor. `diff` then surfaces a meaningful structural
+  diff and `apply` POSTs the full template so the remote gains the
+  missing links; Braze reassigns the lid value on first dashboard
+  save. The subject/preheader positional resolver applies the same
+  fallback when the remote yields fewer lid values than the
+  template. The `ResolutionError::UnresolvedLid` variant is retained
+  for the remaining failure mode — a lid placeholder with no URL
+  anchor at all. Fixes #52.
+
 ## [0.16.0] — 2026-05-25
 
 ### Changed (breaking)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -22,6 +22,7 @@ use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::error::Error;
 use crate::format::OutputFormat;
 use crate::resource::ResourceKind;
+use crate::values::{format_fallback_reports, FallbackReport};
 use anyhow::{anyhow, Context as _};
 use clap::Args;
 use std::path::{Path, PathBuf};
@@ -95,6 +96,7 @@ pub async fn run(
     let mut summary = DiffSummary::default();
     let mut content_block_id_index: Option<ContentBlockIdIndex> = None;
     let mut email_template_id_index: Option<EmailTemplateIdIndex> = None;
+    let mut fallback_reports: Vec<FallbackReport> = Vec::new();
     for kind in &kinds {
         let kind = *kind;
         if warn_if_name_excluded(kind, args.name.as_deref(), resolved.excludes_for(kind)) {
@@ -113,7 +115,7 @@ pub async fn run(
                 summary.diffs.extend(diffs);
             }
             ResourceKind::ContentBlock => {
-                let (diffs, idx) = compute_content_block_plan(
+                let (diffs, idx, reports) = compute_content_block_plan(
                     &client,
                     &content_blocks_root,
                     args.name.as_deref(),
@@ -122,10 +124,11 @@ pub async fn run(
                 .await
                 .context("computing content_block plan")?;
                 summary.diffs.extend(diffs);
+                fallback_reports.extend(reports);
                 content_block_id_index = Some(idx);
             }
             ResourceKind::EmailTemplate => {
-                let (diffs, idx) = compute_email_template_plan(
+                let (diffs, idx, reports) = compute_email_template_plan(
                     &client,
                     &email_templates_root,
                     args.name.as_deref(),
@@ -134,6 +137,7 @@ pub async fn run(
                 .await
                 .context("computing email_template plan")?;
                 summary.diffs.extend(diffs);
+                fallback_reports.extend(reports);
                 email_template_id_index = Some(idx);
             }
             ResourceKind::CustomAttribute => {
@@ -195,6 +199,10 @@ pub async fn run(
     };
     eprintln!("{mode_label}");
     print!("{}", format.formatter().format(&summary));
+    let fallback_block = format_fallback_reports(&fallback_reports);
+    if !fallback_block.is_empty() {
+        eprint!("{fallback_block}");
+    }
 
     // Print the fresh plan first so the operator sees it even on mismatch.
     if let Some(saved) = &saved_plan {

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -23,7 +23,8 @@ use crate::format::OutputFormat;
 use crate::fs::{catalog_io, content_block_io, custom_attribute_io, email_template_io, tag_io};
 use crate::resource::{Catalog, ContentBlock, EmailTemplate, ResourceKind};
 use crate::values::{
-    format_failures, resolve_content_block_with_remote, resolve_email_template_with_remote,
+    format_failures, format_fallback_reports, resolve_content_block_with_remote,
+    resolve_email_template_with_remote, FallbackReport,
 };
 use anyhow::Context as _;
 use clap::Args;
@@ -78,6 +79,7 @@ pub async fn run(
     let kinds = selected_kinds(args.resource, &resolved.resources);
 
     let mut summary = DiffSummary::default();
+    let mut fallback_reports: Vec<FallbackReport> = Vec::new();
     for kind in &kinds {
         let kind = *kind;
         if warn_if_name_excluded(kind, args.name.as_deref(), resolved.excludes_for(kind)) {
@@ -96,7 +98,7 @@ pub async fn run(
                 summary.diffs.extend(diffs);
             }
             ResourceKind::ContentBlock => {
-                let (diffs, _idx) = compute_content_block_plan(
+                let (diffs, _idx, reports) = compute_content_block_plan(
                     &client,
                     &content_blocks_root,
                     args.name.as_deref(),
@@ -105,9 +107,10 @@ pub async fn run(
                 .await
                 .context("computing content_block diff")?;
                 summary.diffs.extend(diffs);
+                fallback_reports.extend(reports);
             }
             ResourceKind::EmailTemplate => {
-                let (diffs, _idx) = compute_email_template_plan(
+                let (diffs, _idx, reports) = compute_email_template_plan(
                     &client,
                     &email_templates_root,
                     args.name.as_deref(),
@@ -116,6 +119,7 @@ pub async fn run(
                 .await
                 .context("computing email_template diff")?;
                 summary.diffs.extend(diffs);
+                fallback_reports.extend(reports);
             }
             ResourceKind::CustomAttribute => {
                 let diffs = compute_custom_attribute_diffs(
@@ -144,6 +148,10 @@ pub async fn run(
 
     let formatted = format.formatter().format(&summary);
     print!("{formatted}");
+    let fallback_block = format_fallback_reports(&fallback_reports);
+    if !fallback_block.is_empty() {
+        eprint!("{fallback_block}");
+    }
 
     if let Some(path) = &args.plan_out {
         let plan = PlanFile::from_summary(
@@ -227,7 +235,7 @@ pub(crate) async fn compute_content_block_plan(
     content_blocks_root: &Path,
     name_filter: Option<&str>,
     excludes: &[Regex],
-) -> anyhow::Result<(Vec<ResourceDiff>, ContentBlockIdIndex)> {
+) -> anyhow::Result<(Vec<ResourceDiff>, ContentBlockIdIndex, Vec<FallbackReport>)> {
     let mut local = content_block_io::load_all_content_blocks(content_blocks_root)?;
     if let Some(name) = name_filter {
         local.retain(|c| c.name == name);
@@ -277,10 +285,12 @@ pub(crate) async fn compute_content_block_plan(
     // for new resources).
     drop(local_by_name);
     let mut cb_failures = Vec::new();
+    let mut fallback_reports: Vec<FallbackReport> = Vec::new();
     for cb in &mut local {
         let remote_cb = fetched.get(&cb.name);
-        if let Err(f) = resolve_content_block_with_remote(cb, remote_cb) {
-            cb_failures.push(f);
+        match resolve_content_block_with_remote(cb, remote_cb) {
+            Ok(reports) => fallback_reports.extend(reports),
+            Err(f) => cb_failures.push(f),
         }
     }
     if !cb_failures.is_empty() {
@@ -320,7 +330,7 @@ pub(crate) async fn compute_content_block_plan(
         }
     }
 
-    Ok((diffs, id_index))
+    Ok((diffs, id_index, fallback_reports))
 }
 
 /// Same pattern as `compute_content_block_plan` — list first, fan-out
@@ -330,7 +340,7 @@ pub(crate) async fn compute_email_template_plan(
     email_templates_root: &Path,
     name_filter: Option<&str>,
     excludes: &[Regex],
-) -> anyhow::Result<(Vec<ResourceDiff>, EmailTemplateIdIndex)> {
+) -> anyhow::Result<(Vec<ResourceDiff>, EmailTemplateIdIndex, Vec<FallbackReport>)> {
     let mut local = email_template_io::load_all_email_templates(email_templates_root)?;
     if let Some(name) = name_filter {
         local.retain(|t| t.name == name);
@@ -375,10 +385,12 @@ pub(crate) async fn compute_email_template_plan(
 
     drop(local_by_name);
     let mut et_failures = Vec::new();
+    let mut fallback_reports: Vec<FallbackReport> = Vec::new();
     for et in &mut local {
         let remote_et = fetched.get(&et.name);
-        if let Err(failures) = resolve_email_template_with_remote(et, remote_et) {
-            et_failures.extend(failures);
+        match resolve_email_template_with_remote(et, remote_et) {
+            Ok(reports) => fallback_reports.extend(reports),
+            Err(failures) => et_failures.extend(failures),
         }
     }
     if !et_failures.is_empty() {
@@ -412,7 +424,7 @@ pub(crate) async fn compute_email_template_plan(
         }
     }
 
-    Ok((diffs, id_index))
+    Ok((diffs, id_index, fallback_reports))
 }
 
 /// Compute Custom Attribute diffs by comparing the local registry file

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -35,6 +35,21 @@ pub struct PreparedTemplate {
     /// Non-fatal warnings — ambiguous URL matches, count mismatches,
     /// stripped cb_id filters on new resources.
     pub warnings: Vec<String>,
+    /// Drift-fallback `lid` values: template placeholders that had no
+    /// matching remote anchor and were resolved with a generated slug.
+    /// Brand-new-resource fallbacks are *not* recorded here — they are
+    /// the expected path and would be noise. Populated only when a
+    /// remote body was provided but came up short.
+    pub fallbacks: Vec<LidFallback>,
+}
+
+/// A single drift-fallback assignment. `anchor` is the URL anchor when
+/// available (HTML / plaintext fields); `None` for positional contexts
+/// like subject / preheader where the placeholder has no URL anchor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LidFallback {
+    pub anchor: Option<String>,
+    pub value: String,
 }
 
 /// Resolve every `__BRAZESYNC__` in `template` against `remote`.
@@ -55,6 +70,7 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
             body: template.to_string(),
             errors,
             warnings: Vec::new(),
+            fallbacks: Vec::new(),
         };
     }
 
@@ -62,6 +78,7 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
         Some(_) => (template.to_string(), Vec::new()),
         None => strip_cb_id_filters(template),
     };
+    let mut fallbacks: Vec<LidFallback> = Vec::new();
 
     // Map each `__BRAZESYNC__` occurrence in `body` to its resolved
     // value. None entries are recorded as errors instead.
@@ -85,6 +102,7 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
             remote_body,
             field,
             &mut warnings,
+            &mut fallbacks,
         ),
         None => fallback_lid_batch(&body, &placeholders, &lid_indices, field),
     };
@@ -139,6 +157,7 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
         body: out,
         errors,
         warnings,
+        fallbacks,
     }
 }
 
@@ -151,12 +170,20 @@ fn resolve_lid_batch(
     remote: &str,
     field: FieldKind,
     warnings: &mut Vec<String>,
+    fallbacks: &mut Vec<LidFallback>,
 ) -> Vec<Option<String>> {
     if lid_indices.is_empty() {
         return Vec::new();
     }
     if !field.supports_html_anchor() && !field.supports_plaintext_anchor() {
-        return resolve_lid_positional(placeholders, lid_indices, remote, field, warnings);
+        return resolve_lid_positional(
+            placeholders,
+            lid_indices,
+            remote,
+            field,
+            warnings,
+            fallbacks,
+        );
     }
 
     let remote_pairs: Vec<LidCorrelation> = if field.supports_html_anchor() {
@@ -223,6 +250,10 @@ fn resolve_lid_batch(
                      using fallback value '{fallback}' (new link; Braze will \
                      reassign on first dashboard save)"
                 ));
+                fallbacks.push(LidFallback {
+                    anchor: Some(url.clone()),
+                    value: fallback.clone(),
+                });
                 out.push(Some(fallback));
             }
         }
@@ -263,6 +294,7 @@ fn resolve_lid_positional(
     remote: &str,
     field: FieldKind,
     warnings: &mut Vec<String>,
+    fallbacks: &mut Vec<LidFallback>,
 ) -> Vec<Option<String>> {
     let remote_values = extract_lid_values_unanchored(remote);
     let field_label = match field {
@@ -291,7 +323,14 @@ fn resolve_lid_positional(
     for _ in lid_indices {
         match iter.next() {
             Some(v) => out.push(Some(v)),
-            None => out.push(Some(fallback_lid_for_url(None, &mut used, &mut seq))),
+            None => {
+                let v = fallback_lid_for_url(None, &mut used, &mut seq);
+                fallbacks.push(LidFallback {
+                    anchor: None,
+                    value: v.clone(),
+                });
+                out.push(Some(v));
+            }
         }
     }
     out

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -194,6 +194,8 @@ fn resolve_lid_batch(
     }
 
     let mut out = Vec::with_capacity(lid_indices.len());
+    let mut used: BTreeMap<String, usize> = BTreeMap::new();
+    let mut seq = 0usize;
     for anchor in anchors {
         let Some(url) = anchor else {
             warnings.push(
@@ -208,12 +210,43 @@ fn resolve_lid_batch(
         match pick {
             Some(p) => out.push(Some(p.value.clone())),
             None => {
-                warnings.push(format!("lid: URL anchor '{url}' not found in remote body"));
-                out.push(None);
+                let fallback = fallback_lid_for_url(Some(&url), &mut used, &mut seq);
+                warnings.push(format!(
+                    "lid: URL anchor '{url}' not found in remote body — \
+                     using fallback value '{fallback}' (new link; Braze will \
+                     reassign on first dashboard save)"
+                ));
+                out.push(Some(fallback));
             }
         }
     }
     out
+}
+
+/// Slug fallback for a single lid placeholder. `used` is shared across
+/// the batch so collisions are disambiguated with `_2`, `_3`, ….
+fn fallback_lid_for_url(
+    url: Option<&str>,
+    used: &mut BTreeMap<String, usize>,
+    seq: &mut usize,
+) -> String {
+    let base = match url {
+        Some(u) => {
+            let tail = url_path_tail(u);
+            let slug = slug_for_lid(&tail);
+            if slug.is_empty() {
+                *seq += 1;
+                format!("lid_{seq}", seq = *seq)
+            } else {
+                slug
+            }
+        }
+        None => {
+            *seq += 1;
+            format!("lid_{seq}", seq = *seq)
+        }
+    };
+    unique(base, used)
 }
 
 /// Positional FIFO match for subject / preheader.
@@ -241,8 +274,13 @@ fn resolve_lid_positional(
     let _ = placeholders;
     let mut out = Vec::with_capacity(lid_indices.len());
     let mut iter = remote_values.into_iter();
+    let mut used: BTreeMap<String, usize> = BTreeMap::new();
+    let mut seq = 0usize;
     for _ in lid_indices {
-        out.push(iter.next());
+        match iter.next() {
+            Some(v) => out.push(Some(v)),
+            None => out.push(Some(fallback_lid_for_url(None, &mut used, &mut seq))),
+        }
     }
     out
 }
@@ -303,23 +341,11 @@ fn fallback_lid_batch(
     let mut out = Vec::with_capacity(lid_indices.len());
     for &i in lid_indices {
         let anchor = lid_anchor_for(body, placeholders[i].start, field);
-        let base = match anchor.as_deref() {
-            Some(u) => {
-                let tail = url_path_tail(u);
-                let slug = slug_for_lid(&tail);
-                if slug.is_empty() {
-                    seq += 1;
-                    format!("lid_{seq}")
-                } else {
-                    slug
-                }
-            }
-            None => {
-                seq += 1;
-                format!("lid_{seq}")
-            }
-        };
-        out.push(Some(unique(base, &mut used)));
+        out.push(Some(fallback_lid_for_url(
+            anchor.as_deref(),
+            &mut used,
+            &mut seq,
+        )));
     }
     out
 }
@@ -548,14 +574,39 @@ mod tests {
     }
 
     #[test]
-    fn lid_without_remote_match_surfaces_error() {
+    fn lid_without_remote_match_falls_back_to_slug() {
         let template = r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#;
         let remote = r#"<p>no anchor</p>"#;
         let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.body.contains("'cta'"), "got: {}", p.body);
         assert!(p
-            .errors
+            .warnings
             .iter()
-            .any(|e| matches!(e, ResolutionError::UnresolvedLid { .. })));
+            .any(|w| w.contains("not found in remote body")));
+    }
+
+    #[test]
+    fn template_with_more_lids_than_remote_resolves_extras_via_fallback() {
+        let template = r#"<a href="https://x.com/a">{{x | lid: '__BRAZESYNC__'}}</a>
+<a href="https://x.com/b">{{x | lid: '__BRAZESYNC__'}}</a>
+<a href="https://x.com/c">{{x | lid: '__BRAZESYNC__'}}</a>"#;
+        let remote = r#"<a href="https://x.com/a">{{x | lid: 'remoteval1a'}}</a>"#;
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.body.contains("'remoteval1a'"));
+        assert!(p.body.contains("'b'"), "got: {}", p.body);
+        assert!(p.body.contains("'c'"), "got: {}", p.body);
+    }
+
+    #[test]
+    fn subject_with_more_lids_than_remote_falls_back() {
+        let template = "{{x | lid: '__BRAZESYNC__'}} A {{y | lid: '__BRAZESYNC__'}}";
+        let remote = "{{x | lid: 'firstval123'}} A";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailSubject);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.body.contains("'firstval123'"));
+        assert!(p.body.contains("'lid_1'"), "got: {}", p.body);
     }
 
     #[test]

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -194,7 +194,14 @@ fn resolve_lid_batch(
     }
 
     let mut out = Vec::with_capacity(lid_indices.len());
+    // Seed `used` with every remote lid value so a fallback slug can
+    // never duplicate a value that is already in the POSTed body. Braze
+    // treats `lid` as a per-link identifier; duplicates corrupt link
+    // analytics.
     let mut used: BTreeMap<String, usize> = BTreeMap::new();
+    for p in &remote_pairs {
+        used.entry(p.value.clone()).or_insert(1);
+    }
     let mut seq = 0usize;
     for anchor in anchors {
         let Some(url) = anchor else {
@@ -273,8 +280,13 @@ fn resolve_lid_positional(
     }
     let _ = placeholders;
     let mut out = Vec::with_capacity(lid_indices.len());
-    let mut iter = remote_values.into_iter();
+    // Seed `used` with every remote positional value so fallback
+    // slugs (`lid_1`, …) can never collide with a real remote value.
     let mut used: BTreeMap<String, usize> = BTreeMap::new();
+    for v in &remote_values {
+        used.entry(v.clone()).or_insert(1);
+    }
+    let mut iter = remote_values.into_iter();
     let mut seq = 0usize;
     for _ in lid_indices {
         match iter.next() {
@@ -667,6 +679,21 @@ mod tests {
             "plaintext URL slug must be used, got: {}",
             p.body
         );
+    }
+
+    #[test]
+    fn url_fallback_disambiguates_against_remote_slug_collision() {
+        // The /checkout URL's natural slug 'checkout' also happens to
+        // appear as a remote lid value (for an unrelated /a anchor).
+        // The seeded `used` map must force the fallback to 'checkout_2'.
+        let template = r#"<a href="https://x.com/a">{{x | lid: '__BRAZESYNC__'}}</a>
+<a href="https://x.com/checkout">{{x | lid: '__BRAZESYNC__'}}</a>"#;
+        let remote = r#"<a href="https://x.com/a">{{x | lid: 'checkout'}}</a>"#;
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        let count = p.body.matches("'checkout'").count();
+        assert_eq!(count, 1, "remote lid must appear exactly once, got: {}", p.body);
+        assert!(p.body.contains("'checkout_2'"), "got: {}", p.body);
     }
 
     #[test]

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -731,7 +731,11 @@ mod tests {
         let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
         assert!(p.errors.is_empty(), "{:?}", p.errors);
         let count = p.body.matches("'checkout'").count();
-        assert_eq!(count, 1, "remote lid must appear exactly once, got: {}", p.body);
+        assert_eq!(
+            count, 1,
+            "remote lid must appear exactly once, got: {}",
+            p.body
+        );
         assert!(p.body.contains("'checkout_2'"), "got: {}", p.body);
     }
 

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -1,9 +1,22 @@
 //! Wiring layer between [`crate::values`] and the diff / apply pipeline.
 
 use crate::resource::{ContentBlock, EmailTemplate};
-use crate::values::braze_managed::prepare_field;
+use crate::values::braze_managed::{prepare_field, LidFallback};
 use crate::values::placeholder::ResolutionError;
 use crate::values::templatize::FieldKind;
+
+/// Drift-fallback summary for one resource (and field, for
+/// email_template). Aggregated across the run and surfaced as a
+/// "Notice" block after the diff / apply output so the operator can
+/// see which links the local template introduced that the remote
+/// body didn't carry.
+#[derive(Debug, Clone)]
+pub struct FallbackReport {
+    pub resource_kind: &'static str,
+    pub resource_name: String,
+    pub field: Option<&'static str>,
+    pub fallbacks: Vec<LidFallback>,
+}
 
 /// One resource's worth of placeholder failures, ready to be folded
 /// into a top-level error message.
@@ -24,9 +37,9 @@ pub struct ResolutionFailure {
 pub fn resolve_content_block_with_remote(
     cb: &mut ContentBlock,
     remote: Option<&ContentBlock>,
-) -> std::result::Result<(), ResolutionFailure> {
+) -> std::result::Result<Vec<FallbackReport>, ResolutionFailure> {
     if !needs_resolve(&cb.content) {
-        return Ok(());
+        return Ok(Vec::new());
     }
     let prep = prepare_field(
         &cb.content,
@@ -43,15 +56,26 @@ pub fn resolve_content_block_with_remote(
         });
     }
     cb.content = prep.body;
-    Ok(())
+    let reports = if prep.fallbacks.is_empty() {
+        Vec::new()
+    } else {
+        vec![FallbackReport {
+            resource_kind: "content_block",
+            resource_name: cb.name.clone(),
+            field: None,
+            fallbacks: prep.fallbacks,
+        }]
+    };
+    Ok(reports)
 }
 
 /// Resolve placeholders across every Liquid-bearing field of `et`.
 pub fn resolve_email_template_with_remote(
     et: &mut EmailTemplate,
     remote: Option<&EmailTemplate>,
-) -> std::result::Result<(), Vec<ResolutionFailure>> {
+) -> std::result::Result<Vec<FallbackReport>, Vec<ResolutionFailure>> {
     let mut failures: Vec<ResolutionFailure> = Vec::new();
+    let mut reports: Vec<FallbackReport> = Vec::new();
 
     macro_rules! resolve_field {
         ($field_name:expr, $field_kind:expr, $accessor:expr, $remote_accessor:expr) => {{
@@ -73,6 +97,14 @@ pub fn resolve_email_template_with_remote(
                     });
                     None
                 } else {
+                    if !prep.fallbacks.is_empty() {
+                        reports.push(FallbackReport {
+                            resource_kind: "email_template",
+                            resource_name: et.name.clone(),
+                            field: Some($field_name),
+                            fallbacks: prep.fallbacks,
+                        });
+                    }
                     Some(prep.body)
                 }
             } else {
@@ -125,7 +157,39 @@ pub fn resolve_email_template_with_remote(
     if let Some(v) = new_preheader {
         et.preheader = Some(v);
     }
-    Ok(())
+    Ok(reports)
+}
+
+/// Human-readable summary block for collected drift fallbacks.
+/// Empty input → empty string (so callers can append unconditionally).
+pub fn format_fallback_reports(reports: &[FallbackReport]) -> String {
+    if reports.is_empty() {
+        return String::new();
+    }
+    let total: usize = reports.iter().map(|r| r.fallbacks.len()).sum();
+    let mut out = String::new();
+    out.push_str(&format!(
+        "\nNotice: {total} link(s) resolved with fallback lid values \
+         (Braze will assign the final lid on first dashboard save):\n"
+    ));
+    for r in reports {
+        let scope = match r.field {
+            Some(f) => format!("  {} '{}' ({})", r.resource_kind, r.resource_name, f),
+            None => format!("  {} '{}'", r.resource_kind, r.resource_name),
+        };
+        out.push_str(&scope);
+        out.push('\n');
+        for fb in &r.fallbacks {
+            match &fb.anchor {
+                Some(url) => out.push_str(&format!("    - {url} → '{}'\n", fb.value)),
+                None => out.push_str(&format!(
+                    "    - (no URL anchor — positional) → '{}'\n",
+                    fb.value
+                )),
+            }
+        }
+    }
+    out
 }
 
 /// Cheap pre-filter: a body needs resolution if it carries the strict

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -282,18 +282,14 @@ mod tests {
     }
 
     #[test]
-    fn missing_remote_anchor_surfaces_as_failure() {
+    fn missing_remote_anchor_falls_back_to_slug() {
         let mut block = cb(
             "promo",
             r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#,
         );
         let remote = cb("promo", "<p>no anchor here</p>");
-        let err = resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap_err();
-        assert_eq!(err.errors.len(), 1);
-        assert!(matches!(
-            err.errors[0],
-            ResolutionError::UnresolvedLid { .. }
-        ));
+        resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
+        assert!(block.content.contains("'cta'"), "got: {}", block.content);
     }
 
     #[test]

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -361,7 +361,10 @@ mod tests {
         assert!(block.content.contains("'cta'"), "got: {}", block.content);
         assert_eq!(reports.len(), 1);
         assert_eq!(reports[0].fallbacks.len(), 1);
-        assert_eq!(reports[0].fallbacks[0].anchor.as_deref(), Some("https://x.com/cta"));
+        assert_eq!(
+            reports[0].fallbacks[0].anchor.as_deref(),
+            Some("https://x.com/cta")
+        );
         assert_eq!(reports[0].fallbacks[0].value, "cta");
     }
 

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -296,8 +296,9 @@ mod tests {
     #[test]
     fn no_placeholders_skips_resolution() {
         let mut block = cb("plain", "<p>hi there</p>");
-        resolve_content_block_with_remote(&mut block, None).unwrap();
+        let reports = resolve_content_block_with_remote(&mut block, None).unwrap();
         assert_eq!(block.content, "<p>hi there</p>");
+        assert!(reports.is_empty());
     }
 
     #[test]
@@ -310,8 +311,9 @@ mod tests {
             "promo",
             r#"<a href="https://x.com/cta">{{x | lid: 'newlidvalue1'}}</a>"#,
         );
-        resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
+        let reports = resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
         assert!(block.content.contains("'newlidvalue1'"));
+        assert!(reports.is_empty());
     }
 
     #[test]
@@ -320,19 +322,21 @@ mod tests {
             "promo",
             r#"<a href="https://x.com/spring-sale">{{x | lid: '__BRAZESYNC__'}}</a>"#,
         );
-        resolve_content_block_with_remote(&mut block, None).unwrap();
+        let reports = resolve_content_block_with_remote(&mut block, None).unwrap();
         assert!(
             block.content.contains("'spring_sale'"),
             "got: {}",
             block.content
         );
+        assert!(reports.is_empty());
     }
 
     #[test]
     fn new_resource_cb_id_filter_is_stripped() {
         let mut block = cb("page", "{{content_blocks.${promo} | id: '__BRAZESYNC__'}}");
-        resolve_content_block_with_remote(&mut block, None).unwrap();
+        let reports = resolve_content_block_with_remote(&mut block, None).unwrap();
         assert_eq!(block.content, "{{content_blocks.${promo}}}");
+        assert!(reports.is_empty());
     }
 
     #[test]
@@ -341,8 +345,9 @@ mod tests {
         t.body_html = r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#.into();
         let mut remote = et("welcome");
         remote.body_html = r#"<a href="https://x.com/cta">{{x | lid: 'newhtmllidx'}}</a>"#.into();
-        resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap();
+        let reports = resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap();
         assert!(t.body_html.contains("'newhtmllidx'"));
+        assert!(reports.is_empty());
     }
 
     #[test]
@@ -352,8 +357,12 @@ mod tests {
             r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#,
         );
         let remote = cb("promo", "<p>no anchor here</p>");
-        resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
+        let reports = resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
         assert!(block.content.contains("'cta'"), "got: {}", block.content);
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].fallbacks.len(), 1);
+        assert_eq!(reports[0].fallbacks[0].anchor.as_deref(), Some("https://x.com/cta"));
+        assert_eq!(reports[0].fallbacks[0].value, "cta");
     }
 
     #[test]
@@ -362,8 +371,9 @@ mod tests {
         t.subject = "Spring sale {{x | lid: '__BRAZESYNC__'}}".into();
         let mut remote = et("promo");
         remote.subject = "Spring sale {{x | lid: 'subjectlid1'}}".into();
-        resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap();
+        let reports = resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap();
         assert!(t.subject.contains("'subjectlid1'"));
+        assert!(reports.is_empty());
     }
 
     #[test]

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -9,14 +9,14 @@ pub mod integration;
 pub mod placeholder;
 pub mod templatize;
 
-pub use braze_managed::{prepare_field, PreparedTemplate};
+pub use braze_managed::{prepare_field, LidFallback, PreparedTemplate};
 pub use correlation::{
     extract_cb_id_values, extract_html_lid_values, extract_plaintext_lid_values, normalize_url,
     slug_for_cb_id, slug_for_lid, CbIdCorrelation, LidCorrelation,
 };
 pub use integration::{
-    format_failures, resolve_content_block_with_remote, resolve_email_template_with_remote,
-    ResolutionFailure,
+    format_failures, format_fallback_reports, resolve_content_block_with_remote,
+    resolve_email_template_with_remote, FallbackReport, ResolutionFailure,
 };
 pub use placeholder::{
     extract_placeholders, find_suspicious_placeholders, has_placeholders, Placeholder,

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -20,7 +20,7 @@ use common::{
     write_local_email_template, write_local_schema,
 };
 use serde_json::json;
-use wiremock::matchers::{body_json, method, path, query_param};
+use wiremock::matchers::{body_json, body_partial_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1618,14 +1618,13 @@ async fn content_block_apply_resolves_lid_via_new_resource_fallback() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn content_block_apply_aborts_when_placeholder_unresolved() {
-    // v0.15: lid resolution aborts when the remote exists but does
-    // not contain a matching URL anchor (structural drift between
-    // local template and remote). The list call IS made (it's the
-    // existence probe), but no /info follows for a name that's not
-    // present, and no /create follows because the existing remote
-    // means we go through diff/update path — the diff finds no
-    // matching URL in remote and aborts.
+async fn content_block_apply_falls_back_when_remote_has_fewer_links() {
+    // When the local template has more lid placeholders than the
+    // remote body has lid values, the extra placeholders resolve to
+    // a URL-slug fallback instead of aborting. The diff therefore
+    // surfaces a content drift and apply POSTs an update so the
+    // remote gains the missing links (Braze reassigns lid values on
+    // first dashboard save).
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/content_blocks/list"))
@@ -1644,6 +1643,17 @@ async fn content_block_apply_aborts_when_placeholder_unresolved() {
         .mount(&server)
         .await;
     Mock::given(method("POST"))
+        .and(path("/content_blocks/update"))
+        .and(body_partial_json(json!({
+            "content_block_id": "id-promo",
+            "content": "<a href=\"https://example.com/cta\">{{x | lid: 'cta'}}</a>"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/create"))
         .respond_with(ResponseTemplate::new(500))
         .expect(0)
         .mount(&server)
@@ -1658,20 +1668,13 @@ async fn content_block_apply_aborts_when_placeholder_unresolved() {
     );
 
     tokio::task::spawn_blocking(move || {
-        let assert = Command::cargo_bin("braze-sync")
+        Command::cargo_bin("braze-sync")
             .unwrap()
             .env("BRAZE_API_KEY", "test-key")
             .args(["--config", config_path.to_str().unwrap()])
             .args(["apply", "--resource", "content_block", "--confirm"])
             .assert()
-            .failure();
-        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
-        assert!(
-            stderr.contains("UnresolvedLid")
-                || stderr.contains("__BRAZESYNC__")
-                || stderr.contains("anchor"),
-            "expected resolution error mentioning the unresolved lid, got:\n{stderr}"
-        );
+            .success();
     })
     .await
     .unwrap();

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1696,6 +1696,58 @@ async fn content_block_apply_falls_back_when_remote_has_fewer_links() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn content_block_apply_aborts_on_anchor_less_lid_with_remote() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-promo", "name": "promo"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo",
+            "content": "<p>existing remote body</p>",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = common::write_config(tmp.path(), &server.uri());
+    common::write_local_content_block(
+        tmp.path(),
+        "promo",
+        "no link tag here {{x | lid: '__BRAZESYNC__'}} just text",
+    );
+
+    tokio::task::spawn_blocking(move || {
+        let assert = Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "content_block", "--confirm"])
+            .assert()
+            .failure()
+            .code(3);
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        assert!(
+            stderr.contains("placeholder resolution failure"),
+            "expected resolution failure message in stderr, got:\n{stderr}"
+        );
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn content_block_apply_works_without_values_file_when_no_placeholders() {
     // Backwards compat: existing users without placeholders must keep
     // working with no values file present.

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1668,13 +1668,28 @@ async fn content_block_apply_falls_back_when_remote_has_fewer_links() {
     );
 
     tokio::task::spawn_blocking(move || {
-        Command::cargo_bin("braze-sync")
+        let assert = Command::cargo_bin("braze-sync")
             .unwrap()
             .env("BRAZE_API_KEY", "test-key")
             .args(["--config", config_path.to_str().unwrap()])
             .args(["apply", "--resource", "content_block", "--confirm"])
             .assert()
             .success();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+        // The operator-facing Notice block must summarize the fallback
+        // so blind `apply --confirm` runs surface the structural drift.
+        assert!(
+            stderr.contains("Notice: 1 link(s) resolved with fallback lid"),
+            "expected fallback Notice in stderr, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("content_block 'promo'"),
+            "expected resource scope in Notice, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("https://example.com/cta") && stderr.contains("'cta'"),
+            "expected URL→fallback mapping in Notice, got:\n{stderr}"
+        );
     })
     .await
     .unwrap();


### PR DESCRIPTION
## Summary

Fixes #52 + two follow-on improvements identified during deep review.

### Core change (commit 1)
- When the local template carries more `lid` placeholders than the remote body has `lid` values, the unmatched placeholders now resolve via the URL-slug fallback (same logic as the new-resource path) instead of aborting with `UnresolvedLid`. `diff` surfaces a meaningful structural drift; `apply` POSTs the full template so Braze gains the missing links and reassigns the `lid` value on first dashboard save.
- Same fallback applies to the subject/preheader positional resolver when the remote yields fewer `lid` values than the template.
- `ResolutionError::UnresolvedLid` is retained for the remaining failure mode: a `lid` placeholder with no URL anchor at all.

### Follow-on 1: collision-safe fallback (commit 2)
- Without this, a fallback URL-slug could equal a `lid` value already resolved from elsewhere in the remote body (e.g. remote assigns `'checkout'` to `/a`, template's `/checkout` placeholder slugs to `'checkout'` → POSTed body carries the same lid string twice, corrupting Braze per-link analytics).
- Fix: seed the `used` map with every remote `lid` value before generating any fallback. Duplicates get the standard `_2`, `_3`, … disambiguation.

### Follow-on 2: visible fallback summary (commit 3)
- Promote drift-fallback usage from a stderr warning line to a structured per-resource Notice block printed after the diff/apply plan, scoped by resource (and field for `email_template`) with the URL→fallback-value mapping.
- Lets an operator running blind `apply --confirm` see which links the local template introduced that the remote didn't carry, without scanning interleaved warning lines.
- Brand-new-resource fallbacks are intentionally not listed (they're the expected path).

### Design rationale (no `--strict` flag)
Considered adding a `--strict` / `--allow-new-links` opt-in. Decided against it:
- The new-resource path already pushes the full structure via fallback with no flag. Requiring a flag for the *partial-sync* sub-case is incoherent.
- Splitting `diff` (fallback) vs `apply` (strict) breaks the `diff = apply preview` invariant that every GitOps tool needs.
- Real safety = `diff` visibility. Typos/stray-link drift surface in the diff regardless of fallback policy. A flag adds friction without adding safety. The Notice block (follow-on 2) makes fallback usage explicit so it can't slip past review.

## Test plan

- [x] `cargo test` — all suites pass (lib + 5 cli integration suites)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Unit tests: URL-anchor fallback, subject/preheader positional fallback, single-placeholder URL miss
- [x] Collision regression test: `url_fallback_disambiguates_against_remote_slug_collision`
- [x] Integration test: apply path POSTs `/update` with fallback `lid` AND stderr carries the Notice block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v0.16.1

* **Bug Fixes**
  * Link identifier resolution is now more robust: when local templates have more identifiers than remote configurations provide, synchronization gracefully falls back to URL path-derived values instead of aborting. Automatic collision prevention ensures fallback values don't duplicate existing identifiers.

* **Improvements**
  * Added notices in diff/apply output clearly showing which link identifiers were assigned as fallbacks and how they were resolved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->