### PR TITLE
fix: read plaintext lid anchors through whole Liquid tags

### DIFF
--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -60,7 +60,10 @@ For every `apply` and `diff`:
    string and fragment dropped, and with any `| lid:` / `| id:` filter
    inside it masked out — so a URL assembled from Liquid (e.g.
    `href="{{ item.url }}{{ sep }}lid={{ x | lid: '…' }}"`, which has no
-   literal `?`) still correlates.
+   literal `?`) still correlates. In plaintext the bare URL is read
+   through whole `{{…}}` tags for the same reason, so the anchor keeps
+   whatever follows the tag and links that differ only past the filter
+   stay distinct.
 3. For each `__BRAZESYNC__` in a `| id:` argument inside a
    `{{content_blocks.${NAME} ...}}` include, it looks up the live
    `cb_id` under the same `${NAME}` in the remote body.

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -512,13 +512,14 @@ fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<String>
         // side keys through the same trim + normalize, and any asymmetry
         // there makes correlation impossible (see its doc comment).
         //
-        // Scanning the whole body and taking the last URL starting at or
-        // before `offset` is equivalent to the `body[..offset]` prefix
-        // scan for every input reachable today — `plaintext_url_re`
-        // excludes `'` and `"`, and `placeholder::infer_type` only types a
-        // token as a lid when the byte before it is one of those, so a URL
-        // run can never span `offset`. Kept as the whole-body form because
-        // it stays correct if that regex is ever widened to admit quotes.
+        // Scanning the whole body — rather than `body[..offset]` — is
+        // load-bearing: `plaintext_url_re` spans a whole `{{…}}`, so for a
+        // URL assembled from Liquid the run *contains* the placeholder.
+        // Truncating at `offset` would cut the tag in half, leaving a
+        // partial filter that no longer masks, and the key would go back
+        // to depending on where the quote happens to fall. Taking the last
+        // URL starting at or before `offset` covers both that case and the
+        // usual "URL, then lid tag after it" shape.
         plaintext_url_anchors(body)
             .into_iter()
             .take_while(|(start, _)| *start <= offset)
