### PR TITLE
chore(deps): bump anyhow to 1.0.104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayref"


### PR DESCRIPTION
## Why

The RUSTSEC advisory against `anyhow` 1.0.102 ([dtolnay/anyhow#451](https://github.com/dtolnay/anyhow/issues/451)) is failing the `audit` and `deny` jobs on `main` and on every PR branch.

## What

`cargo update -p anyhow` → 1.0.104 (advisory requires >= 1.0.103). `Cargo.toml` already declares `anyhow = "1"`, so this is a lockfile-only change; no source or CHANGELOG changes.

## Verification (local)

- `cargo test --all-features` — all suites pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo deny --all-features check advisories` — `advisories ok`

## Note: `audit` job will still be red

Independent of this change, `cargo audit` reports **RUSTSEC-2026-0185** (high, 7.5) — remote memory exhaustion in `quinn-proto` 0.11.14, transitive via `reqwest` 0.12.28. `cargo-deny` does not flag it because feature resolution keeps `quinn` out of the actual graph (`reqwest`'s `http3` feature is off), but `rustsec/audit-check` scans `Cargo.lock` directly and will fail on it.

Left out of this PR deliberately: `cargo update -p quinn-proto` pulls 0.11.16 **and** bumps `rand` 0.9.2 → 0.10.2, dropping `rand_chacha`/`zerocopy`/`ppv-lite86` and adding `rand_pcg`. That is a much larger dependency change deserving its own review — and it may also allow dropping the `RUSTSEC-2026-0097` ignore in `.cargo/audit.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)