### PR TITLE
chore(deps): bump anyhow and quinn-proto for RUSTSEC advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,14 +3,4 @@
 # justify every entry — ignores silently mask future real findings.
 
 [advisories]
-ignore = [
-    # RUSTSEC-2026-0097: `rand` is unsound when a custom `log` logger
-    # calls `rand::rng()` from inside its log hook, while `ThreadRng`
-    # is attempting to reseed. We do not install any `log` logger
-    # (we use `tracing`) and never call `rand::rng()` from logging
-    # code paths, so this advisory does not apply to this binary.
-    # The advisory fires on rand 0.8.5 and 0.9.2, pulled in transitively
-    # (wiremock dev-dep). Re-check once that crate upgrades to
-    # rand >= 0.9.3 and drop this entry.
-    "RUSTSEC-2026-0097",
-]
+ignore = []

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,29 +632,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1168,15 +1168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,14 +1248,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1301,43 +1293,34 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -2518,26 +2501,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayref"


### PR DESCRIPTION
## Why

Two RUSTSEC advisories are failing the `audit` and `deny` jobs on `main` and on every PR branch:

- **anyhow 1.0.102** — unsoundness in `Error::downcast_mut()` ([dtolnay/anyhow#451](https://github.com/dtolnay/anyhow/issues/451)). Fails `deny`.
- **RUSTSEC-2026-0185** (high, 7.5) — remote memory exhaustion in `quinn-proto` 0.11.14 from unbounded out-of-order stream reassembly. Transitive via `reqwest` 0.12.28 → `quinn` 0.11.9. Fails `audit`.

These were originally split into two PRs, but neither could go green on its own: each branch was still missing the other's fix, so #74 was red on `audit` and this one was red on `deny`. Combined here so CI can actually pass before merge. #74 is closed in favour of this.

The two checks disagree because `cargo-deny` resolves features (so `quinn` drops out — `reqwest`'s `http3` is off) while `rustsec/audit-check` scans `Cargo.lock` directly. Each tool sees one advisory the other misses.

## What

`cargo update -p anyhow` → 1.0.104, and `cargo update -p quinn-proto` → 0.11.16. The latter carries `rand` 0.9.2 → 0.10.2 with it:

- dropped: `rand_chacha`, `zerocopy`, `zerocopy-derive`, `ppv-lite86`, `r-efi`, `getrandom` 0.3.4
- added: `chacha20`, `rand_pcg`

`Cargo.toml` already declares `anyhow = "1"`, and no first-party code depends on `rand` — it is transitive only. So the dependency change is lockfile-only.

**Also removes the `RUSTSEC-2026-0097` ignore from `.cargo/audit.toml`.** That advisory fires on `rand` 0.8.5 and 0.9.2; after this bump only 0.10.2 remains in the graph, so the entry is dead. Its own comment asked for removal once `rand` moved past 0.9.3.

Per repo convention, no CHANGELOG.md change — the release commit writes it.

## Verification (local)

- `cargo audit` — exit 0, no vulnerabilities (one remaining allowed warning: `number_prefix` unmaintained, already ignored in `deny.toml`)
- `cargo deny --all-features check advisories` — `advisories ok`
- `cargo test --all-features` — 11 suites, all pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)