### PR TITLE
chore: release v0.16.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to v0.16.4

### Changes since v0.16.3

- fix: templatize new resources without local template on export (#60, closes #59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)