### PR TITLE
fix: make content block orphans report-only instead of failing archive (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ frontmatter (name, description, tags, state) followed by the Liquid
 body. `braze-sync apply` can create new blocks and update existing
 ones, but **the Braze API has no DELETE for content blocks**, so blocks
 that exist in Braze but not in Git become *orphans* — `diff` flags
-them and `apply` does nothing about them by default. Pass
-`--archive-orphans` to rename them remotely with an
-`[ARCHIVED-YYYY-MM-DD]` prefix; the data is never silently dropped.
+them and `apply` does nothing about them. Braze also rejects renaming a
+content block after activation, so they can't be archived in place
+either; `apply --archive-orphans` lists them for manual removal in the
+Braze dashboard. The data is never silently dropped. (Email template
+orphans *can* be renamed with an `[ARCHIVED-YYYY-MM-DD]` prefix — see
+`docs/orphan-tracking.md`.)
 
 When a block body references another block via the Liquid include
 syntax `{{content_blocks.${other} | id: '...'}}`, `apply` topologically
@@ -159,12 +162,16 @@ These will be lifted across the v0.x → v1.0 milestones:
   `number` (or similar) is not auto-applied because the operation is
   data-losing on the field. Drop the field manually in Braze, then
   run `braze-sync apply` to re-add it with the new type.
-- **No DELETE for content blocks.** Braze's content blocks API does
-  not expose a DELETE endpoint, so blocks that exist in Braze but not
-  in Git become *orphans*. `diff` flags them; `apply` does nothing
-  about them unless you pass `--archive-orphans`, which renames them
-  remotely with an `[ARCHIVED-YYYY-MM-DD]` prefix instead of pretending
-  they were dropped.
+- **No DELETE for content blocks, and no archive either.** Braze's
+  content blocks API does not expose a DELETE endpoint, so blocks that
+  exist in Braze but not in Git become *orphans*. `diff` flags them;
+  `apply` does nothing about them. Braze also rejects renaming a
+  content block after activation (`"Content Block name cannot be changed
+  after activation"`), and `/content_blocks/info` exposes no state field
+  to tell draft from active, so `--archive-orphans` cannot rename them
+  the way it renames email templates. Content block orphans stay
+  report-only: `apply --archive-orphans` lists them for manual removal
+  in the Braze dashboard and exits 0 instead of aborting.
 - **Content block `state` is local-only and not observable.** The
   `state: active|draft` field in `content_blocks/<name>.liquid`
   frontmatter is a purely local authoring annotation. Braze's
@@ -179,14 +186,15 @@ These will be lifted across the v0.x → v1.0 milestones:
   The diff layer also ignores the field to prevent an "infinite
   drift" loop (Braze has no DELETE, so a persistently-Modified
   Content Block is a trap).
-- **`--archive-orphans` is a two-step read-modify-write.** The rename
-  fetches `/content_blocks/info` to preserve the body, then posts
-  `/content_blocks/update` with the archived name. If another operator
-  edits the same block in the dashboard between those two calls, the
-  update clobbers their change with the pre-rename body. Safe for the
-  single-operator GitOps workflow v0.2.0 targets; a compare-and-swap
-  header would lift it, but Braze's content_blocks API does not
-  currently document one.
+- **`--archive-orphans` is a two-step read-modify-write (email
+  templates only).** The rename fetches `/templates/email/info` to
+  preserve the body, then posts `/templates/email/update` with the
+  archived name. If another operator edits the same template in the
+  dashboard between those two calls, the update clobbers their change
+  with the pre-rename body. Safe for the single-operator GitOps
+  workflow braze-sync targets; a compare-and-swap header would lift it,
+  but Braze's API does not currently document one. (Content blocks are
+  never renamed — see above.)
 - **`--no-color` only affects tracing output.** Table and diff output
   do not currently emit ANSI colors, so the flag only suppresses
   ANSI escapes from the tracing subscriber on stderr.

--- a/docs/orphan-tracking.md
+++ b/docs/orphan-tracking.md
@@ -72,30 +72,46 @@ API calls for them. This is the right default: the tool cannot delete
 the resource, and silently leaving stale data behind is not an option
 either.
 
-### `--archive-orphans`: rename in place
+### `--archive-orphans`: rename in place (email templates only)
 
