### PR TITLE
chore: release v0.16.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [0.16.5] — 2026-05-28
+
+### Fixed
+
+- **`apply --archive-orphans` no longer aborts on orphan content blocks.**
+  Braze rejects renaming a content block after activation (`HTTP 400:
+  "Content Block name cannot be changed after activation."`), so the
+  rename-based archival aborted the whole apply on the first activated
+  orphan — and since Braze has no cross-resource transaction, earlier
+  writes in the same run were left applied. Fixes #62.
+
+### Changed
+
+- **Content block orphans are now report-only.** `--archive-orphans`
+  cannot rename content blocks (Braze locks the name after activation,
+  and `/content_blocks/info` exposes no state field to tell draft from
+  active ahead of time), so content block orphans are listed for manual
+  removal in the Braze dashboard and `apply` exits 0 instead of issuing
+  a rename Braze rejects. Email template orphan archival is unchanged —
+  Braze allows post-activation renames there.
+
+## [0.16.4] — 2026-05-28
+
+### Fixed
+
+- **`export` now templatizes new resources without a local template.**
+  Previously `export` only reverse-templatized remote bodies when a local
+  file with `__BRAZESYNC__` placeholders already existed; brand-new
+  resources (no local file yet) were written with raw `lid`/`cb_id`
+  values, causing spurious drift on subsequent diff cycles until a manual
+  templatize. `templatize_body` is now applied unconditionally for new
+  resources; the only opt-out is an existing local file that deliberately
+  contains no placeholders. Fixes #59.
+
+- **Email template preheader is now templatized when locally absent.**
+  A local template with no `preheader` field previously skipped
+  templatization of the remote preheader, leaving raw `lid` values on
+  disk.
+
+## [0.16.3] — 2026-05-28
+
+### Fixed
+
+- **`lid` regex now accepts digit-leading values.** The first character
+  class in both `lid_match_re` and `lid_value_re` was widened from
+  `[a-z]` to `[a-z0-9]` so Braze-generated `lid` values that start with a
+  digit (e.g. `275ua26snuk7`) are matched correctly. The `__BRAZESYNC__`
+  placeholder remains excluded, preserving idempotency. Fixes #56.
+
 ## [0.16.2] — 2026-05-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.16.4"
+version = "0.16.5"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release **v0.16.5**.

- Bumps `Cargo.toml` / `Cargo.lock` to `0.16.5`.
- Backfills CHANGELOG entries that were missed for **0.16.3** and **0.16.4**, and adds the **0.16.5** entry.

## Release contents (v0.16.5)

### Fixed
- `apply --archive-orphans` no longer aborts on orphan content blocks — Braze rejects renaming a content block after activation, which previously aborted the whole apply (leaving earlier writes applied). Fixes #62 (PR #63).

### Changed
- Content block orphans are now report-only: `--archive-orphans` lists them for manual dashboard removal and `apply` exits 0. Email template archival is unchanged.

## Backfilled entries
- **0.16.4** — `export` now templatizes new resources without a local template (#59); email template preheader templatized when locally absent.
- **0.16.3** — `lid` regex accepts digit-leading values (#56).

## Test plan
- [x] `cargo build` succeeds; `Cargo.lock` updated to 0.16.5
- [x] CHANGELOG headings consistent with prior format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `apply --archive-orphans` to prevent crashes when encountering orphan content blocks
  * Changed `--archive-orphans` to report-only mode with successful completion

* **New Features**
  * `export` now automatically templatizes newly exported resources without requiring pre-existing local templates
  * Enhanced email preheader templatization when locally unavailable
  * Updated `lid` validation to accept digit-leading values

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uny/braze-sync/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->