@@ -569,6 +570,7 @@ fn element_open_tag_re() -> &'static Regex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::values::templatize::templatize_body;
 
     #[test]
     fn no_placeholders_returns_body_verbatim() {
@@ -799,17 +801,68 @@ mod tests {
 
     #[test]
     fn plaintext_lid_inside_liquid_url_correlates() {
-        // No literal `?` to cut at. Note what actually makes this pass:
-        // `plaintext_url_re` stops at the `'`, so both sides key on
-        // `https://x.com/p{{sep}}lid={{x|lid` — masking never fires here.
-        // The fix under test is that the template side now shares
-        // `trim_trailing_punctuation` with the remote side (without it the
-        // template keeps the trailing `:` and never matches).
+        // No literal `?` to cut at, and the run now spans the whole
+        // `{{…}}`, so the key is `https://x.com/p{{sep}}lid={{x` plus the
+        // masked filter. Both spellings of the filter reach the same key —
+        // see `plaintext_lid_round_trips_whatever_the_filter_spacing`.
         let template = "Visit https://x.com/p{{sep}}lid={{x|lid:'__BRAZESYNC__'}} now";
         let remote = "Visit https://x.com/p{{sep}}lid={{x|lid:'liveeeeeeee1'}} now";
         let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
         assert!(p.errors.is_empty(), "{:?}", p.errors);
         assert!(p.warnings.is_empty(), "{:?}", p.warnings);
         assert!(p.body.contains("'liveeeeeeee1'"), "got: {}", p.body);
+    }
+
+    #[test]
+    fn plaintext_lid_round_trips_whatever_the_filter_spacing() {
+        // `templatize` canonicalizes the filter, inserting a space into
+        // the compact spelling — so the round-trip is the identity up to
+        // that rewrite, i.e. the live value must land back in the token's
+        // place. Whichever way the author wrote the filter, resolving the
+        // template against the very remote it came from has to recover
+        // `liveeeeeeee1`; otherwise every apply overwrites the live lid
+        // with a fallback slug and the resource never converges.
+        for remote in [
+            "Visit https://x.com/p{{sep}}lid={{x|lid:'liveeeeeeee1'}} now",
+            "Visit https://x.com/p{{sep}}lid={{x | lid: 'liveeeeeeee1'}} now",
+        ] {
+            let t = templatize_body(remote, FieldKind::EmailPlainBody);
+            assert_eq!(t.lid_rewrites, 1, "not templatized: {}", t.new_body);
+            let p = prepare_field(&t.new_body, Some(remote), FieldKind::EmailPlainBody);
+            assert!(p.errors.is_empty(), "{:?}", p.errors);
+            assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+            assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
+            assert_eq!(
+                p.body,
+                t.new_body.replace(TOKEN, "liveeeeeeee1"),
+                "the live lid must land back in the token's place"
+            );
+        }
+    }
+
+    #[test]
+    fn plaintext_urls_differing_only_after_the_filter_keep_distinct_anchors() {
+        // Both links share a prefix and differ only *past* the lid filter.
+        // The remote lists them in the opposite order, so a collapsed key
+        // hands each link the other's live lid via FIFO — and because both
+        // values stay valid, Braze never self-corrects and click
+        // attribution is transposed permanently.
+        let template = "Go https://x.com/p{{sep}}lid={{x | lid: '__BRAZESYNC__'}}/beta and \
+                        https://x.com/p{{sep}}lid={{x | lid: '__BRAZESYNC__'}}/alpha now";
+        let remote = "Go https://x.com/p{{sep}}lid={{x | lid: 'aaaaaaaaaaa'}}/alpha and \
+                      https://x.com/p{{sep}}lid={{x | lid: 'bbbbbbbbbbb'}}/beta now";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+        assert!(
+            p.body.contains("lid: 'bbbbbbbbbbb'}}/beta"),
+            "/beta must keep its own lid, got: {}",
+            p.body
+        );
+        assert!(
+            p.body.contains("lid: 'aaaaaaaaaaa'}}/alpha"),
+            "/alpha must keep its own lid, got: {}",
+            p.body
+        );
     }
 }

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -124,7 +124,10 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
             Some(PlaceholderType::Lid) => {
                 let v = lid_iter.next().flatten();
                 if v.is_none() {
-                    let anchor = lid_anchor_for(&body, ph.start, field);
+                    // Display-only (see `format_failures`), so render the
+                    // mask back rather than showing a key.
+                    let anchor =
+                        lid_anchor_for(&body, ph.start, field).map(|u| anchor_for_display(&u));
                     errors.push(ResolutionError::UnresolvedLid {
                         start: ph.start,
                         anchor,
@@ -212,11 +215,12 @@ fn resolve_lid_batch(
         let tmpl_count = tmpl_per_url.get(url).copied().unwrap_or(0);
         if bucket.len() > 1 || (tmpl_count > 0 && bucket.len() != tmpl_count) {
             warnings.push(format!(
-                "URL '{url}' has {} remote lid occurrences and {tmpl_count} \
+                "URL '{shown}' has {} remote lid occurrences and {tmpl_count} \
                  template placeholders — using positional FIFO match. \
                  If links were reordered in Braze, lid values may be assigned \
                  to the wrong placeholder.",
-                bucket.len()
+                bucket.len(),
+                shown = anchor_for_display(url)
             ));
         }
     }

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -17,7 +17,7 @@ use regex_lite::Regex;
 use crate::values::correlation::{
     extract_cb_id_values, extract_html_lid_values, extract_lid_values_unanchored,
     extract_plaintext_lid_values, normalize_url, plaintext_url_anchors, slug_for_lid,
-    CbIdCorrelation, LidCorrelation,
+    CbIdCorrelation, LidCorrelation, MANAGED_FILTER_MASK,
 };
 use crate::values::placeholder::{
     extract_placeholders, find_suspicious_placeholders, PlaceholderType, ResolutionError, TOKEN,
@@ -413,6 +413,12 @@ fn unique(base: String, used: &mut BTreeMap<String, usize>) -> String {
 }
 
 fn url_path_tail(url: &str) -> String {
+    // The input is an anchor *key*, so it may carry `MANAGED_FILTER_MASK`
+    // — a comparison-only sentinel. The tail feeds `slug_for_lid`, whose
+    // output is POSTed as a live Braze `lid`, so strip it first or the
+    // slug reads `…_braze_managed`. Now that the plaintext run spans a
+    // whole `{{…}}`, the mask lands inside the key on that path too.
+    let url = &url.replace(MANAGED_FILTER_MASK, "");
     let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
     let path_start = after_scheme
         .find('/')
@@ -803,8 +809,12 @@ mod tests {
     fn plaintext_lid_inside_liquid_url_correlates() {
         // No literal `?` to cut at, and the run now spans the whole
         // `{{…}}`, so the key is `https://x.com/p{{sep}}lid={{x` plus the
-        // masked filter. Both spellings of the filter reach the same key —
-        // see `plaintext_lid_round_trips_whatever_the_filter_spacing`.
+        // masked filter. Masking is what makes template and remote agree
+        // here despite `templatize` respacing the filter — each spelling
+        // round-trips against its own remote, which is what
+        // `plaintext_lid_round_trips_whatever_the_filter_spacing` pins.
+        // The two spellings do *not* produce the same key as each other
+        // (the space before `|` is outside the mask).
         let template = "Visit https://x.com/p{{sep}}lid={{x|lid:'__BRAZESYNC__'}} now";
         let remote = "Visit https://x.com/p{{sep}}lid={{x|lid:'liveeeeeeee1'}} now";
         let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
@@ -836,6 +846,29 @@ mod tests {
                 p.body,
                 t.new_body.replace(TOKEN, "liveeeeeeee1"),
                 "the live lid must land back in the token's place"
+            );
+        }
+    }
+
+    #[test]
+    fn plaintext_fallback_slug_never_leaks_the_managed_filter_mask() {
+        // The anchor key now spans the whole `{{…}}`, so `normalize_url`
+        // masks the filter *inside* it. That mask is a comparison-only
+        // sentinel: it must not reach the slug, which is POSTed as a live
+        // Braze `lid`. Both fallback paths derive from the same key.
+        let template = "Visit https://x.com/promo{{sep}}lid={{x | lid: '__BRAZESYNC__'}} now";
+        for remote in [None, Some("Visit https://elsewhere.example/other now")] {
+            let p = prepare_field(template, remote, FieldKind::EmailPlainBody);
+            assert!(p.errors.is_empty(), "{:?}", p.errors);
+            assert!(
+                !p.body.contains("braze_managed"),
+                "sentinel leaked into the POSTed lid: {}",
+                p.body
+            );
+            assert!(
+                p.body.contains("| lid: 'promo_sep_lid_x'}}"),
+                "got: {}",
+                p.body
             );
         }
     }

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -246,13 +246,14 @@ fn resolve_lid_batch(
             Some(p) => out.push(Some(p.value.clone())),
             None => {
                 let fallback = fallback_lid_for_url(Some(&url), &mut used, &mut seq);
+                let shown = anchor_for_display(&url);
                 warnings.push(format!(
-                    "lid: URL anchor '{url}' not found in remote body — \
+                    "lid: URL anchor '{shown}' not found in remote body — \
                      using fallback value '{fallback}' (new link; Braze will \
                      reassign on first dashboard save)"
                 ));
                 fallbacks.push(LidFallback {
-                    anchor: Some(url.clone()),
+                    anchor: Some(shown),
                     value: fallback.clone(),
                 });
                 out.push(Some(fallback));
@@ -260,6 +261,14 @@ fn resolve_lid_batch(
         }
     }
     out
+}
+
+/// Render an anchor key for a human. The key carries
+/// `MANAGED_FILTER_MASK` where the Braze-managed filter stood — a
+/// comparison-only sentinel — so printing it verbatim shows the operator
+/// a URL that appears nowhere in their template.
+fn anchor_for_display(url: &str) -> String {
+    url.replace(MANAGED_FILTER_MASK, "| lid: '…'")
 }
 
 /// Slug fallback for a single lid placeholder. `used` is shared across
@@ -883,6 +892,19 @@ mod tests {
                 "sentinel leaked into the POSTed lid: {}",
                 p.body
             );
+            // ...nor into what the operator is shown, where it would name
+            // a URL that appears nowhere in their template.
+            for shown in p
+                .warnings
+                .iter()
+                .cloned()
+                .chain(p.fallbacks.iter().filter_map(|f| f.anchor.clone()))
+            {
+                assert!(
+                    !shown.contains("braze-managed"),
+                    "sentinel leaked into operator output: {shown}"
+                );
+            }
             assert!(
                 p.body.contains("| lid: 'promo_sep_lid_x'}}"),
                 "got: {}",

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -851,6 +851,24 @@ mod tests {
     }
 
     #[test]
+    fn editing_copy_after_a_plaintext_link_keeps_the_live_lid() {
+        // The link is untouched; only the copy behind it changed. The
+        // anchor must not depend on that copy — if it does, apply POSTs a
+        // fallback slug over `liveeeeeeee1` and the Braze-side click
+        // history for the link is severed. Nothing reassigns it back,
+        // because the fallback is itself a valid lid.
+        let remote = "Visit https://x.com/p{{x | lid: 'liveeeeeeee1'}}.{{ old_copy }}";
+        let template = "Visit https://x.com/p{{x | lid: '__BRAZESYNC__'}}.{{ new_copy }}";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
+        assert_eq!(
+            p.body, "Visit https://x.com/p{{x | lid: 'liveeeeeeee1'}}.{{ new_copy }}",
+            "the live lid must survive an edit to the copy after the link"
+        );
+    }
+
+    #[test]
     fn plaintext_fallback_slug_never_leaks_the_managed_filter_mask() {
         // The anchor key now spans the whole `{{…}}`, so `normalize_url`
         // masks the filter *inside* it. That mask is a comparison-only

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -43,14 +43,50 @@ pub(crate) const MANAGED_FILTER_MASK: &str = "|<braze-managed>";
 /// either direction. Note that it does *not* pass non-URL text through
 /// untouched: anything after a `?` / `#` is dropped and any managed
 /// filter is masked, whatever the input looks like.
+///
+/// The `?` / `#` must be *outside* a Liquid tag to count. One inside is
+/// the tag's own text — `{{ sep | default: '?' }}` is the same separator
+/// as `{{sep}}`, just spelled with a fallback — and cutting there would
+/// truncate the key mid-tag, collapsing every link that differs only
+/// past that tag onto one anchor.
 pub fn normalize_url(url: &str) -> String {
     let masked = lid_filter_re().replace_all(url, MANAGED_FILTER_MASK);
     // `${1}` keeps the `{{content_blocks.${NAME}` prefix the cb_id regex
     // had to capture; only the `| id: '…'` after it is masked.
     let cb_replacement = format!("${{1}}{MANAGED_FILTER_MASK}");
     let masked = cb_id_filter_re().replace_all(masked.as_ref(), cb_replacement.as_str());
-    let stop = masked.find(['?', '#']).unwrap_or(masked.len());
+    let stop = query_or_fragment_start(masked.as_ref()).unwrap_or(masked.len());
     masked[..stop].to_string()
+}
+
+/// If a Liquid output tag opens at `i`, the index just past its `}}`.
+/// `None` when no tag opens there, and when one opens but never closes —
+/// callers decide what an unclosed tag means for them.
+fn liquid_tag_end(bytes: &[u8], i: usize) -> Option<usize> {
+    if !bytes[i..].starts_with(b"{{") {
+        return None;
+    }
+    bytes[i..]
+        .windows(2)
+        .position(|w| w == b"}}")
+        .map(|rel| i + rel + "}}".len())
+}
+
+/// First `?` / `#` that is not inside a Liquid tag.
+fn query_or_fragment_start(value: &str) -> Option<usize> {
+    let bytes = value.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if let Some(end) = liquid_tag_end(bytes, i) {
+            i = end;
+            continue;
+        }
+        if matches!(bytes[i], b'?' | b'#') {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
 }
 
 fn lid_filter_re() -> &'static Regex {
@@ -328,9 +364,11 @@ fn split_on_embedded_scheme(run: &str) -> Vec<(usize, &str)> {
             // first `}}` is the close for every tag `plaintext_url_re`
             // matches as an atom, since `[^{}]*` admits no braces; a
             // brace-bearing tag arrives here only via the character
-            // class, and lands mid-tag rather than past it.
-            match bytes[i..].windows(2).position(|w| w == b"}}") {
-                Some(rel) => i += rel + "}}".len(),
+            // class, and lands mid-tag rather than past it. An unclosed
+            // `{{` ends the scan — splitting on a scheme inside what may
+            // be tag text is worse than not splitting.
+            match liquid_tag_end(bytes, i) {
+                Some(end) => i = end,
                 None => break,
             }
             continue;
@@ -508,6 +546,40 @@ mod tests {
         assert_eq!(
             normalize_url("https://example.com/x"),
             "https://example.com/x"
+        );
+    }
+
+    #[test]
+    fn normalize_only_cuts_at_a_separator_outside_a_liquid_tag() {
+        // `{{ sep | default: '?' }}` is the same query separator as
+        // `{{sep}}`, spelled with a fallback. Cutting at the `?` inside
+        // it would truncate the key mid-tag, so two links differing only
+        // past the tag would share one anchor and `resolve_lid_batch`'s
+        // FIFO could hand each the other's live lid.
+        assert_ne!(
+            normalize_url("https://x/{{ sep | default: '?' }}/alpha"),
+            normalize_url("https://x/{{ sep | default: '?' }}/beta")
+        );
+        assert_eq!(
+            normalize_url("https://x/{{ sep | default: '?' }}/alpha"),
+            "https://x/{{ sep | default: '?' }}/alpha"
+        );
+        // The brace-free spelling already behaved this way — the two
+        // must not disagree.
+        assert_ne!(
+            normalize_url("https://x/{{sep}}/alpha"),
+            normalize_url("https://x/{{sep}}/beta")
+        );
+        // A real separator still cuts, inside or outside a tag's reach.
+        assert_eq!(
+            normalize_url("https://x/{{sep}}/alpha?utm=1"),
+            "https://x/{{sep}}/alpha"
+        );
+        assert_eq!(normalize_url("https://x/a#frag"), "https://x/a");
+        // An unclosed tag must not swallow the rest of the key.
+        assert_eq!(
+            normalize_url("https://x/{{ oops ?utm=1"),
+            "https://x/{{ oops "
         );
     }
 
@@ -713,7 +785,7 @@ mod tests {
         assert_eq!(
             keys,
             vec![
-                "https://a.example/one{{ sep | default: '",
+                "https://a.example/one{{ sep | default: '?' }}",
                 "https://b.example/two{{y |<braze-managed>}}",
             ]
         );

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -291,22 +291,47 @@ pub(crate) fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
         .collect()
 }
 
-/// Split a run at any `https?://` that is not at its start.
+/// Split a run at an embedded `https?://` that starts a second link.
 ///
 /// `plaintext_url_re` stops at whitespace, but a Liquid tag is one atom
 /// of the run and may itself contain whitespace — so two links written
 /// back-to-back with only a tag between them (`…/one{{ sep }}https://b…`)
 /// would otherwise land in a single anchor, and a dashboard-side reorder
-/// would hand each the other's lid. A scheme starts a link, so it ends
-/// the previous one.
+/// would hand each the other's lid.
+///
+/// Only a scheme that would really begin a new link counts. Two places
+/// carry one that does not, and splitting at either is worse than not
+/// splitting at all:
+///
+/// - **inside the query** — `…/r?u=https://dest…` is a redirect target,
+///   an argument of the first URL. [`normalize_url`] drops the query
+///   anyway, so splitting there would move the anchor onto the shared
+///   destination and collapse every tracking link that redirects to it.
+/// - **inside a `{{…}}`** — `{{ u | default: 'https://cdn…' }}` is a
+///   filter argument, and the enclosing tag is part of the URL being
+///   assembled.
 fn split_on_embedded_scheme(run: &str) -> Vec<(usize, &str)> {
-    let mut starts: Vec<usize> = std::iter::once(0)
-        .chain(run.match_indices("http").filter_map(|(i, _)| {
-            let rest = &run[i..];
-            (i > 0 && (rest.starts_with("http://") || rest.starts_with("https://"))).then_some(i)
-        }))
-        .collect();
-    starts.dedup();
+    let bytes = run.as_bytes();
+    // A scheme past the query separator is an argument, not a link.
+    let limit = run.find(['?', '#']).unwrap_or(run.len());
+    let mut starts = vec![0usize];
+    let mut i = 0;
+    while i < limit {
+        if bytes[i..].starts_with(b"{{") {
+            // Skip the whole tag rather than inspecting inside it.
+            match bytes[i..].windows(2).position(|w| w == b"}}") {
+                Some(rel) => i += rel + "}}".len(),
+                None => break,
+            }
+            continue;
+        }
+        if i > 0 && (bytes[i..].starts_with(b"http://") || bytes[i..].starts_with(b"https://")) {
+            starts.push(i);
+            i += "http://".len();
+            continue;
+        }
+        i += 1;
+    }
     starts
         .iter()
         .enumerate()
@@ -648,6 +673,32 @@ mod tests {
         );
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].url, "https://b.example/two{{y |<braze-managed>}}");
+    }
+
+    #[test]
+    fn plaintext_anchor_keeps_a_redirect_target_inside_the_link() {
+        // A scheme in the query is the redirect target of a tracking
+        // link, not a second link. Splitting there would anchor both
+        // links on the shared destination and let a reorder transpose
+        // their lids — the very failure the split exists to prevent.
+        let body = "Go https://track.example/r?u=https://dest.example/x {{a | lid: 'aaaaaaaaaaa'}} \
+                    and https://track.example/s?u=https://dest.example/x {{b | lid: 'bbbbbbbbbbb'}}";
+        let pairs = extract_plaintext_lid_values(body);
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].url, "https://track.example/r");
+        assert_eq!(pairs[0].value, "aaaaaaaaaaa");
+        assert_eq!(pairs[1].url, "https://track.example/s");
+        assert_eq!(pairs[1].value, "bbbbbbbbbbb");
+
+        // Same for a scheme that is an argument inside a Liquid tag.
+        let anchors = plaintext_url_anchors(
+            "Go https://x.com/{{ u | default: 'https://cdn.example/i' }}/end",
+        );
+        assert_eq!(anchors.len(), 1);
+        assert_eq!(
+            anchors[0].1,
+            "https://x.com/{{ u | default: 'https://cdn.example/i' }}/end"
+        );
     }
 
     #[test]

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -310,20 +310,31 @@ pub(crate) fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
 /// - **inside a `{{…}}`** — `{{ u | default: 'https://cdn…' }}` is a
 ///   filter argument, and the enclosing tag is part of the URL being
 ///   assembled.
+///
+/// Both exclusions are decided in one left-to-right scan, because the
+/// query separator only ends the URL when it is *outside* a tag: a `?`
+/// within `{{ sep | default: '?' }}` is part of the tag's own text, and
+/// treating it as the separator would abandon the scan before a genuine
+/// second link.
 fn split_on_embedded_scheme(run: &str) -> Vec<(usize, &str)> {
     let bytes = run.as_bytes();
-    // A scheme past the query separator is an argument, not a link.
-    let limit = run.find(['?', '#']).unwrap_or(run.len());
     let mut starts = vec![0usize];
     let mut i = 0;
-    while i < limit {
+    while i < bytes.len() {
         if bytes[i..].starts_with(b"{{") {
-            // Skip the whole tag rather than inspecting inside it.
+            // Skip the whole tag rather than inspecting inside it. The
+            // first `}}` is the close for every tag `plaintext_url_re`
+            // matches as an atom, since `[^{}]*` admits no braces; a
+            // brace-bearing tag arrives here only via the character
+            // class, and lands mid-tag rather than past it.
             match bytes[i..].windows(2).position(|w| w == b"}}") {
                 Some(rel) => i += rel + "}}".len(),
                 None => break,
             }
             continue;
+        }
+        if bytes[i] == b'?' || bytes[i] == b'#' {
+            break;
         }
         if i > 0 && (bytes[i..].starts_with(b"http://") || bytes[i..].starts_with(b"https://")) {
             starts.push(i);
@@ -689,6 +700,21 @@ mod tests {
         assert_eq!(pairs[0].value, "aaaaaaaaaaa");
         assert_eq!(pairs[1].url, "https://track.example/s");
         assert_eq!(pairs[1].value, "bbbbbbbbbbb");
+
+        // A `?` inside the separator tag is the tag's own text, not the
+        // query separator — it must not abandon the scan before the
+        // second link, or both lids land in one FIFO bucket.
+        let anchors = plaintext_url_anchors(
+            "Go https://a.example/one{{ sep | default: '?' }}https://b.example/two{{y | lid: 'bbbbbbbbbbb'}}",
+        );
+        let keys: Vec<&str> = anchors.iter().map(|(_, u)| u.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "https://a.example/one{{ sep | default: '",
+                "https://b.example/two{{y |<braze-managed>}}",
+            ]
+        );
 
         // Same for a scheme that is an argument inside a Liquid tag.
         let anchors = plaintext_url_anchors(

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -20,7 +20,12 @@ pub(crate) const LID_VALUE_PATTERN: &str = "[a-z0-9][a-z0-9_]*";
 
 /// Stand-in for a Braze-managed filter inside an anchor key. Contains no
 /// `?` / `#` so it survives the query/fragment cut below.
-const MANAGED_FILTER_MASK: &str = "|<braze-managed>";
+///
+/// Comparison-only: it exists so both sides of a correlation collapse to
+/// the same string. Anything that derives an *outgoing* value from an
+/// anchor key must strip it first (see `braze_managed::url_path_tail`) —
+/// leaking it would put `braze_managed` into a live Braze identifier.
+pub(crate) const MANAGED_FILTER_MASK: &str = "|<braze-managed>";
 
 /// Normalize a URL for anchor comparison: mask Braze-managed filters,
 /// then keep `scheme://host/path` and drop `?query` / `#fragment`.
@@ -130,10 +135,18 @@ fn plaintext_url_re() -> &'static Regex {
         //      and `…{{x | lid: 'b'}}/two` collapse to one key and
         //      `resolve_lid_batch`'s FIFO hands each link the other's lid.
         //
-        // Spanning the tag also lets `normalize_url` mask the filter,
-        // which is what makes the key formatting-insensitive. The
-        // alternative only fires on a *closed* `{{…}}`: a stray `{`
-        // falls through to the character class, which admits it anyway.
+        // Spanning the tag also lets `normalize_url` mask the filter, so
+        // the key stops depending on the spacing `templatize` rewrites —
+        // everything from the `|` onward. Whitespace *before* the pipe is
+        // not absorbed (see `plaintext_url_anchors`), so this is not full
+        // formatting insensitivity.
+        //
+        // The alternative only fires on a *closed*, brace-free `{{…}}`: a
+        // stray `{` falls through to the character class, which admits it
+        // anyway. A tag containing braces — notably this repo's own
+        // `{{content_blocks.${NAME} | id: 'cbN'}}` — is likewise *not* one
+        // atom, so a plaintext URL built from such an include still keys
+        // the pre-fix way.
         Regex::new(r#"https?://(?:\{\{[^{}]*\}\}|[^\s<>"'])+"#)
             .expect("plaintext URL regex is valid")
     })
@@ -243,13 +256,19 @@ fn href_iter(body: &str) -> Vec<(usize, String)> {
 /// both, or a URL like `https://x.com/end.` keys differently on each side
 /// and the correlation can never match.
 ///
-/// Note that [`normalize_url`]'s masking is inert here: `plaintext_url_re`
-/// stops at `'` / `"`, so a quoted managed filter is never inside the
-/// match and the key ends mid-filter (`…{{x|lid`). Both sides truncate at
-/// the same byte, so they still agree — but the key therefore also drops
-/// everything after the filter, and two plaintext URLs differing only in
-/// that tail share one anchor. `resolve_lid_batch` warns when a bucket
-/// holds more than one remote value.
+/// [`normalize_url`]'s masking is load-bearing here: `plaintext_url_re`
+/// spans a whole `{{…}}`, so a quoted managed filter *is* inside the
+/// match, and masking it is what lets the two sides agree despite the
+/// spacing `templatize` rewrites. The key keeps whatever follows the tag,
+/// so two plaintext URLs differing only in that tail stay distinct.
+///
+/// What the mask does **not** absorb is whitespace to the left of the
+/// `|` — [`lid_filter_re`] starts matching at the pipe. Correlation
+/// survives that only because `templatize_body` rewrites from the `|`
+/// onward and leaves the bytes before it untouched, so both sides carry
+/// the same spelling. A filter respaced on the Braze side (`{{x|lid:…}}`
+/// edited to `{{ x | lid: … }}`) therefore does *not* correlate; the
+/// anchor misses and the live lid is replaced by a fallback slug.
 pub(crate) fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
     plaintext_url_re()
         .find_iter(body)
@@ -482,9 +501,12 @@ mod tests {
              https://x.com/p{{sep}}lid={{x|lid:'bbbbbbbbbbb'}}/beta now",
         );
         let keys: Vec<&str> = anchors.iter().map(|(_, u)| u.as_str()).collect();
-        // The run covers the whole tag, so the suffix past it survives and
-        // the two links stay distinguishable; the filter itself is masked,
-        // so the compact and spaced spellings agree.
+        // The run covers the whole tag, so the suffix past it survives
+        // and the two links stay distinguishable. The filter itself is
+        // masked, which is what removes the dependence on the spacing
+        // `templatize` rewrites — note this is *not* symmetric across the
+        // pipe: the space before `|` survives into the first key, because
+        // `lid_filter_re` starts matching at the pipe.
         assert_eq!(
             keys,
             vec![

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -259,8 +259,10 @@ fn href_iter(body: &str) -> Vec<(usize, String)> {
 /// [`normalize_url`]'s masking is load-bearing here: `plaintext_url_re`
 /// spans a whole `{{…}}`, so a quoted managed filter *is* inside the
 /// match, and masking it is what lets the two sides agree despite the
-/// spacing `templatize` rewrites. The key keeps whatever follows the tag,
-/// so two plaintext URLs differing only in that tail stay distinct.
+/// spacing `templatize` rewrites. The key keeps the plain text that
+/// follows the tag, so two plaintext URLs differing only in that tail
+/// stay distinct — a further *tag* is cut, see
+/// [`bound_after_managed_tag`].
 ///
 /// What the mask does **not** absorb is whitespace to the left of the
 /// `|` — [`lid_filter_re`] starts matching at the pipe. Correlation

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -272,17 +272,80 @@ fn href_iter(body: &str) -> Vec<(usize, String)> {
 pub(crate) fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
     plaintext_url_re()
         .find_iter(body)
-        .map(|m| {
-            let raw = m.as_str();
-            let preceded_by = if m.start() > 0 {
-                body[..m.start()].chars().last()
-            } else {
-                None
-            };
-            let trimmed = trim_trailing_punctuation(raw, preceded_by);
-            (m.start(), normalize_url(trimmed))
+        .flat_map(|m| {
+            split_on_embedded_scheme(m.as_str())
+                .into_iter()
+                .map(move |(rel, piece)| {
+                    let start = m.start() + rel;
+                    let preceded_by = if start > 0 {
+                        body[..start].chars().last()
+                    } else {
+                        None
+                    };
+                    let bounded = bound_after_managed_tag(piece);
+                    let trimmed = trim_trailing_punctuation(bounded, preceded_by);
+                    (start, normalize_url(trimmed))
+                })
+                .collect::<Vec<_>>()
         })
         .collect()
+}
+
+/// Split a run at any `https?://` that is not at its start.
+///
+/// `plaintext_url_re` stops at whitespace, but a Liquid tag is one atom
+/// of the run and may itself contain whitespace — so two links written
+/// back-to-back with only a tag between them (`…/one{{ sep }}https://b…`)
+/// would otherwise land in a single anchor, and a dashboard-side reorder
+/// would hand each the other's lid. A scheme starts a link, so it ends
+/// the previous one.
+fn split_on_embedded_scheme(run: &str) -> Vec<(usize, &str)> {
+    let mut starts: Vec<usize> = std::iter::once(0)
+        .chain(run.match_indices("http").filter_map(|(i, _)| {
+            let rest = &run[i..];
+            (i > 0 && (rest.starts_with("http://") || rest.starts_with("https://"))).then_some(i)
+        }))
+        .collect();
+    starts.dedup();
+    starts
+        .iter()
+        .enumerate()
+        .map(|(n, &s)| {
+            let end = starts.get(n + 1).copied().unwrap_or(run.len());
+            (s, &run[s..end])
+        })
+        .collect()
+}
+
+/// Stop the run at the first `{{` that follows the tag carrying the
+/// managed `lid` filter.
+///
+/// Spanning a `{{…}}` is what lets the key survive the spacing
+/// `templatize` rewrites, but it also lets the run leap the whitespace
+/// *inside* an unrelated tag and swallow ordinary copy. Once the managed
+/// filter's own tag is closed, a further tag is prose rather than URL:
+/// keeping it would make the anchor depend on text that has nothing to
+/// do with the link, so editing that copy locally would discard the live
+/// lid. Plain characters after the tag (`}}/alpha` vs `}}/beta`) are
+/// still kept — distinguishing those is the reason the run spans the tag
+/// at all.
+///
+/// The cut is structural, so template and remote land on it identically.
+/// Cost: two links differing *only* by a Liquid tag after the filter
+/// share one anchor; `resolve_lid_batch` warns when a bucket holds more
+/// than one remote value.
+fn bound_after_managed_tag(run: &str) -> &str {
+    let Some(filter) = lid_filter_re().find(run) else {
+        return run;
+    };
+    let Some(rel) = run[filter.end()..].find("}}") else {
+        return run;
+    };
+    let after_tag = filter.end() + rel + "}}".len();
+    match run[after_tag..].find("{{") {
+        Some(rel) => &run[..after_tag + rel],
+        None => run,
+    }
 }
 
 fn pair_urls_with_lids(urls: Vec<(usize, String)>, body: &str) -> Vec<LidCorrelation> {
@@ -541,6 +604,50 @@ mod tests {
             assert_eq!(anchors.len(), 1, "{body}");
             assert_eq!(anchors[0].1, want, "{body}");
         }
+    }
+
+    #[test]
+    fn plaintext_anchor_stops_at_a_tag_past_the_managed_filter() {
+        // Copy that merely *follows* the link must not enter the anchor:
+        // spanning the lid tag lets the run leap the whitespace inside a
+        // later tag, and an edit to that copy would then discard the live
+        // lid. Both spellings of the trailing tag cut at the same point.
+        for tail in [".{{ old_copy }}", ".{{old_copy}}", "{{ other }}"] {
+            let body = format!("Visit https://x.com/p{{{{x | lid: 'liveeeeeeee1'}}}}{tail}");
+            let anchors = plaintext_url_anchors(&body);
+            assert_eq!(anchors.len(), 1, "{body}");
+            assert_eq!(
+                anchors[0].1, "https://x.com/p{{x |<braze-managed>}}",
+                "{body}"
+            );
+        }
+        // ...but plain characters after the tag still distinguish links.
+        let anchors = plaintext_url_anchors("Go https://x.com/p{{x | lid: 'aaaaaaaaaaa'}}/alpha");
+        assert_eq!(anchors[0].1, "https://x.com/p{{x |<braze-managed>}}/alpha");
+    }
+
+    #[test]
+    fn plaintext_anchor_splits_at_a_second_scheme() {
+        // A tag between two links carries whitespace, so without the
+        // split the two would share one anchor and a reorder would
+        // transpose their lids.
+        let anchors = plaintext_url_anchors(
+            "Go https://a.example/one{{ sep }}https://b.example/two{{y | lid: 'bbbbbbbbbbb'}} end",
+        );
+        let keys: Vec<&str> = anchors.iter().map(|(_, u)| u.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "https://a.example/one{{ sep }}",
+                "https://b.example/two{{y |<braze-managed>}}",
+            ]
+        );
+        // The lid must pair with the link it sits on, not the first one.
+        let pairs = extract_plaintext_lid_values(
+            "Go https://a.example/one{{ sep }}https://b.example/two{{y | lid: 'bbbbbbbbbbb'}} end",
+        );
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].url, "https://b.example/two{{y |<braze-managed>}}");
     }
 
     #[test]

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -5,7 +5,9 @@
 //!
 //! - HTML lid: anchor = the URL attribute of the enclosing element.
 //!   Same-URL occurrences are matched by appearance order.
-//! - Plaintext lid: anchor = the raw `https?://…` preceding the lid.
+//! - Plaintext lid: anchor = the raw `https?://…` run at or before the
+//!   lid. The run spans whole Liquid tags, so a URL built from Liquid
+//!   can enclose the lid rather than merely precede it.
 //! - cb_id: anchor = `${NAME}` in the same Liquid include.
 
 use regex_lite::Regex;
@@ -107,11 +109,33 @@ fn lid_value_re() -> &'static Regex {
 fn plaintext_url_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        // Greedy `[^\s<>"]` runs up to whitespace or a quote/angle —
+        // Greedy `[^\s<>"']` runs up to whitespace or a quote/angle —
         // good enough for Braze plaintext where URLs aren't routinely
         // wrapped in markup. Trailing punctuation is trimmed post-hoc
         // (see `trim_trailing_punctuation`).
-        Regex::new(r#"https?://[^\s<>"']+"#).expect("plaintext URL regex is valid")
+        //
+        // A Liquid output tag is one atom, so a URL assembled from Liquid
+        // keeps its whole run. Without it the run ends *inside* the tag —
+        // at the space or the `'` — and two failures follow, because
+        // whether a byte is whitespace there depends on formatting that
+        // `templatize` rewrites:
+        //
+        //   1. `templatize` canonicalizes `{{x|lid:'v'}}` to
+        //      `{{x| lid: '__BRAZESYNC__'}}`, inserting a space. The
+        //      template run then stops at that space (`…{{x|`) while the
+        //      remote run stops at the quote (`…{{x|lid`), so the keys
+        //      never match and every apply overwrites the live lid with a
+        //      fallback slug.
+        //   2. Anything past the tag is dropped, so `…{{x | lid: 'a'}}/one`
+        //      and `…{{x | lid: 'b'}}/two` collapse to one key and
+        //      `resolve_lid_batch`'s FIFO hands each link the other's lid.
+        //
+        // Spanning the tag also lets `normalize_url` mask the filter,
+        // which is what makes the key formatting-insensitive. The
+        // alternative only fires on a *closed* `{{…}}`: a stray `{`
+        // falls through to the character class, which admits it anyway.
+        Regex::new(r#"https?://(?:\{\{[^{}]*\}\}|[^\s<>"'])+"#)
+            .expect("plaintext URL regex is valid")
     })
 }
 
@@ -449,6 +473,52 @@ mod tests {
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].url, "https://example.com/x");
         assert_eq!(pairs[0].value, "lidvaluexyz1");
+    }
+
+    #[test]
+    fn plaintext_run_spans_liquid_tags_and_keys_past_them() {
+        let anchors = plaintext_url_anchors(
+            "Go https://x.com/p{{sep}}lid={{x | lid: 'aaaaaaaaaaa'}}/alpha and \
+             https://x.com/p{{sep}}lid={{x|lid:'bbbbbbbbbbb'}}/beta now",
+        );
+        let keys: Vec<&str> = anchors.iter().map(|(_, u)| u.as_str()).collect();
+        // The run covers the whole tag, so the suffix past it survives and
+        // the two links stay distinguishable; the filter itself is masked,
+        // so the compact and spaced spellings agree.
+        assert_eq!(
+            keys,
+            vec![
+                "https://x.com/p{{sep}}lid={{x |<braze-managed>}}/alpha",
+                "https://x.com/p{{sep}}lid={{x|<braze-managed>}}/beta",
+            ]
+        );
+    }
+
+    #[test]
+    fn plaintext_run_stops_at_whitespace_outside_a_liquid_tag() {
+        // The documented plaintext shape puts the lid tag *after* the URL.
+        // Spanning a `{{…}}` must not make the run jump the space into it,
+        // or the anchor stops being the URL. Same for a bare `| lid:` in
+        // prose (`plaintext_lid_trims_trailing_punctuation` covers pairing
+        // for that one) and for quoted prose around a URL.
+        for (body, want) in [
+            (
+                "Click https://example.com/promo {{x | lid: 'lidplain01a'}} now.",
+                "https://example.com/promo",
+            ),
+            (
+                "Visit (https://example.com/cta) | lid: 'lidplain01a' for the deal.",
+                "https://example.com/cta",
+            ),
+            (
+                r#"He said "visit https://x.com/a" then "bye""#,
+                "https://x.com/a",
+            ),
+        ] {
+            let anchors = plaintext_url_anchors(body);
+            assert_eq!(anchors.len(), 1, "{body}");
+            assert_eq!(anchors[0].1, want, "{body}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #70. Both symptoms were verified to be **byte-identical on `b56769b`**, so they predate #69.

## Root cause

The plaintext anchor key came from `https?://[^\s<>"']+` — it stops at whitespace *and* at either quote. For a URL assembled from Liquid the run ends **inside** the `{{…}}`, and where it ends depends on formatting that `templatize` rewrites.

## Symptom 1 — round-trip destroys the live lid

`templatize` canonicalizes the filter, inserting a space:

```
REMOTE   = Visit https://x.com/p{{sep}}lid={{x|lid:'liveeeeeeee1'}} now
TEMPLATE = Visit https://x.com/p{{sep}}lid={{x| lid: '__BRAZESYNC__'}} now
RESOLVED = Visit https://x.com/p{{sep}}lid={{x| lid: 'p_sep_lid_x'}} now
```

Template key stopped at the inserted space (`…{{x|`), remote key at the quote (`…{{x|lid`). Whether a resource converged depended on how the author happened to write the filter — the exact #68 impact, on every apply.

## Symptom 2 — permanently transposed click attribution

Everything past the tag was dropped, so two links sharing a prefix collapsed to one key. With the links reordered in the dashboard, `resolve_lid_batch`'s FIFO handed each the other's lid:

```
RESOLVED = …lid: 'aaaaaaaaaaa'}}/beta and …lid: 'bbbbbbbbbbb'}}/alpha
```

Both values stay valid, so Braze never self-corrects.

## Fix

A Liquid output tag is now one atom of the run:

```rust
https?://(?:\{\{[^{}]*\}\}|[^\s<>"'])+
```

The key covers the whole tag plus whatever follows it, so suffixes stay distinguishing — and `normalize_url`'s masking, **inert on this path before** (the run never reached the filter), now makes the key insensitive to the spacing `templatize` rewrites, i.e. everything from the `|` onward. Whitespace *before* the pipe is not absorbed; correlation survives that only because `templatize` leaves those bytes untouched.

Deliberately *not* widened to admit bare quotes: `'[^']*'` as a general alternative would swallow across prose (`He said "visit https://x.com/a" then "bye"`). Restricting the extension to a closed `{{…}}` is what keeps that safe — a stray `{` falls through to the character class, which admitted it already. A tag containing braces (this repo's own `{{content_blocks.${NAME} | id: 'cbN'}}`) is likewise not an atom, so that shape still keys the pre-fix way — tracked in #73, out of scope here.

`lid_anchor_for`'s whole-body plaintext scan — added in #69 as a defensive equivalent of the prefix scan — becomes load-bearing: the run now encloses the placeholder, so truncating at its offset would cut the tag in half. Its comment is updated, as is the now-stale note on #69's `plaintext_lid_inside_liquid_url_correlates` (which said masking never fires there).

## Bounding the run (review follow-ups)

Making the run span a tag has a second edge, since a tag may itself contain whitespace: the run could leap *out* of the URL. Three defects found while reviewing this branch, each fixed with a test that fails without its rule.

**Copy behind the link entered the anchor.** `…{{x | lid: 'liveeeeeeee1'}}.{{ old_copy }}` vs `…{{x | lid: '__BRAZESYNC__'}}.{{ new_copy }}` keyed differently, so editing the copy — link untouched — POSTed `lid: 'p_x_new_copy'` over the live value. Pre-PR the same input preserved it. The run now stops at the first `{{` after the managed filter's own tag closes; plain characters after the tag (`}}/alpha` vs `}}/beta`) are still kept, so symptom 2 stays fixed.

**Two links written back-to-back with only a tag between them** (`…/one{{ sep }}https://b…`) landed in a single anchor, so a reorder would transpose their lids. The run is now split at an embedded `https?://` — but only one that really begins a link. A scheme inside the query (`…/r?u=https://dest…`, a redirect target shared by many tracking links) or inside a `{{…}}` (a filter argument) must not split, and the query separator only ends the URL when it is *outside* a tag, so both exclusions are decided in one left-to-right scan.

**`MANAGED_FILTER_MASK` leaked out of the comparison layer.** The anchor key now carries the mask, and the fallback slug is derived from that key, so `| lid: 'p_sep_lid_x'` became `| lid: 'p_sep_lid_x_braze_managed'` — an internal sentinel POSTed to Braze as a live link identifier, on both the new-resource and drift-fallback paths. It is stripped in `url_path_tail`, and operator-facing anchors render it back as `| lid: '…'` instead of showing a URL that appears nowhere in the template.

Residual, recorded in the code: two links differing *only* by a Liquid tag after the filter share one anchor, where `resolve_lid_batch` already warns on a bucket holding more than one remote value.

## Coverage

Both regression cases #70 asked for, a guard on what must *not* change, and one test per follow-up rule:

- `plaintext_lid_round_trips_whatever_the_filter_spacing` — compact and spaced spellings through `templatize_body` + `prepare_field`, asserting the live value lands back in the token's place (identity up to templatize's canonicalization)
- `plaintext_urls_differing_only_after_the_filter_keep_distinct_anchors` — remote order reversed, each link must keep its own lid
- `plaintext_run_spans_liquid_tags_and_keys_past_them` — key-level assertion
- `plaintext_run_stops_at_whitespace_outside_a_liquid_tag` — the documented "URL, then lid tag after it" shape, a bare `| lid:` in prose, and quoted prose around a URL all key exactly as before
- `editing_copy_after_a_plaintext_link_keeps_the_live_lid` — end-to-end: the live lid survives an edit to the copy behind the link
- `plaintext_anchor_stops_at_a_tag_past_the_managed_filter` — both spellings of a trailing tag cut at the same point; plain characters after the tag still distinguish links
- `plaintext_anchor_splits_at_a_second_scheme` — the lid pairs with the link it sits on
- `plaintext_anchor_keeps_a_redirect_target_inside_the_link` — a scheme in the query, in a Liquid tag, and a `?` inside the separator tag
- `plaintext_fallback_slug_never_leaks_the_managed_filter_mask` — neither the POSTed lid nor operator output carries the sentinel

`cargo test` (407 lib + all integration), `cargo clippy --all-targets -D warnings`, `cargo fmt --check` clean. Multibyte and pathological runs (unclosed `{{`, `{{}}`, `}}` before `{{`, non-ASCII hosts) were exercised for slicing panics — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of plaintext URLs containing Liquid tags.
  * Preserved URL content following embedded filters and correctly distinguished links that differ after masked identifiers.
  * Improved URL boundary handling so links stop correctly at whitespace, quotation marks, or surrounding text.
  * Prevented internal masking markers from appearing in warnings, fallback metadata, or submitted link identifiers.

* **Documentation**
  * Updated resolution guidance to describe the expanded URL-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

