### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
-## [Unreleased]
+## [0.17.0] — 2026-06-07
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.16.5"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release **v0.17.0**. Bumps the version in `Cargo.toml` / `Cargo.lock` and promotes the CHANGELOG `[Unreleased]` section to `[0.17.0] — 2026-06-07`.

This is a **breaking change** — the `--archive-orphans` CLI flag is removed on both `apply` and `diff` (#66, fixes #65). Per the project's semver policy the v0.x line takes a minor bump for breaking changes (matching the v0.16.0 precedent).

## Release notes (0.17.0)

### Removed
- **`--archive-orphans` is gone** on both `apply` and `diff`, along with its plan-scope field and plan-lock comparison. The rename-based archival was non-functional for content blocks (Braze locks the name after activation) and unsafe for email templates (rename can silently break API-triggered sends that resolve by name). The real prune path (`--allow-destructive` for catalogs, catalog fields, custom-attribute deprecation) is unaffected.

### Changed
- **Orphan reporting is now always on.** `diff` and `apply` print a read-only "N Braze resource(s) not present in Git…" notice across all resource kinds. Orphans still count as drift (so `diff --fail-on-drift` exits non-zero), but are no longer treated as actionable apply work — an orphan-only `apply` reports "no actionable changes".

## Testing
- `cargo build` — clean at v0.17.0, `Cargo.lock` consistent
- Full suite + clippy already green on the merged feature PR (#66)

🤖 Generated with [Claude Code](https://claude.com/claude-code)