### PR TITLE
fix: mask Braze-managed filters when keying lid correlation

### DIFF
--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -56,7 +56,11 @@ For every `apply` and `diff`:
    bare URL in plaintext) and pairs it with the matching anchor in
    the remote body to lift the live `lid` value. Multiple
    placeholders sharing one URL consume distinct remote values in
-   template appearance order.
+   template appearance order. The anchor is compared with its query
+   string and fragment dropped, and with any `| lid:` / `| id:` filter
+   inside it masked out — so a URL assembled from Liquid (e.g.
+   `href="{{ item.url }}{{ sep }}lid={{ x | lid: '…' }}"`, which has no
+   literal `?`) still correlates.
 3. For each `__BRAZESYNC__` in a `| id:` argument inside a
    `{{content_blocks.${NAME} ...}}` include, it looks up the live
    `cb_id` under the same `${NAME}` in the remote body.

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -508,12 +508,17 @@ fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<String>
             .and_then(|cap| cap.get(1).or(cap.get(2)))
             .map(|m| normalize_url(m.as_str()))
     } else if field.supports_plaintext_anchor() {
-        // Scan the whole body, not `body[..offset]`: when the lid filter
-        // sits inside the URL run itself the placeholder is *part of* the
-        // match, and truncating at `offset` would cut the filter in half
-        // so it no longer masks. Taking the last URL starting at or
-        // before `offset` covers both that case and the usual
-        // "URL, then lid after it" shape.
+        // The load-bearing part is `plaintext_url_anchors`: the remote
+        // side keys through the same trim + normalize, and any asymmetry
+        // there makes correlation impossible (see its doc comment).
+        //
+        // Scanning the whole body and taking the last URL starting at or
+        // before `offset` is equivalent to the `body[..offset]` prefix
+        // scan for every input reachable today — `plaintext_url_re`
+        // excludes `'` and `"`, and `placeholder::infer_type` only types a
+        // token as a lid when the byte before it is one of those, so a URL
+        // run can never span `offset`. Kept as the whole-body form because
+        // it stays correct if that regex is ever widened to admit quotes.
         plaintext_url_anchors(body)
             .into_iter()
             .take_while(|(start, _)| *start <= offset)
@@ -794,8 +799,12 @@ mod tests {
 
     #[test]
     fn plaintext_lid_inside_liquid_url_correlates() {
-        // No spaces, so the lid filter is *inside* the matched URL run
-        // and there is no literal `?` to cut at.
+        // No literal `?` to cut at. Note what actually makes this pass:
+        // `plaintext_url_re` stops at the `'`, so both sides key on
+        // `https://x.com/p{{sep}}lid={{x|lid` — masking never fires here.
+        // The fix under test is that the template side now shares
+        // `trim_trailing_punctuation` with the remote side (without it the
+        // template keeps the trailing `:` and never matches).
         let template = "Visit https://x.com/p{{sep}}lid={{x|lid:'__BRAZESYNC__'}} now";
         let remote = "Visit https://x.com/p{{sep}}lid={{x|lid:'liveeeeeeee1'}} now";
         let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -16,7 +16,8 @@ use regex_lite::Regex;
 
 use crate::values::correlation::{
     extract_cb_id_values, extract_html_lid_values, extract_lid_values_unanchored,
-    extract_plaintext_lid_values, normalize_url, slug_for_lid, CbIdCorrelation, LidCorrelation,
+    extract_plaintext_lid_values, normalize_url, plaintext_url_anchors, slug_for_lid,
+    CbIdCorrelation, LidCorrelation,
 };
 use crate::values::placeholder::{
     extract_placeholders, find_suspicious_placeholders, PlaceholderType, ResolutionError, TOKEN,
@@ -507,11 +508,17 @@ fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<String>
             .and_then(|cap| cap.get(1).or(cap.get(2)))
             .map(|m| normalize_url(m.as_str()))
     } else if field.supports_plaintext_anchor() {
-        let prefix = &body[..offset];
-        plaintext_url_re()
-            .find_iter(prefix)
+        // Scan the whole body, not `body[..offset]`: when the lid filter
+        // sits inside the URL run itself the placeholder is *part of* the
+        // match, and truncating at `offset` would cut the filter in half
+        // so it no longer masks. Taking the last URL starting at or
+        // before `offset` covers both that case and the usual
+        // "URL, then lid after it" shape.
+        plaintext_url_anchors(body)
+            .into_iter()
+            .take_while(|(start, _)| *start <= offset)
             .last()
-            .map(|m| normalize_url(m.as_str()))
+            .map(|(_, url)| url)
     } else {
         None
     }
@@ -545,11 +552,6 @@ fn url_attr_re() -> &'static Regex {
         )
         .expect("url attr regex is valid")
     })
