### PR TITLE
fix: accept digit-leading lid values in regexes

### DIFF
--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -11,9 +11,7 @@
 use regex_lite::Regex;
 use std::sync::OnceLock;
 
-/// Character pattern for a raw lid value (e.g. `ai8kexrxcp03`, `275ua26snuk7`).
-/// Shared between `lid_value_re()` here and `templatize::lid_match_re()` so the
-/// two regexes cannot drift.
+/// Shared pattern for raw lid values so templatize and correlation cannot drift.
 pub(crate) const LID_VALUE_PATTERN: &str = "[a-z0-9][a-z0-9_]*";
 
 /// Normalize a URL for anchor comparison: keep `scheme://host/path`,

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -437,8 +437,7 @@ mod tests {
 
     #[test]
     fn html_lid_pairs_digit_leading_value() {
-        let body =
-            r#"<a href="https://example.com/sale">{{ x | lid: '47043wg2o5wi' }}Buy</a>"#;
+        let body = r#"<a href="https://example.com/sale">{{ x | lid: '47043wg2o5wi' }}Buy</a>"#;
         let pairs = extract_html_lid_values(body);
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].value, "47043wg2o5wi");

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -11,6 +11,11 @@
 use regex_lite::Regex;
 use std::sync::OnceLock;
 
+/// Character pattern for a raw lid value (e.g. `ai8kexrxcp03`, `275ua26snuk7`).
+/// Shared between `lid_value_re()` here and `templatize::lid_match_re()` so the
+/// two regexes cannot drift.
+pub(crate) const LID_VALUE_PATTERN: &str = "[a-z0-9][a-z0-9_]*";
+
 /// Normalize a URL for anchor comparison: keep `scheme://host/path`,
 /// drop `?query` and `#fragment`.
 ///
@@ -42,9 +47,11 @@ fn href_re() -> &'static Regex {
 fn lid_value_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        // Must stay in sync with templatize::lid_match_re().
-        Regex::new(r#"\|\s*lid:\s*(?:"([a-z0-9][a-z0-9_]*)"|'([a-z0-9][a-z0-9_]*)')"#)
-            .expect("lid value regex is valid")
+        Regex::new(&format!(
+            r#"\|\s*lid:\s*(?:"({p})"|'({p})')"#,
+            p = LID_VALUE_PATTERN
+        ))
+        .expect("lid value regex is valid")
     })
 }
 
@@ -416,6 +423,12 @@ mod tests {
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].value, "cta");
         assert_eq!(pairs[0].url, "https://example.com/promo");
+    }
+
+    #[test]
+    fn lid_value_ignores_brazesync_placeholder() {
+        let vals = extract_lid_values_unanchored("{{ x | lid: '__BRAZESYNC__' }}");
+        assert!(vals.is_empty());
     }
 
     #[test]

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -43,7 +43,7 @@ fn lid_value_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         // Must stay in sync with templatize::lid_match_re().
-        Regex::new(r#"\|\s*lid:\s*(?:"([a-z][a-z0-9_]*)"|'([a-z][a-z0-9_]*)')"#)
+        Regex::new(r#"\|\s*lid:\s*(?:"([a-z0-9][a-z0-9_]*)"|'([a-z0-9][a-z0-9_]*)')"#)
             .expect("lid value regex is valid")
     })
 }
@@ -416,5 +416,20 @@ mod tests {
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].value, "cta");
         assert_eq!(pairs[0].url, "https://example.com/promo");
+    }
+
+    #[test]
+    fn lid_value_extracts_digit_leading_value() {
+        let vals = extract_lid_values_unanchored("{{ x | lid: '275ua26snuk7' }}");
+        assert_eq!(vals, vec!["275ua26snuk7"]);
+    }
+
+    #[test]
+    fn html_lid_pairs_digit_leading_value() {
+        let body =
+            r#"<a href="https://example.com/sale">{{ x | lid: '47043wg2o5wi' }}Buy</a>"#;
+        let pairs = extract_html_lid_values(body);
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].value, "47043wg2o5wi");
     }
 }

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -9,6 +9,7 @@
 //! are NOT persisted — they are re-fetched from the remote body at
 //! apply/diff time (see [`crate::values::braze_managed`]).
 
+use crate::values::correlation::LID_VALUE_PATTERN;
 use regex_lite::Regex;
 use std::sync::OnceLock;
 
