### PR TITLE
chore: release v0.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to v0.16.3
- Includes fix from #57: accept digit-leading lid values in templatize/correlation regexes

## Changelog

- **fix:** lid regex now accepts digit-leading values (e.g. `275ua26snuk7`) that were silently skipped since v0.16.2 (#57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)