-}
-
-fn plaintext_url_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r#"https?://[^\s<>"']+"#).expect("plaintext URL regex is valid"))
 }
 
 fn element_open_tag_re() -> &'static Regex {
@@ -746,5 +748,59 @@ mod tests {
         assert_eq!(url_path_tail("https://x.com/page/?a=1#b"), "page");
         assert_eq!(url_path_tail("https://x.com/"), "");
         assert_eq!(url_path_tail("https://x.com/sale"), "sale");
+    }
+    #[test]
+    fn liquid_separator_href_lid_correlates() {
+        // The query separator comes from Liquid, so the href holds no
+        // literal `?` and the lid filter is part of the anchor key on
+        // both sides. Without masking, template (`__BRAZESYNC__`) and
+        // remote (live value) keys can never be equal and the resource
+        // is permanently drifted.
+        let template =
+            r#"<a href="{{ item.url }}{{ sep }}lid={{ x | lid: '__BRAZESYNC__' }}">go</a>"#;
+        let remote = r#"<a href="{{ item.url }}{{ sep }}lid={{ x | lid: 'liveeeeeeee1' }}">go</a>"#;
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+        assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
+        assert!(p.body.contains("'liveeeeeeee1'"), "got: {}", p.body);
+    }
+
+    #[test]
+    fn cb_id_inside_href_does_not_break_lid_anchor() {
+        // A content_block include supplying the URL prefix carries its
+        // own Braze-managed value; it must be masked out of the anchor
+        // key too, or the lid never correlates.
+        let template = r#"<a href="{{content_blocks.${base} | id: '__BRAZESYNC__'}}{{sep}}lid={{x | lid: '__BRAZESYNC__'}}">go</a>"#;
+        let remote = r#"<a href="{{content_blocks.${base} | id: 'cb42'}}{{sep}}lid={{x | lid: 'liveeeeeeee1'}}">go</a>"#;
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+        assert!(p.body.contains("'liveeeeeeee1'"), "got: {}", p.body);
+        assert!(p.body.contains("'cb42'"), "got: {}", p.body);
+    }
+
+    #[test]
+    fn plaintext_lid_anchor_trims_trailing_punctuation() {
+        // Remote-side extraction trims the sentence period; the
+        // template-side anchor must trim it identically.
+        let template = "See https://x.com/end. {{x | lid: '__BRAZESYNC__'}}";
+        let remote = "See https://x.com/end. {{x | lid: 'liveeeeeeee1'}}";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+        assert!(p.body.contains("'liveeeeeeee1'"), "got: {}", p.body);
+    }
+
+    #[test]
+    fn plaintext_lid_inside_liquid_url_correlates() {
+        // No spaces, so the lid filter is *inside* the matched URL run
+        // and there is no literal `?` to cut at.
+        let template = "Visit https://x.com/p{{sep}}lid={{x|lid:'__BRAZESYNC__'}} now";
+        let remote = "Visit https://x.com/p{{sep}}lid={{x|lid:'liveeeeeeee1'}} now";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+        assert!(p.body.contains("'liveeeeeeee1'"), "got: {}", p.body);
     }
 }

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -11,18 +11,49 @@
 use regex_lite::Regex;
 use std::sync::OnceLock;
 
+use crate::values::placeholder::TOKEN;
+
 /// Shared pattern for raw lid values so templatize and correlation cannot drift.
 pub(crate) const LID_VALUE_PATTERN: &str = "[a-z0-9][a-z0-9_]*";
 
