### PR TITLE
fix: templatize new resources without local template on export

### DIFF
--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -218,12 +218,9 @@ async fn export_content_blocks(
             None
         };
         let mut to_save = remote.clone();
-        let should_templatize = local
-            .as_ref()
-            .is_none_or(|l| has_placeholders(&l.content));
+        let should_templatize = local.as_ref().is_none_or(|l| has_placeholders(&l.content));
         if should_templatize {
-            to_save.content =
-                templatize_body(&remote.content, FieldKind::ContentBlock).new_body;
+            to_save.content = templatize_body(&remote.content, FieldKind::ContentBlock).new_body;
         }
         content_block_io::save_content_block(content_blocks_root, &to_save)?;
     }
@@ -277,9 +274,7 @@ async fn export_email_templates(
             None
         };
         let mut to_save = remote.clone();
-        let subject_templ = local
-            .as_ref()
-            .is_none_or(|l| has_placeholders(&l.subject));
+        let subject_templ = local.as_ref().is_none_or(|l| has_placeholders(&l.subject));
         let body_html_templ = local
             .as_ref()
             .is_none_or(|l| has_placeholders(&l.body_html));
@@ -290,8 +285,7 @@ async fn export_email_templates(
             .as_ref()
             .is_none_or(|l| l.preheader.as_deref().is_none_or(has_placeholders));
         if subject_templ {
-            to_save.subject =
-                templatize_body(&remote.subject, FieldKind::EmailSubject).new_body;
+            to_save.subject = templatize_body(&remote.subject, FieldKind::EmailSubject).new_body;
         }
         if body_html_templ {
             to_save.body_html =

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -166,11 +166,14 @@ async fn export_catalog_schemas(
 /// `--name`, the list still happens (to translate name → id) but only
 /// the matching block's body is fetched.
 ///
-/// When a local template with `__BRAZESYNC__` placeholders exists for
-/// a given name, the remote body is reverse-templatized (raw lid /
-/// cb_id values rewritten back to `__BRAZESYNC__`) before being
-/// written to disk, so Dashboard HTML edits are captured while
-/// runtime-volatile lid / cb_id values do not produce spurious drift.
+/// Remote bodies are reverse-templatized (raw lid / cb_id values
+/// rewritten back to `__BRAZESYNC__`) before being written to disk,
+/// so Dashboard HTML edits are captured while runtime-volatile lid /
+/// cb_id values do not produce spurious drift. This applies to both
+/// new resources (no local file yet) and existing ones whose local
+/// template already contains placeholders. The only case where
+/// templatization is skipped is when a local file exists but
+/// deliberately contains no placeholders.
 /// v0.15: no values-file writeback — lid / cb_id are resolved from
 /// the remote body at apply/diff time.
 async fn export_content_blocks(
@@ -215,11 +218,12 @@ async fn export_content_blocks(
             None
         };
         let mut to_save = remote.clone();
-        if let Some(local) = local.as_ref() {
-            if has_placeholders(&local.content) {
-                to_save.content =
-                    templatize_body(&remote.content, FieldKind::ContentBlock).new_body;
-            }
+        let should_templatize = local
+            .as_ref()
+            .is_none_or(|l| has_placeholders(&l.content));
+        if should_templatize {
+            to_save.content =
+                templatize_body(&remote.content, FieldKind::ContentBlock).new_body;
         }
         content_block_io::save_content_block(content_blocks_root, &to_save)?;
     }
@@ -228,10 +232,8 @@ async fn export_content_blocks(
 
 /// Same list-then-fetch pattern as content blocks. Per-field reverse-
 /// templatize: each of `subject`, `body_html`, `body_plaintext`,
-/// `preheader` is independently checked for `__BRAZESYNC__` content
-/// in the local template and, when present, the remote field is
-/// rewritten back to placeholder form before saving, so Dashboard
-/// edits are captured without lid / cb_id rotation producing drift.
+/// `preheader` is templatized for new resources (no local dir) or
+/// when the corresponding local field already contains placeholders.
 async fn export_email_templates(
     client: &BrazeClient,
     email_templates_root: &Path,
@@ -274,29 +276,41 @@ async fn export_email_templates(
             None
         };
         let mut to_save = remote.clone();
-        if let Some(local) = local.as_ref() {
-            let subject_has = has_placeholders(&local.subject);
-            let body_html_has = has_placeholders(&local.body_html);
-            let body_plain_has = has_placeholders(&local.body_plaintext);
-            let preheader_has = local.preheader.as_deref().is_some_and(has_placeholders);
-            if subject_has {
-                to_save.subject =
-                    templatize_body(&remote.subject, FieldKind::EmailSubject).new_body;
-            }
-            if body_html_has {
-                to_save.body_html =
-                    templatize_body(&remote.body_html, FieldKind::EmailHtmlBody).new_body;
-            }
-            if body_plain_has {
-                to_save.body_plaintext =
-                    templatize_body(&remote.body_plaintext, FieldKind::EmailPlainBody).new_body;
-            }
-            if preheader_has {
-                to_save.preheader = remote
-                    .preheader
-                    .as_deref()
-                    .map(|p| templatize_body(p, FieldKind::EmailPreheader).new_body);
-            }
+        let no_local = local.is_none();
+        let subject_templ = no_local
+            || local
+                .as_ref()
+                .is_some_and(|l| has_placeholders(&l.subject));
+        let body_html_templ = no_local
+            || local
+                .as_ref()
+                .is_some_and(|l| has_placeholders(&l.body_html));
+        let body_plain_templ = no_local
+            || local
+                .as_ref()
+                .is_some_and(|l| has_placeholders(&l.body_plaintext));
+        let preheader_templ = no_local
+            || local
+                .as_ref()
+                .and_then(|l| l.preheader.as_deref())
+                .is_some_and(has_placeholders);
+        if subject_templ {
+            to_save.subject =
+                templatize_body(&remote.subject, FieldKind::EmailSubject).new_body;
+        }
+        if body_html_templ {
+            to_save.body_html =
+                templatize_body(&remote.body_html, FieldKind::EmailHtmlBody).new_body;
+        }
+        if body_plain_templ {
+            to_save.body_plaintext =
+                templatize_body(&remote.body_plaintext, FieldKind::EmailPlainBody).new_body;
+        }
+        if preheader_templ {
+            to_save.preheader = remote
+                .preheader
+                .as_deref()
+                .map(|p| templatize_body(p, FieldKind::EmailPreheader).new_body);
         }
         email_template_io::save_email_template(email_templates_root, &to_save)?;
     }

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -232,8 +232,9 @@ async fn export_content_blocks(
 
 /// Same list-then-fetch pattern as content blocks. Per-field reverse-
 /// templatize: each of `subject`, `body_html`, `body_plaintext`,
-/// `preheader` is templatized for new resources (no local dir) or
-/// when the corresponding local field already contains placeholders.
+/// `preheader` is templatized for new resources (no local dir), when
+/// the corresponding local field already contains placeholders, or
+/// when the local field is absent (preheader not yet saved locally).
 async fn export_email_templates(
     client: &BrazeClient,
     email_templates_root: &Path,
@@ -276,24 +277,18 @@ async fn export_email_templates(
             None
         };
         let mut to_save = remote.clone();
-        let no_local = local.is_none();
-        let subject_templ = no_local
-            || local
-                .as_ref()
-                .is_some_and(|l| has_placeholders(&l.subject));
-        let body_html_templ = no_local
-            || local
-                .as_ref()
-                .is_some_and(|l| has_placeholders(&l.body_html));
-        let body_plain_templ = no_local
-            || local
-                .as_ref()
-                .is_some_and(|l| has_placeholders(&l.body_plaintext));
-        let preheader_templ = no_local
-            || local
-                .as_ref()
-                .and_then(|l| l.preheader.as_deref())
-                .is_some_and(has_placeholders);
+        let subject_templ = local
+            .as_ref()
+            .is_none_or(|l| has_placeholders(&l.subject));
+        let body_html_templ = local
+            .as_ref()
+            .is_none_or(|l| has_placeholders(&l.body_html));
+        let body_plain_templ = local
+            .as_ref()
+            .is_none_or(|l| has_placeholders(&l.body_plaintext));
+        let preheader_templ = local
+            .as_ref()
+            .is_none_or(|l| l.preheader.as_deref().is_none_or(has_placeholders));
         if subject_templ {
             to_save.subject =
                 templatize_body(&remote.subject, FieldKind::EmailSubject).new_body;

--- a/tests/cli_export.rs
+++ b/tests/cli_export.rs
@@ -893,3 +893,64 @@ async fn export_existing_content_block_without_placeholders_skips_templatize() {
         "must not introduce placeholders when local file opts out, got:\n{saved}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn export_existing_email_template_without_placeholders_skips_templatize() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": [
+                {"email_template_id": "id-noplc-et", "template_name": "no_placeholder_et"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "template_name": "no_placeholder_et",
+            "subject": "Hello {{ x | lid: 'raw_subj' }}",
+            "body": "<a href=\"https://example.com\">{{ x | lid: 'raw_html' }}click</a>",
+            "plaintext_body": "{{ x | lid: 'raw_plain' }}",
+            "preheader": "{{ x | lid: 'raw_pre' }}",
+            "tags": [],
+            "message": "success"
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    common::write_local_email_template(
+        tmp.path(),
+        "no_placeholder_et",
+        "Hello",
+        "<a href=\"https://example.com\">{{ x | lid: 'old_html' }}click</a>",
+        "{{ x | lid: 'old_plain' }}",
+    );
+
+    let tmp_path = tmp.path().to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["export", "--resource", "email_template"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let et_dir = tmp_path.join("email_templates/no_placeholder_et");
+    let html = fs::read_to_string(et_dir.join("body.html")).unwrap();
+    assert!(
+        html.contains("raw_html"),
+        "existing email template without placeholders must keep raw values, got:\n{html}"
+    );
+    assert!(
+        !html.contains("__BRAZESYNC__"),
+        "must not introduce placeholders when local email template opts out, got:\n{html}"
+    );
+}

--- a/tests/cli_export.rs
+++ b/tests/cli_export.rs
@@ -726,3 +726,170 @@ content_block:
     let after = fs::read_to_string(tmp.path().join("values").join("test.yaml")).unwrap();
     assert_eq!(after, legacy, "export must not touch the values yaml");
 }
+
+// =====================================================================
+// Issue #59: new resources (no local file) must be templatized on export
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn export_new_content_block_templatizes_lid() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-new", "name": "new_block"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "new_block",
+            "content": "<a href=\"https://example.com\">{{ x | lid: 'abc123' }}click</a>",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    // No local file — this is a brand-new resource.
+
+    let tmp_path = tmp.path().to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["export", "--resource", "content_block"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let saved =
+        fs::read_to_string(tmp_path.join("content_blocks").join("new_block.liquid")).unwrap();
+    assert!(
+        saved.contains("__BRAZESYNC__"),
+        "new resource must be templatized, got:\n{saved}"
+    );
+    assert!(
+        !saved.contains("abc123"),
+        "raw lid value must not persist for new resources, got:\n{saved}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn export_new_email_template_templatizes_lid() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": [
+                {"email_template_id": "id-new-et", "template_name": "new_email"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "template_name": "new_email",
+            "subject": "Hello",
+            "body": "<a href=\"https://example.com\">{{ x | lid: 'xyz789' }}click</a>",
+            "plaintext_body": "click here",
+            "preheader": "News",
+            "tags": [],
+            "message": "success"
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    // No local email template directory — brand-new resource.
+
+    let tmp_path = tmp.path().to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["export", "--resource", "email_template"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let et_dir = tmp_path.join("email_templates/new_email");
+    let html = fs::read_to_string(et_dir.join("body.html")).unwrap();
+    assert!(
+        html.contains("__BRAZESYNC__"),
+        "new email template must be templatized, got:\n{html}"
+    );
+    assert!(
+        !html.contains("xyz789"),
+        "raw lid value must not persist for new email templates, got:\n{html}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn export_existing_content_block_without_placeholders_skips_templatize() {
+    // When a local file exists but deliberately has no placeholders,
+    // templatization must be skipped (opt-out).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-noplc", "name": "no_placeholder"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "no_placeholder",
+            "content": "<a href=\"https://example.com\">{{ x | lid: 'raw123' }}click</a>",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    common::write_local_content_block(
+        tmp.path(),
+        "no_placeholder",
+        "<a href=\"https://example.com\">{{ x | lid: 'old_raw' }}click</a>",
+    );
+
+    let tmp_path = tmp.path().to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["export", "--resource", "content_block"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let saved = fs::read_to_string(
+        tmp_path
+            .join("content_blocks")
+            .join("no_placeholder.liquid"),
+    )
+    .unwrap();
+    assert!(
+        saved.contains("raw123"),
+        "existing file without placeholders must keep raw values, got:\n{saved}"
+    );
+    assert!(
+        !saved.contains("__BRAZESYNC__"),
+        "must not introduce placeholders when local file opts out, got:\n{saved}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #59.

- Export now applies `templatize_body` to new resources (no local file yet), so raw `lid`/`cb_id` values are replaced with `__BRAZESYNC__` placeholders on first export
- Existing resources with local files that already contain placeholders continue to be templatized as before
- The only case where templatization is skipped: a local file exists but deliberately contains no placeholders (opt-out)

## Test plan

- [x] `export_new_content_block_templatizes_lid` — new content block without local file gets templatized
- [x] `export_new_email_template_templatizes_lid` — new email template without local dir gets templatized
- [x] `export_existing_content_block_without_placeholders_skips_templatize` — local file without placeholders is not templatized (opt-out preserved)
- [x] All 18 export integration tests pass
- [x] Full test suite (397 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)