-Passing `--archive-orphans` renames each orphan in Braze with a
-date-stamped prefix:
+Passing `--archive-orphans` renames each **email template** orphan in
+Braze with a date-stamped prefix:
 
 ```
-legacy_promo  →  [ARCHIVED-2026-04-18] legacy_promo
+old_welcome  →  [ARCHIVED-2026-04-18] old_welcome
 ```
 
 The resource still exists in Braze — it just becomes obvious in the
 dashboard that it has been retired. This is a **two-step
 read-modify-write**:
 
-1. `GET /content_blocks/info` (or the email equivalent) to fetch the
-   current body.
-2. `POST /content_blocks/update` with the prefixed name and the body
+1. `GET /templates/email/info` to fetch the current body.
+2. `POST /templates/email/update` with the prefixed name and the body
    from step 1.
 
-If another operator edits the same resource in the Braze dashboard
+If another operator edits the same template in the Braze dashboard
 between those two calls, the update clobbers their edit with the
 pre-rename body. This race is acceptable for the single-operator
 GitOps workflow `braze-sync` targets; it would lift with a
-compare-and-swap header, which Braze's content-block API does not
-currently expose.
+compare-and-swap header, which Braze's API does not currently expose.
+
+#### Content blocks are report-only
+
+`--archive-orphans` does **not** rename content block orphans. Braze
+rejects renaming a content block once it has been activated:
+
+```
+HTTP 400: {"message":"Content Block name cannot be changed after activation."}
+```
+
+`/content_blocks/info` also exposes no state field, so braze-sync
+cannot tell a draft (renamable) block from an active (locked) one
+ahead of time. Rather than fire a write that aborts the whole apply on
+the first activated orphan, content block orphans stay report-only:
+they are listed in the run summary for manual removal in the Braze
+dashboard, and `apply` exits 0. This mirrors the underlying Braze API
+capability — email templates allow post-activation renames, content
+blocks do not.
 
 ### Deletion is never attempted
 
@@ -133,11 +149,15 @@ Other GitOps tools solve this with a separate state file that tracks
 
 Before adopting `--archive-orphans` in CI:
 