-/// Normalize a URL for anchor comparison: keep `scheme://host/path`,
-/// drop `?query` and `#fragment`.
+/// Stand-in for a Braze-managed filter inside an anchor key. Contains no
+/// `?` / `#` so it survives the query/fragment cut below.
+const MANAGED_FILTER_MASK: &str = "|<braze-managed>";
+
+/// Normalize a URL for anchor comparison: mask Braze-managed filters,
+/// then keep `scheme://host/path` and drop `?query` / `#fragment`.
+///
+/// Both sides of a correlation run through this, so the key must never
+/// embed the very value being correlated. Cutting at the first literal
+/// `?` is not enough: when the query separator is Liquid-templated
+/// (`{{ item.url }}{{ sep }}lid={{ x | lid: '…' }}`) there is no literal
+/// `?`, so the lid filter would stay in the key — `__BRAZESYNC__` on the
+/// template side, the live value on the remote side, never equal. Masking
+/// the filter first makes both sides collapse to the same string.
 ///
 /// Returns the input unchanged if it doesn't look like a URL with a
 /// scheme — callers pass already-detected URLs, but normalizing
 /// idempotently keeps the function safe to apply in either direction.
 pub fn normalize_url(url: &str) -> String {
-    let stop = url.find(['?', '#']).unwrap_or(url.len());
-    url[..stop].to_string()
+    let masked = managed_filter_re().replace_all(url, MANAGED_FILTER_MASK);
+    let stop = masked.find(['?', '#']).unwrap_or(masked.len());
+    masked[..stop].to_string()
+}
+
+fn managed_filter_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // `| lid: 'X'` / `| id: 'cbN'` in either their live form or their
+        // templatized `__BRAZESYNC__` form. Values are restricted to the
+        // shapes templatize round-trips, so unrelated Liquid filters that
+        // happen to be named `id` keep their place in the key.
+        let lid = format!("(?:{LID_VALUE_PATTERN}|{TOKEN})");
+        let cb = format!("(?:cb[0-9]+|{TOKEN})");
+        Regex::new(&format!(
+            r#"\|\s*(?:lid:\s*(?:"{lid}"|'{lid}')|id:\s*(?:"{cb}"|'{cb}'))"#
+        ))
+        .expect("managed filter regex is valid")
+    })
 }
 
 fn href_re() -> &'static Regex {