@@ -47,7 +48,7 @@ pub struct TemplatizedField {
 
 /// Rewrite every raw `| lid: 'X'` and `{{content_blocks.${NAME} | id: 'cbN'}}`
 /// to the anonymous `__BRAZESYNC__` token. Idempotent: the detection
-/// regexes require raw literals (`[a-z0-9][a-z0-9_]*` for lid, `cb[0-9]+` for
+/// regexes require raw literals ([`LID_VALUE_PATTERN`] for lid, `cb[0-9]+` for
 /// cb_id), so an already-templated `__BRAZESYNC__` never re-matches.
 pub fn templatize_body(body: &str, field: FieldKind) -> TemplatizedField {
     let mut spans: Vec<DetectionSpan> = Vec::new();
@@ -104,9 +105,11 @@ struct DetectionSpan {
 fn lid_match_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        // Must stay in sync with correlation::lid_value_re().
-        Regex::new(r#"\|\s*lid:\s*(?:"[a-z0-9][a-z0-9_]*"|'[a-z0-9][a-z0-9_]*')"#)
-            .expect("lid match regex is valid")
+        Regex::new(&format!(
+            r#"\|\s*lid:\s*(?:"{p}"|'{p}')"#,
+            p = LID_VALUE_PATTERN
+        ))
+        .expect("lid match regex is valid")
     })
 }
 
@@ -127,6 +130,14 @@ mod tests {
     #[test]
     fn idempotent_on_already_templatized_body() {
         let body = "<p>__BRAZESYNC__ kept verbatim</p>";
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.new_body, body);
+        assert_eq!(r.lid_rewrites, 0);
+    }
+
+    #[test]
+    fn idempotent_on_templatized_lid_filter() {
+        let body = r#"<a href="https://example.com">{{x | lid: '__BRAZESYNC__'}}</a>"#;
         let r = templatize_body(body, FieldKind::ContentBlock);
         assert_eq!(r.new_body, body);
         assert_eq!(r.lid_rewrites, 0);

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -47,7 +47,7 @@ pub struct TemplatizedField {
 
 /// Rewrite every raw `| lid: 'X'` and `{{content_blocks.${NAME} | id: 'cbN'}}`
 /// to the anonymous `__BRAZESYNC__` token. Idempotent: the detection
-/// regexes require raw literals (`[a-z][a-z0-9_]*` for lid, `cb[0-9]+` for
+/// regexes require raw literals (`[a-z0-9][a-z0-9_]*` for lid, `cb[0-9]+` for
 /// cb_id), so an already-templated `__BRAZESYNC__` never re-matches.
 pub fn templatize_body(body: &str, field: FieldKind) -> TemplatizedField {
     let mut spans: Vec<DetectionSpan> = Vec::new();
@@ -105,7 +105,7 @@ fn lid_match_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         // Must stay in sync with correlation::lid_value_re().
-        Regex::new(r#"\|\s*lid:\s*(?:"[a-z][a-z0-9_]*"|'[a-z][a-z0-9_]*')"#)
+        Regex::new(r#"\|\s*lid:\s*(?:"[a-z0-9][a-z0-9_]*"|'[a-z0-9][a-z0-9_]*')"#)
             .expect("lid match regex is valid")
     })
 }
@@ -208,5 +208,18 @@ mod tests {
         let r = templatize_body(body, FieldKind::EmailSubject);
         let n = r.new_body.matches("| lid: '__BRAZESYNC__'").count();
         assert_eq!(n, 2, "got: {}", r.new_body);
+    }
+
+    #[test]
+    fn rewrites_digit_leading_lid() {
+        let body =
+            r#"<a href="https://example.com/sale">{{x | lid: '275ua26snuk7'}}</a>"#;
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert!(
+            r.new_body.contains("| lid: '__BRAZESYNC__'"),
+            "got: {}",
+            r.new_body
+        );
+        assert_eq!(r.lid_rewrites, 1);
     }
 }

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -223,8 +223,7 @@ mod tests {
 
     #[test]
     fn rewrites_digit_leading_lid() {
-        let body =
-            r#"<a href="https://example.com/sale">{{x | lid: '275ua26snuk7'}}</a>"#;
+        let body = r#"<a href="https://example.com/sale">{{x | lid: '275ua26snuk7'}}</a>"#;
         let r = templatize_body(body, FieldKind::ContentBlock);
         assert!(
             r.new_body.contains("| lid: '__BRAZESYNC__'"),


### PR DESCRIPTION
## Summary

- Fix `lid_match_re()` and `lid_value_re()` to accept digit-leading lid values (e.g. `275ua26snuk7`, `47043wg2o5wi`) by changing `[a-z]` → `[a-z0-9]` as the first character class
- `__BRAZESYNC__` placeholder (uppercase + leading underscore) remains excluded, preserving idempotency
- Add regression tests for digit-leading lid values in both templatize and correlation modules

Fixes #56

## Test plan

- [x] All 504 existing tests pass
- [x] New test `rewrites_digit_leading_lid` verifies templatize handles `275ua26snuk7`
- [x] New test `lid_value_extracts_digit_leading_value` verifies correlation extraction
- [x] New test `html_lid_pairs_digit_leading_value` verifies HTML anchor pairing with `47043wg2o5wi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated lid value pattern definitions across the codebase to ensure consistent handling and prevent pattern drift between modules.

* **Tests**
  * Expanded test coverage to verify lid extraction correctly handles special placeholder values while maintaining idempotence.
  * Added tests confirming lid values starting with digits are properly accepted and extracted in HTML anchor scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->