-- [ ] Confirm there's no other workflow that matches on *exact* content
-      block or email template names — archiving changes the name.
-- [ ] Confirm no campaign or canvas references the block by name. Braze
-      resolves references at send time; a renamed block will break
-      anything that still references the old name.
+- [ ] Confirm there's no other workflow that matches on *exact* email
+      template names — archiving changes the name. (Content block names
+      are never changed; those orphans are report-only.)
+- [ ] Confirm no campaign or canvas references the email template by
+      name. Braze resolves references at send time; a renamed template
+      will break anything that still references the old name.
+- [ ] Plan for content block orphans separately: braze-sync cannot
+      archive them, so they must be retired manually in the Braze
+      dashboard.
 - [ ] Decide on a recovery procedure (see "Unarchiving" above) and
       document it alongside your `braze-sync` runbook.
 

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -55,9 +55,12 @@ pub struct ApplyArgs {
     #[arg(long)]
     pub allow_destructive: bool,
 
-    /// Archive orphan Content Blocks / Email Templates by prefixing the
-    /// remote name with `[ARCHIVED-YYYY-MM-DD]`. Inert for resource
-    /// kinds that have no orphan concept (e.g. catalog schema).
+    /// Archive orphan Email Templates by prefixing the remote name with
+    /// `[ARCHIVED-YYYY-MM-DD]`. Inert for resource kinds that have no
+    /// orphan concept (e.g. catalog schema) and for Content Blocks, whose
+    /// names Braze locks after activation ("Content Block name cannot be
+    /// changed after activation") — those orphans stay report-only and are
+    /// listed for manual dashboard handling. See docs/orphan-tracking.md.
     #[arg(long)]
     pub archive_orphans: bool,
 
@@ -243,20 +246,17 @@ pub async fn run(
     let mut applied = 0;
     let mut ca_deprecate: Vec<&str> = Vec::new();
     let mut ca_reactivate: Vec<&str> = Vec::new();
+    let mut content_block_orphans: Vec<&str> = Vec::new();
     for diff in &summary.diffs {
         match diff {
             ResourceDiff::CatalogSchema(d) => {
                 applied += apply_catalog_schema(&client, d).await?;
             }
             ResourceDiff::ContentBlock(d) => {
-                applied += apply_content_block(
-                    &client,
-                    d,
-                    content_block_id_index.as_ref(),
-                    args.archive_orphans,
-                    today,
-                )
-                .await?;
+                if d.orphan {
+                    content_block_orphans.push(&d.name);
+                }
+                applied += apply_content_block(&client, d, content_block_id_index.as_ref()).await?;
             }
             ResourceDiff::EmailTemplate(d) => {
                 applied += apply_email_template(
@@ -287,6 +287,23 @@ pub async fn run(
         applied += apply_custom_attribute_batch(&client, &ca_deprecate, &ca_reactivate).await?;
     }
 
+    // Content blocks can't be archived via rename: Braze rejects renaming a
+    // content block once it has been activated, and `/content_blocks/info`
+    // exposes no state field so we can't tell draft from active ahead of
+    // time. They stay report-only; surface them so an operator who asked to
+    // archive knows to handle them manually. See docs/orphan-tracking.md.
+    if args.archive_orphans && !content_block_orphans.is_empty() {
+        eprintln!(
+            "⚠ {} content block orphan(s) left in place — Braze does not allow \
+             archiving content blocks via the API (name is locked after \
+             activation). Remove them in the Braze dashboard if no longer needed:",
+            content_block_orphans.len(),
+        );
+        for name in &content_block_orphans {
+            eprintln!("    - {name}");
+        }
+    }
+
     eprintln!("✓ Applied {applied} change(s).");
     Ok(())
 }
@@ -297,7 +314,7 @@ pub async fn run(
 ///
 /// ContentBlock diffs are deliberately not inspected here: every shape
 /// the diff layer can produce (`Added` → create, `Modified` → update,
-/// `orphan` → archive-or-noop) maps to a supported API call, so there
+/// `orphan` → report-only no-op) maps to a supported API call, so there
 /// is nothing to statically reject. If a future diff shape is added
 /// (e.g. content-type change with no in-place update), re-evaluate.
 /// Block apply when any resource that would be mutated references a tag
@@ -499,46 +516,14 @@ async fn apply_content_block(
     client: &BrazeClient,
     d: &ContentBlockDiff,
     id_index: Option<&ContentBlockIdIndex>,
-    archive_orphans: bool,
-    today: chrono::NaiveDate,
 ) -> anyhow::Result<usize> {
-    // Orphans only mutate remote state when --archive-orphans is set;
-    // otherwise the plan-print is the entire effect.
+    // Content block orphans are report-only: Braze has no DELETE endpoint
+    // and rejects renaming a content block after activation, so the
+    // rename-archival path used for email templates can't work here. The
+    // run-level summary lists them for manual handling; see the note after
+    // the apply loop and docs/orphan-tracking.md.
     if d.orphan {
-        if !archive_orphans {
-            return Ok(0);
-        }
-        let id_index = id_index.ok_or_else(|| {
-            anyhow!("internal: content_block id index missing for orphan apply path")
-        })?;
-        let id = id_index.get(&d.name).ok_or_else(|| {
-            anyhow!(
-                "internal: orphan '{}' missing from id index — list/diff drift",
-                d.name
-            )
-        })?;
-        let archived = orphan::archive_name(today, &d.name);
-        if archived == d.name {
-            return Ok(0);
-        }
-        // Update endpoint requires the full body, not a partial. Safe
-        // re: state — `get_content_block` defaults state to Active
-        // (Braze /info has no state field) and `update_content_block`
-        // omits state from the wire body, so this rename can never
-        // toggle the remote state as a side effect. If either of those
-        // invariants ever changes, the orphan path needs revisiting.
-        let mut cb = client
-            .get_content_block(id)
-            .await
-            .with_context(|| format!("fetching content block '{}' for archive rename", d.name))?;
-        cb.name = archived;
-        tracing::info!(
-            content_block = %d.name,
-            new_name = %cb.name,
-            "archiving orphan content block"
-        );
-        client.update_content_block(id, &cb).await?;
-        return Ok(1);
+        return Ok(0);
     }
 
     match &d.op {

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -19,6 +19,7 @@ use common::{
     write_config, write_local_content_block, write_local_custom_attribute_registry,
     write_local_email_template, write_local_schema,
 };
+use predicates::prelude::*;
 use serde_json::json;
 use wiremock::matchers::{body_json, body_partial_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -595,73 +596,16 @@ async fn content_block_orphan_without_archive_flag_makes_no_write_calls() {
     .unwrap();
 }
 
-/// Custom matcher that asserts an `[ARCHIVED-...]` rename request body
-/// has the right shape AND does not carry a `state` field.
-///
-/// State is local-only per the README and `diff::content_block::syncable_eq`
-/// — see `braze::content_block::update_content_block` for the full
-/// rationale. The unit test in that module pins state-absence at the
-/// `BrazeClient` level; this matcher pins it again at the binary level so
-/// a future refactor that bypasses `update_content_block` (or constructs
-/// its own request body) can't silently leak state into the wire.
-struct ArchiveRenameBody {
-    expected_id: &'static str,
-    expected_content: &'static str,
-    expected_tags: serde_json::Value,
-    original_name: &'static str,
-}
-
-impl wiremock::Match for ArchiveRenameBody {
-    fn matches(&self, request: &wiremock::Request) -> bool {
-        let body: serde_json::Value = match serde_json::from_slice(&request.body) {
-            Ok(v) => v,
-            Err(_) => return false,
-        };
-        let Some(obj) = body.as_object() else {
-            return false;
-        };
-        if obj.contains_key("state") {
-            return false;
-        }
-        let id_ok = obj.get("content_block_id").and_then(|v| v.as_str()) == Some(self.expected_id);
-        let content_ok = obj.get("content").and_then(|v| v.as_str()) == Some(self.expected_content);
-        let tags_ok = obj.get("tags") == Some(&self.expected_tags);
-        // Parse the archive prefix strictly: `[ARCHIVED-YYYY-MM-DD] <original>`.
-        // A looser "starts_with / ends_with" match would happily accept
-        // `[ARCHIVED-foo] legacy` or `[ARCHIVED-] legacy`, which would
-        // silently tolerate a bug in the date formatter.
-        let name_ok = obj.get("name").and_then(|v| v.as_str()).is_some_and(|n| {
-            let Some(rest) = n.strip_prefix("[ARCHIVED-") else {
-                return false;
-            };
-            let Some((date, tail)) = rest.split_once("] ") else {
-                return false;
-            };
-            tail == self.original_name && looks_like_iso_date(date)
-        });
-        id_ok && content_ok && tags_ok && name_ok
-    }
-}
-
-/// Permissive ISO-shape check for `YYYY-MM-DD`. Doesn't validate the
-/// actual calendar date — an off-by-one month is already caught by the
-/// `diff::orphan` unit tests; this matcher's job is to pin the wire
-/// shape, not to re-test chrono.
-fn looks_like_iso_date(s: &str) -> bool {
-    let bytes = s.as_bytes();
-    bytes.len() == 10
-        && bytes[4] == b'-'
-        && bytes[7] == b'-'
-        && bytes[..4].iter().all(|b| b.is_ascii_digit())
-        && bytes[5..7].iter().all(|b| b.is_ascii_digit())
-        && bytes[8..].iter().all(|b| b.is_ascii_digit())
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn content_block_archive_orphans_renames_via_update() {
-    // With --archive-orphans, the orphan is renamed via POST /update
-    // to `[ARCHIVED-YYYY-MM-DD] <name>`. The body is preserved by
-    // first fetching /info — verified by mounting an /info mock.
+async fn content_block_archive_orphans_is_report_only() {
+    // Content blocks cannot be archived via rename: Braze rejects
+    // renaming a content block after activation ("Content Block name
+    // cannot be changed after activation") and `/content_blocks/info`
+    // exposes no state field, so braze-sync cannot tell draft from
+    // active ahead of time. Unlike email templates, the orphan path
+    // therefore makes ZERO write calls even with --archive-orphans:
+    // no /info fetch and no /update. The orphan is reported instead.
+    // See docs/orphan-tracking.md.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/content_blocks/list"))
@@ -672,81 +616,10 @@ async fn content_block_archive_orphans_renames_via_update() {
         .await;
     Mock::given(method("GET"))
         .and(path("/content_blocks/info"))
-        .and(query_param("content_block_id", "id-orphan"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "name": "legacy",
-            "content": "preserved body\n",
-            "tags": ["pr"]
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
-    // Pin the request body shape AND the absence of `state` via
-    // ArchiveRenameBody. The name carries today's date so a literal
-    // body_json match would couple to the system clock; the matcher
-    // checks the dynamic field's prefix/suffix instead.
-    Mock::given(method("POST"))
-        .and(path("/content_blocks/update"))
-        .and(ArchiveRenameBody {
-            expected_id: "id-orphan",
-            expected_content: "preserved body\n",
-            expected_tags: json!(["pr"]),
-            original_name: "legacy",
-        })
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let tmp = tempfile::tempdir().unwrap();
-    let config_path = write_config(tmp.path(), &server.uri());
-
-    tokio::task::spawn_blocking(move || {
-        Command::cargo_bin("braze-sync")
-            .unwrap()
-            .env("BRAZE_API_KEY", "test-key")
-            .args(["--config", config_path.to_str().unwrap()])
-            .args([
-                "apply",
-                "--resource",
-                "content_block",
-                "--confirm",
-                "--archive-orphans",
-            ])
-            .assert()
-            .success();
-    })
-    .await
-    .unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn content_block_archive_orphans_skips_already_archived_blocks() {
-    // Idempotent re-archive: an orphan whose name already carries the
-    // [ARCHIVED-YYYY-MM-DD] prefix must NOT trigger another /info or
-    // /update call. The unit test for `archive_name` covers the pure
-    // function; this test pins the binary-level short-circuit in
-    // `apply_content_block` so a future refactor can't regress it
-    // (otherwise re-running `apply --archive-orphans` would stamp
-    // `[ARCHIVED-today] [ARCHIVED-yesterday] foo`).
-    let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/content_blocks/list"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "content_blocks": [
-                {"content_block_id": "id-old", "name": "[ARCHIVED-2024-01-01] ancient"}
-            ]
-        })))
-        .mount(&server)
-        .await;
-    // /info must NOT be called — the short-circuit fires before the fetch.
-    Mock::given(method("GET"))
-        .and(path("/content_blocks/info"))
         .respond_with(ResponseTemplate::new(500))
         .expect(0)
         .mount(&server)
         .await;
-    // No POST should fire either.
     Mock::given(method("POST"))
         .respond_with(ResponseTemplate::new(500))
         .expect(0)
@@ -769,7 +642,10 @@ async fn content_block_archive_orphans_skips_already_archived_blocks() {
                 "--archive-orphans",
             ])
             .assert()
-            .success();
+            .success()
+            // The orphan is surfaced for manual handling rather than archived.
+            .stderr(predicate::str::contains("content block orphan"))
+            .stderr(predicate::str::contains("legacy"));
     })
     .await
     .unwrap();


### PR DESCRIPTION
## Summary

`apply --archive-orphans` archived orphan content blocks by renaming them with an `[ARCHIVED-YYYY-MM-DD]` prefix. Braze rejects this for activated content blocks (`HTTP 400: "Content Block name cannot be changed after activation."`), so the apply aborted on the first activated orphan — and because Braze has no cross-resource transaction, earlier writes in the same run were left applied (partial completion). See #62.

Verified against the Braze API docs:
- **Content block update**: `name` cannot be changed after activation, and `active → draft` is also rejected. `/content_blocks/info` returns no `state` field, so braze-sync cannot tell a draft (renamable) block from an active (locked) one ahead of time. There is no DELETE endpoint.
- **Email template update**: no post-activation rename restriction — archival still works.

## Approach

Rather than patch the broken rename path, this removes it for content blocks (the capability isn't reliably available via the API) and keeps it for email templates (where it is):

- Content block orphans are now **report-only**. `apply --archive-orphans` lists them for manual removal in the Braze dashboard and **exits 0** instead of issuing a rename Braze rejects. A non-zero exit was deliberately avoided: an activated orphan is permanently un-archivable via the API, so failing the run would make CI red forever with no remediation path.
- Email template orphan archival is unchanged.
- The asymmetry mirrors the underlying Braze API capability difference, consistent with how the codebase documents other Braze-specific divergences.

## Changes

- `src/cli/apply.rs` — drop the content block orphan rename (get→rename→update) and the now-unused params on `apply_content_block`; collect content block orphans and emit a manual-handling note after the apply loop when `--archive-orphans` is set; update the flag help and a stale comment.
- `tests/cli_apply.rs` — replace the rename test with `content_block_archive_orphans_is_report_only` (asserts zero `/info` and `/update` calls + the warning), remove the now-dead idempotency test and `ArchiveRenameBody`/`looks_like_iso_date` helpers.
- `docs/orphan-tracking.md`, `README.md` — document content block orphans as report-only; archival applies to email templates only.

## Test plan

- [x] `cargo test` — all suites pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] New test pins that `--archive-orphans` makes zero write calls for a content block orphan and surfaces it for manual handling

> Note: CHANGELOG entry / version bump intentionally left out — handled in the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)