@@ -132,7 +163,7 @@ pub fn extract_html_lid_values(body: &str) -> Vec<LidCorrelation> {
 /// Extract `(url, lid_value)` pairs from a plaintext field. Same
 /// pairing rule as HTML but URLs come from raw `https?://…` matches.
 pub fn extract_plaintext_lid_values(body: &str) -> Vec<LidCorrelation> {
-    pair_urls_with_lids(plaintext_url_iter(body), body)
+    pair_urls_with_lids(plaintext_url_anchors(body), body)
 }
 
 /// Extract raw lid values in field appearance order without any URL
@@ -160,7 +191,14 @@ fn href_iter(body: &str) -> Vec<(usize, String)> {
         .collect()
 }
 
-fn plaintext_url_iter(body: &str) -> Vec<(usize, String)> {
+/// Scan `body` for plaintext URLs, returning `(byte offset, anchor key)`
+/// in appearance order.
+///
+/// Shared by remote-side extraction and template-side anchor lookup:
+/// trailing-punctuation trimming and [`normalize_url`] must be applied to
+/// both, or a URL like `https://x.com/end.` keys differently on each side
+/// and the correlation can never match.
+pub fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
     plaintext_url_re()
         .find_iter(body)
         .map(|m| {
@@ -298,6 +336,34 @@ mod tests {
         assert_eq!(
             normalize_url("https://example.com/x"),
             "https://example.com/x"
+        );
+    }
+
+    #[test]
+    fn normalize_masks_managed_filters_so_both_sides_agree() {
+        // No literal `?`, so the cut alone leaves the lid value in the
+        // key. Template and remote must still normalize identically.
+        let template = "{{ item.url }}{{ sep }}lid={{ x | lid: '__BRAZESYNC__' }}";
+        let remote = "{{ item.url }}{{ sep }}lid={{ x | lid: 'liveeeeeeee1' }}";
+        assert_eq!(normalize_url(template), normalize_url(remote));
+        assert!(!normalize_url(template).contains("__BRAZESYNC__"));
+
+        let tmpl_cb = "{{content_blocks.${base} | id: '__BRAZESYNC__'}}/go";
+        let remote_cb = "{{content_blocks.${base} | id: 'cb42'}}/go";
+        assert_eq!(normalize_url(tmpl_cb), normalize_url(remote_cb));
+    }
+
+    #[test]
+    fn normalize_leaves_unrelated_filters_intact() {
+        // Only the value shapes templatize round-trips are masked, so an
+        // unrelated `id`-named filter still distinguishes two anchors.
+        assert_eq!(
+            normalize_url("{{ a | id: 'not-a-cb-id' }}"),
+            "{{ a | id: 'not-a-cb-id' }}"
+        );
+        assert_ne!(
+            normalize_url("{{ a | upcase }}"),
+            normalize_url("{{ b | upcase }}")
         );
     }
 

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -38,14 +38,13 @@ const MANAGED_FILTER_MASK: &str = "|<braze-managed>";
 /// filter is masked, whatever the input looks like.
 pub fn normalize_url(url: &str) -> String {
     let masked = lid_filter_re().replace_all(url, MANAGED_FILTER_MASK);
-    let masked = cb_id_filter_re().replace_all(masked.as_ref(), CB_ID_MASK_REPLACEMENT);
+    // `${1}` keeps the `{{content_blocks.${NAME}` prefix the cb_id regex
+    // had to capture; only the `| id: '…'` after it is masked.
+    let cb_replacement = format!("${{1}}{MANAGED_FILTER_MASK}");
+    let masked = cb_id_filter_re().replace_all(masked.as_ref(), cb_replacement.as_str());
     let stop = masked.find(['?', '#']).unwrap_or(masked.len());
     masked[..stop].to_string()
 }
-
-/// Keeps the `{{content_blocks.${NAME}` prefix (group 1) and masks only
-/// the `| id: '…'` filter after it.
-const CB_ID_MASK_REPLACEMENT: &str = "${1}|<braze-managed>";
 
 fn lid_filter_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -219,7 +219,15 @@ fn href_iter(body: &str) -> Vec<(usize, String)> {
 /// trailing-punctuation trimming and [`normalize_url`] must be applied to
 /// both, or a URL like `https://x.com/end.` keys differently on each side
 /// and the correlation can never match.
-pub fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
+///
+/// Note that [`normalize_url`]'s masking is inert here: `plaintext_url_re`
+/// stops at `'` / `"`, so a quoted managed filter is never inside the
+/// match and the key ends mid-filter (`…{{x|lid`). Both sides truncate at
+/// the same byte, so they still agree — but the key therefore also drops
+/// everything after the filter, and two plaintext URLs differing only in
+/// that tail share one anchor. `resolve_lid_batch` warns when a bucket
+/// holds more than one remote value.
+pub(crate) fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
     plaintext_url_re()
         .find_iter(body)
         .map(|m| {

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -31,28 +31,49 @@ const MANAGED_FILTER_MASK: &str = "|<braze-managed>";
 /// template side, the live value on the remote side, never equal. Masking
 /// the filter first makes both sides collapse to the same string.
 ///
-/// Returns the input unchanged if it doesn't look like a URL with a
-/// scheme — callers pass already-detected URLs, but normalizing
-/// idempotently keeps the function safe to apply in either direction.
+/// Callers pass already-detected URLs, but the rewrite is idempotent and
+/// shape-driven rather than scheme-driven, so it is safe to apply in
+/// either direction. Note that it does *not* pass non-URL text through
+/// untouched: anything after a `?` / `#` is dropped and any managed
+/// filter is masked, whatever the input looks like.
 pub fn normalize_url(url: &str) -> String {
-    let masked = managed_filter_re().replace_all(url, MANAGED_FILTER_MASK);
+    let masked = lid_filter_re().replace_all(url, MANAGED_FILTER_MASK);
+    let masked = cb_id_filter_re().replace_all(masked.as_ref(), CB_ID_MASK_REPLACEMENT);
     let stop = masked.find(['?', '#']).unwrap_or(masked.len());
     masked[..stop].to_string()
 }
 
-fn managed_filter_re() -> &'static Regex {
+/// Keeps the `{{content_blocks.${NAME}` prefix (group 1) and masks only
+/// the `| id: '…'` filter after it.
+const CB_ID_MASK_REPLACEMENT: &str = "${1}|<braze-managed>";
+
+fn lid_filter_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        // `| lid: 'X'` / `| id: 'cbN'` in either their live form or their
-        // templatized `__BRAZESYNC__` form. Values are restricted to the
-        // shapes templatize round-trips, so unrelated Liquid filters that
-        // happen to be named `id` keep their place in the key.
+        // `| lid: 'X'` in either its live form or its templatized
+        // `__BRAZESYNC__` form. `lid` is Braze's own filter, so matching it
+        // by name anywhere is safe.
         let lid = format!("(?:{LID_VALUE_PATTERN}|{TOKEN})");
+        Regex::new(&format!(r#"\|\s*lid:\s*(?:"{lid}"|'{lid}')"#))
+            .expect("lid filter regex is valid")
+    })
+}
+
+fn cb_id_filter_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // `id` is NOT a Braze-reserved filter name — a template may define
+        // its own. Only the `| id: 'cbN'` inside a `content_blocks.${NAME}`
+        // include is Braze-managed, so anchor on that prefix (mirroring
+        // `cb_id_include_re`) and keep it in the key. Masking every
+        // `| id: 'cbN'` would collapse two anchors that differ only in an
+        // unrelated `id` filter, and `resolve_lid_batch`'s FIFO would then
+        // hand each link the other's live lid.
         let cb = format!("(?:cb[0-9]+|{TOKEN})");
         Regex::new(&format!(
-            r#"\|\s*(?:lid:\s*(?:"{lid}"|'{lid}')|id:\s*(?:"{cb}"|'{cb}'))"#
+            r#"(\{{\{{\s*content_blocks\.\$\{{\s*[^\s}}|]+\s*\}}\s*)\|\s*id:\s*(?:"{cb}"|'{cb}')"#
         ))
-        .expect("managed filter regex is valid")
+        .expect("cb_id filter regex is valid")
     })
 }
 
@@ -364,6 +385,30 @@ mod tests {
         assert_ne!(
             normalize_url("{{ a | upcase }}"),
             normalize_url("{{ b | upcase }}")
+        );
+    }
+
+    #[test]
+    fn normalize_keeps_unrelated_id_filter_with_cb_shaped_value_distinct() {
+        // `id` is not reserved: a template may define its own filter named
+        // `id` whose value happens to look like a cb_id. Masking by name +
+        // value shape alone would collapse these two anchors into one FIFO
+        // bucket, and a dashboard-side link reorder would then swap the two
+        // links' live lid values — permanently, since both stay valid.
+        assert_ne!(
+            normalize_url("https://x/{{ product | id: 'cb1' }}"),
+            normalize_url("https://x/{{ product | id: 'cb2' }}")
+        );
+        // The genuine managed form — inside a `content_blocks.${NAME}`
+        // include — must still collapse across template/remote.
+        assert_eq!(
+            normalize_url("{{content_blocks.${base} | id: '__BRAZESYNC__'}}/go"),
+            normalize_url("{{content_blocks.${base} | id: 'cb42'}}/go")
+        );
+        // ...while still distinguishing two different includes.
+        assert_ne!(
+            normalize_url("{{content_blocks.${a} | id: 'cb1'}}"),
+            normalize_url("{{content_blocks.${b} | id: 'cb2'}}")
         );
     }
 


### PR DESCRIPTION
Fixes #68.

## The bug

`lid` correlation keys on the enclosing URL anchor, normalized by cutting at the first literal `?` / `#`:

```rust
let stop = url.find(['?', '#']).unwrap_or(url.len());
```

When the query separator is Liquid-templated there is no literal `?`, so nothing is stripped and the `lid` filter stays in the key — `__BRAZESYNC__` on the template side, the live value on the remote side. **The key embedded the very value being correlated**, so `by_url.get_mut(&url)` could never hit: every `diff`/`apply` warned `URL anchor … not found in remote body`, wrote a fallback slug over the live lid, and the resource never converged.

## The fix

`normalize_url` masks `| lid: 'X'` and `| id: 'cbN'` — in both their live and `__BRAZESYNC__` forms — *before* the query/fragment cut, so both sides collapse to the same key regardless of how the URL is assembled. Masking is applied in the one function both sides already share, so remote extraction and template-side `lid_anchor_for` stay symmetric by construction.

The two filters are matched by **different** rules, because they are not equally reserved:

- `| lid: '…'` is matched anywhere. `lid` is Braze's own filter name, so name + value shape is a safe signal.
- `| id: '…'` is matched **only inside a `{{content_blocks.${NAME} …}}` include**, whose prefix the regex captures and preserves (mirroring `cb_id_include_re`). `id` is *not* reserved — a template may define its own filter called `id` — so matching it by name and value shape alone would collapse two anchors that differ only in an unrelated `id` filter. See "Review follow-ups" below: the first cut of this PR did exactly that.

Static-URL paths are untouched: `https://x.com/page/?lid={{x | lid: '…'}}` still normalizes to `https://x.com/page/`, since the `?` cut happens after the mask.

## Second instance of the same failure family

Confirming the report surfaced another asymmetry with identical consequences (permanent drift + live lid overwritten): **plaintext trailing-punctuation trimming was applied only on the remote side**. `See https://x.com/end. {{x | lid: '…'}}` keyed as `https://x.com/end.` in the template and `https://x.com/end` in the remote.

Root cause is the same shape — the two sides computed the key through duplicated code. Both now share one `plaintext_url_anchors` scan (the duplicate `plaintext_url_re` in `braze_managed.rs` is gone), which is what actually repairs both plaintext cases.

The template-side lookup also now scans the whole body rather than `body[..offset]`. To be precise about what that does and does not buy: it is **equivalent to the prefix scan for every input reachable today** — `plaintext_url_re` excludes `'` and `"`, and `infer_type` only types a token as a lid when the byte before it is one of those, so a URL run can never span the placeholder. It is kept as the whole-body form because it stays correct if that regex is ever widened to admit quotes, not because it fixes a case the prefix scan missed. `normalize_url`'s masking is likewise **inert on the plaintext path** for the same reason; the plaintext keys agree because both sides truncate at the same byte, not because they were masked.

## Coverage

Four new resolution tests (all fail on `main`, pass here) plus three `normalize_url` unit tests:

- `liquid_separator_href_lid_correlates` — the reported repro, alongside the existing `vml_href_anchors_lid` literal-`?` case
- `cb_id_inside_href_does_not_break_lid_anchor` — content block include supplying the URL prefix
- `plaintext_lid_anchor_trims_trailing_punctuation`
- `plaintext_lid_inside_liquid_url_correlates`
- `normalize_masks_managed_filters_so_both_sides_agree` / `normalize_leaves_unrelated_filters_intact` / `normalize_keeps_unrelated_id_filter_with_cb_shaped_value_distinct`

`cargo test` (398 lib + all integration), `cargo clippy --all-targets -D warnings`, and `cargo fmt --check` are clean.

## Review follow-ups

Three commits on top of the original fix, from a review pass over this branch.

**`27a28fa` — only mask `| id:` inside content_blocks includes (must-fix).**
The first cut of this PR masked every `| id: 'cbN'` by filter name and value shape. Because `id` is not reserved, two anchors differing solely in an unrelated `id` filter collapsed into one FIFO bucket, and a dashboard-side link reorder made `resolve_lid_batch` hand each link the other's live lid:

```
template: href="https://x/{{ product | id: 'cb1' }}"  (+ lid placeholder)
          href="https://x/{{ product | id: 'cb2' }}"
remote:   the same two links, order reversed
→ cb1's link resolved to cb2's live lid, and vice versa
```

Both values stay valid, so Braze never self-corrects — click attribution is transposed permanently, behind a non-fatal warning. This was a defect **introduced by this PR**, and it was the exact property the old comment claimed to have; the old test only exercised a value (`'not-a-cb-id'`) that failed the `cb[0-9]+` shape anyway, so a cb-shaped unrelated value slipped straight through.

**`ab21a7d` — correct the plaintext anchor rationale (docs).**
Three comments added by this branch described mechanisms the code does not have (the "lid filter sits inside the URL run" case cannot occur; the plaintext test passes via the shared trimming, not via masking). Corrected in place, and `plaintext_url_anchors` now documents that its key stops mid-filter. It is also narrowed to `pub(crate)` — the only consumer is in-crate, and it was `pub` without being re-exported from `values::mod`.

**`5387e8f` — derive the cb_id mask replacement from the sentinel (refactor).**
The replacement string held a second hardcoded copy of `MANAGED_FILTER_MASK`.

### Deferred, not fixed here

- **#70** — plaintext anchor keys are formatting-sensitive and truncate at the first quote. `templatize` canonicalizes `|lid:'v'` to `| lid: '__BRAZESYNC__'`, so a compactly-written remote does not round-trip and its live lid is overwritten by a fallback slug. Same failure family as #68, but **present on `main`** (verified against `b56769b`) and the fix needs the URL scan rebuilt, so it is out of scope here.
- **#71** — the internal sentinel `|<braze-managed>` reaches operator warnings and, via `slug_for_lid`, the lid values POSTed to Braze (`x_braze_managed`). Not a regression in kind — the pre-change path produced the equally synthetic `x_lid_brazesync`.

### Release note

`plaintext_url_anchors` went from `pub` to `pub(crate)`, removing one item from the published API surface. The next release needs a **0.18.0** bump, not 0.17.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of links that include query strings, fragments, or embedded tracking filters.
  * Fixed link matching for URLs assembled dynamically from Liquid expressions.
  * Improved handling of content-block identifiers and trailing punctuation in plain-text URLs.
  * Preserved unrelated URL filters while consistently matching managed link identifiers.
* **Documentation**
  * Updated guidance for environment-specific values and link resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
