### PR TITLE
fix: key plaintext anchors through include-bearing Liquid tags

### DIFF
--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -60,10 +60,13 @@ For every `apply` and `diff`:
    string and fragment dropped, and with any `| lid:` / `| id:` filter
    inside it masked out — so a URL assembled from Liquid (e.g.
    `href="{{ item.url }}{{ sep }}lid={{ x | lid: '…' }}"`, which has no
-   literal `?`) still correlates. In plaintext the bare URL is read
-   through whole `{{…}}` tags for the same reason, so the anchor keeps
-   whatever follows the tag and links that differ only past the filter
-   stay distinct.
+   literal `?`) still correlates. The whitespace around a masked filter
+   is masked with it, so reformatting `{{x|lid:'…'}}` to
+   `{{ x | lid: '…' }}` in the Braze dashboard does not lose the link.
+   In plaintext the bare URL is read through whole `{{…}}` tags —
+   including an embedded `${NAME}` — for the same reason, so the anchor
+   keeps the plain text following the tag and links that differ only
+   past the filter stay distinct.
 3. For each `__BRAZESYNC__` in a `| id:` argument inside a
    `{{content_blocks.${NAME} ...}}` include, it looks up the live
    `cb_id` under the same `${NAME}` in the remote body.

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -60,9 +60,13 @@ For every `apply` and `diff`:
    string and fragment dropped, and with any `| lid:` / `| id:` filter
    inside it masked out — so a URL assembled from Liquid (e.g.
    `href="{{ item.url }}{{ sep }}lid={{ x | lid: '…' }}"`, which has no
-   literal `?`) still correlates. The whitespace around a masked filter
-   is masked with it, so reformatting `{{x|lid:'…'}}` to
-   `{{ x | lid: '…' }}` in the Braze dashboard does not lose the link.
+   literal `?`) still correlates. The whitespace immediately around a
+   masked filter is masked with it, so respacing the filter itself —
+   `{{x|lid:'…'}}` to `{{x | lid: '…' }}` — survives a dashboard edit.
+   Whitespace *elsewhere* in the tag is not normalized, so a reformat
+   that also moves the bytes before the `|` (`{{x|…}}` to `{{ x | …}}`,
+   note the space after `{{`) still keys differently and falls back to a
+   generated `lid`. See #77 for the general fix.
    In plaintext the bare URL is read through whole `{{…}}` tags —
    including an embedded `${NAME}` — for the same reason, so the anchor
    keeps the plain text following the tag and links that differ only

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -66,7 +66,8 @@ For every `apply` and `diff`:
    Whitespace *elsewhere* in the tag is not normalized, so a reformat
    that also moves the bytes before the `|` (`{{x|…}}` to `{{ x | …}}`,
    note the space after `{{`) still keys differently and falls back to a
-   generated `lid`. See #77 for the general fix.
+   generated `lid`. The general fix is tracked in
+   <https://github.com/uny/braze-sync/issues/77>.
    In plaintext the bare URL is read through whole `{{…}}` tags —
    including an embedded `${NAME}` — for the same reason, so the anchor
    keeps the plain text following the tag and links that differ only

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -779,6 +779,46 @@ mod tests {
         assert_eq!(url_path_tail("https://x.com/"), "");
         assert_eq!(url_path_tail("https://x.com/sale"), "sale");
     }
+
+    #[test]
+    fn url_path_tail_strips_both_managed_sentinels_from_the_last_segment() {
+        // Both masks must be stripped, not just the lid one: the tail
+        // feeds `slug_for_lid`, whose output is POSTed as a live Braze
+        // `lid`. The include has to sit in the *final* segment or
+        // `rsplit('/')` discards it and the assertion cannot fail.
+        let cb = format!("https://x.com/{{{{content_blocks.${{base}}{MANAGED_CB_ID_MASK}}}}}");
+        assert_eq!(url_path_tail(&cb), "{{content_blocks.${base}}}");
+        assert_eq!(slug_for_lid(&url_path_tail(&cb)), "content_blocks_base");
+
+        let lid = format!("https://x.com/p{{{{x{MANAGED_LID_MASK}}}}}");
+        assert_eq!(url_path_tail(&lid), "p{{x}}");
+    }
+
+    #[test]
+    fn fallback_lid_never_carries_a_sentinel_from_an_include_only_anchor() {
+        // End-to-end companion to the above: the anchor is an include and
+        // nothing else, the remote has no matching href, so the fallback
+        // slug is derived from a key whose last segment is the masked
+        // include. `braze_managed` must not reach the POSTed value.
+        let template = r#"<a href="https://x.com/{{content_blocks.${base} | id: '__BRAZESYNC__'}}">{{x | lid: '__BRAZESYNC__'}}</a>"#;
+        let remote = "{{content_blocks.${base} | id: 'cb1'}}";
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert_eq!(
+            p.fallbacks
+                .iter()
+                .map(|f| f.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["content_blocks_base"],
+            "got: {:?}",
+            p.fallbacks
+        );
+        assert!(
+            !p.body.contains("braze_managed"),
+            "sentinel leaked: {}",
+            p.body
+        );
+    }
     #[test]
     fn liquid_separator_href_lid_correlates() {
         // The query separator comes from Liquid, so the href holds no
@@ -830,8 +870,11 @@ mod tests {
         // here despite `templatize` respacing the filter — each spelling
         // round-trips against its own remote, which is what
         // `plaintext_lid_round_trips_whatever_the_filter_spacing` pins.
-        // The two spellings do *not* produce the same key as each other
-        // (the space before `|` is outside the mask).
+        // The two spellings now *do* produce the same key as each other —
+        // the mask absorbs the whitespace on both sides of the filter (see
+        // `plaintext_run_spans_liquid_tags_and_keys_past_them`). What still
+        // separates keys is whitespace before the `|` that is not adjacent
+        // to it, e.g. the space in `{{ x`.
         let template = "Visit https://x.com/p{{sep}}lid={{x|lid:'__BRAZESYNC__'}} now";
         let remote = "Visit https://x.com/p{{sep}}lid={{x|lid:'liveeeeeeee1'}} now";
         let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -17,7 +17,7 @@ use regex_lite::Regex;
 use crate::values::correlation::{
     extract_cb_id_values, extract_html_lid_values, extract_lid_values_unanchored,
     extract_plaintext_lid_values, normalize_url, plaintext_url_anchors, slug_for_lid,
-    CbIdCorrelation, LidCorrelation, MANAGED_FILTER_MASK,
+    CbIdCorrelation, LidCorrelation, MANAGED_CB_ID_MASK, MANAGED_LID_MASK,
 };
 use crate::values::placeholder::{
     extract_placeholders, find_suspicious_placeholders, PlaceholderType, ResolutionError, TOKEN,
@@ -267,12 +267,14 @@ fn resolve_lid_batch(
     out
 }
 
-/// Render an anchor key for a human. The key carries
-/// `MANAGED_FILTER_MASK` where the Braze-managed filter stood — a
-/// comparison-only sentinel — so printing it verbatim shows the operator
-/// a URL that appears nowhere in their template.
+/// Render an anchor key for a human. The key carries a comparison-only
+/// sentinel where the Braze-managed filter stood, so printing it verbatim
+/// shows the operator a URL that appears nowhere in their template. Each
+/// sentinel renders back as the filter it replaced — a `| id:` inside an
+/// include must not read as `| lid:`.
 fn anchor_for_display(url: &str) -> String {
-    url.replace(MANAGED_FILTER_MASK, "| lid: '…'")
+    url.replace(MANAGED_LID_MASK, "| lid: '…'")
+        .replace(MANAGED_CB_ID_MASK, "| id: '…'")
 }
 
 /// Slug fallback for a single lid placeholder. `used` is shared across
@@ -426,12 +428,14 @@ fn unique(base: String, used: &mut BTreeMap<String, usize>) -> String {
 }
 
 fn url_path_tail(url: &str) -> String {
-    // The input is an anchor *key*, so it may carry `MANAGED_FILTER_MASK`
-    // — a comparison-only sentinel. The tail feeds `slug_for_lid`, whose
-    // output is POSTed as a live Braze `lid`, so strip it first or the
-    // slug reads `…_braze_managed`. Now that the plaintext run spans a
-    // whole `{{…}}`, the mask lands inside the key on that path too.
-    let url = &url.replace(MANAGED_FILTER_MASK, "");
+    // The input is an anchor *key*, so it may carry a comparison-only
+    // sentinel. The tail feeds `slug_for_lid`, whose output is POSTed as a
+    // live Braze `lid`, so strip them first or the slug reads
+    // `…_braze_managed`. Now that the plaintext run spans a whole `{{…}}`,
+    // a mask lands inside the key on that path too.
+    let url = &url
+        .replace(MANAGED_LID_MASK, "")
+        .replace(MANAGED_CB_ID_MASK, "");
     let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
     let path_start = after_scheme
         .find('/')
@@ -941,5 +945,74 @@ mod tests {
             "/alpha must keep its own lid, got: {}",
             p.body
         );
+    }
+    #[test]
+    fn plaintext_lid_survives_a_content_blocks_include_in_the_url() {
+        // `templatize` rebuilds the whole include, normalising the space
+        // before the pipe, so a compactly-written remote keys differently
+        // from its own template unless the mask absorbs that space.
+        let remote = "Go https://x.com/{{content_blocks.${cta}|id:'cb1'}}/a{{sep}}lid={{x | lid: 'aaaaaaaaaaa'}} now";
+        let t = templatize_body(remote, FieldKind::EmailPlainBody);
+        let p = prepare_field(&t.new_body, Some(remote), FieldKind::EmailPlainBody);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+        assert_eq!(
+            p.body,
+            t.new_body
+                .replace("| lid: '__BRAZESYNC__'", "| lid: 'aaaaaaaaaaa'")
+                .replace("| id: '__BRAZESYNC__'", "| id: 'cb1'"),
+            "the live lid and cb_id must land back in the tokens' places"
+        );
+    }
+
+    #[test]
+    fn plaintext_urls_differing_after_a_content_blocks_include_keep_distinct_anchors() {
+        let template = "Go https://x.com/{{content_blocks.${cta} | id: '__BRAZESYNC__'}}/alpha{{s}}lid={{x | lid: '__BRAZESYNC__'}} and \
+                        https://x.com/{{content_blocks.${cta} | id: '__BRAZESYNC__'}}/beta{{s}}lid={{x | lid: '__BRAZESYNC__'}} now";
+        let remote = "Go https://x.com/{{content_blocks.${cta} | id: 'cb1'}}/beta{{s}}lid={{x | lid: 'bbbbbbbbbbb'}} and \
+                      https://x.com/{{content_blocks.${cta} | id: 'cb1'}}/alpha{{s}}lid={{x | lid: 'aaaaaaaaaaa'}} now";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+        assert!(
+            p.body.contains("/alpha{{s}}lid={{x | lid: 'aaaaaaaaaaa'}}"),
+            "got: {}",
+            p.body
+        );
+        assert!(
+            p.body.contains("/beta{{s}}lid={{x | lid: 'bbbbbbbbbbb'}}"),
+            "got: {}",
+            p.body
+        );
+    }
+
+    #[test]
+    fn lid_survives_a_filter_respaced_on_the_braze_side() {
+        // The dashboard reformatted the filter. The key must not depend on
+        // that, or the live lid is silently replaced by a fallback slug.
+        let template =
+            r#"<a href="https://x.com/p{{sep}}lid={{ x | lid: '__BRAZESYNC__' }}">go</a>"#;
+        let remote = r#"<a href="https://x.com/p{{sep}}lid={{ x|lid:'liveeeeeeee1' }}">go</a>"#;
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+        assert!(p.body.contains("'liveeeeeeee1'"), "got: {}", p.body);
+    }
+    #[test]
+    fn anchor_shown_to_an_operator_names_the_filter_it_replaced() {
+        // The anchor key masks both managed filters. Rendering it back for
+        // a human must not relabel a `| id:` inside an include as `| lid:`,
+        // and no sentinel may reach the operator or the POSTed value —
+        // the key is comparison-only.
+        let template = r#"<a href="https://x.com/{{content_blocks.${cta} | id: '__BRAZESYNC__'}}/p{{sep}}lid={{x | lid: '__BRAZESYNC__'}}">go</a>"#;
+        let remote = "{{content_blocks.${cta} | id: 'cb1'}}";
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        let shown = format!("{:?}{:?}", p.warnings, p.fallbacks);
+        assert!(shown.contains("| id: '…'"), "got: {shown}");
+        assert!(shown.contains("| lid: '…'"), "got: {shown}");
+        let dump = format!("{shown}{}", p.body);
+        assert!(!dump.contains("braze-managed"), "sentinel leaked: {dump}");
+        assert!(!dump.contains("braze_managed"), "sentinel leaked: {dump}");
     }
 }

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -323,13 +323,18 @@ fn href_iter(body: &str) -> Vec<(usize, String)> {
 /// stay distinct — a further *tag* is cut, see
 /// [`bound_after_managed_tag`].
 ///
-/// What the mask does **not** absorb is whitespace to the left of the
-/// `|` — [`lid_filter_re`] starts matching at the pipe. Correlation
-/// survives that only because `templatize_body` rewrites from the `|`
-/// onward and leaves the bytes before it untouched, so both sides carry
-/// the same spelling. A filter respaced on the Braze side (`{{x|lid:…}}`
-/// edited to `{{ x | lid: … }}`) therefore does *not* correlate; the
-/// anchor misses and the live lid is replaced by a fallback slug.
+/// [`lid_filter_re`] absorbs the whitespace on *both* sides of the
+/// filter, so respacing the filter itself survives a dashboard edit.
+/// What it does **not** absorb is whitespace elsewhere in the tag —
+/// notably between `{{` and the expression. Those bytes stay verbatim in
+/// the key, and correlation survives only because `templatize_body`
+/// rewrites from the `|` onward and leaves them untouched, so both sides
+/// carry the same spelling. A reformat that moves them (`{{x|lid:…}}`
+/// edited to `{{ x | lid: … }}` — note the space after `{{`) therefore
+/// still does *not* correlate; the anchor misses and the live lid is
+/// replaced by a fallback slug. Normalizing whitespace across the whole
+/// tag would close that, but it has to be quote-aware — the space in
+/// `{{ sep | default: ' - ' }}` is identity, not formatting.
 pub(crate) fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
     plaintext_url_re()
         .find_iter(body)
@@ -710,6 +715,33 @@ mod tests {
                 "https://x.com/p{{sep}}lid={{x|<braze-managed-lid>}}/alpha",
                 "https://x.com/p{{sep}}lid={{x|<braze-managed-lid>}}/beta",
             ]
+        );
+    }
+
+    #[test]
+    fn tag_whose_interior_ends_in_a_brace_still_scans_correctly() {
+        // `plaintext_url_re` now atomizes `{{content_blocks.${NAME}}}`, so
+        // `liquid_tag_end` sees a tag whose interior itself ends in `}` and
+        // stops one byte early. The diff asserts that is inert for both
+        // scanners; pin it, because the inertness is a property of the
+        // input shape rather than of the code.
+        let anchors = plaintext_url_anchors("Go https://x.com/{{content_blocks.${cta}}}?u=1 end");
+        assert_eq!(
+            anchors.iter().map(|(_, u)| u.as_str()).collect::<Vec<_>>(),
+            vec!["https://x.com/{{content_blocks.${cta}}}"],
+            "the `?` after the tag must still cut the key"
+        );
+
+        let anchors = plaintext_url_anchors(
+            "Go https://a.example/{{content_blocks.${cta}}}https://b.example/two{{y | lid: 'bbbbbbbbbbb'}} end",
+        );
+        assert_eq!(
+            anchors.iter().map(|(_, u)| u.as_str()).collect::<Vec<_>>(),
+            vec![
+                "https://a.example/{{content_blocks.${cta}}}",
+                "https://b.example/two{{y|<braze-managed-lid>}}",
+            ],
+            "a scheme immediately after such a tag must still split"
         );
     }
 

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -18,14 +18,19 @@ use crate::values::placeholder::TOKEN;
 /// Shared pattern for raw lid values so templatize and correlation cannot drift.
 pub(crate) const LID_VALUE_PATTERN: &str = "[a-z0-9][a-z0-9_]*";
 
-/// Stand-in for a Braze-managed filter inside an anchor key. Contains no
-/// `?` / `#` so it survives the query/fragment cut below.
+/// Stand-ins for a Braze-managed filter inside an anchor key. Neither
+/// contains `?` / `#`, so both survive the query/fragment cut below.
 ///
-/// Comparison-only: it exists so both sides of a correlation collapse to
+/// Comparison-only: they exist so both sides of a correlation collapse to
 /// the same string. Anything that derives an *outgoing* value from an
-/// anchor key must strip it first (see `braze_managed::url_path_tail`) —
-/// leaking it would put `braze_managed` into a live Braze identifier.
-pub(crate) const MANAGED_FILTER_MASK: &str = "|<braze-managed>";
+/// anchor key must strip them first (see `braze_managed::url_path_tail`) —
+/// leaking one would put `braze_managed` into a live Braze identifier.
+///
+/// The two filters mask to distinct sentinels only so that a key rendered
+/// back for an operator names the filter that was actually there; for
+/// comparison a single sentinel would do.
+pub(crate) const MANAGED_LID_MASK: &str = "|<braze-managed-lid>";
+pub(crate) const MANAGED_CB_ID_MASK: &str = "|<braze-managed-id>";
 
 /// Normalize a URL for anchor comparison: mask Braze-managed filters,
 /// then keep `scheme://host/path` and drop `?query` / `#fragment`.
@@ -50,11 +55,18 @@ pub(crate) const MANAGED_FILTER_MASK: &str = "|<braze-managed>";
 /// truncate the key mid-tag, collapsing every link that differs only
 /// past that tag onto one anchor.
 pub fn normalize_url(url: &str) -> String {
-    let masked = lid_filter_re().replace_all(url, MANAGED_FILTER_MASK);
-    // `${1}` keeps the `{{content_blocks.${NAME}` prefix the cb_id regex
-    // had to capture; only the `| id: '…'` after it is masked.
-    let cb_replacement = format!("${{1}}{MANAGED_FILTER_MASK}");
-    let masked = cb_id_filter_re().replace_all(masked.as_ref(), cb_replacement.as_str());
+    let masked = lid_filter_re().replace_all(url, MANAGED_LID_MASK);
+    // The include prefix has to stay in the key to keep two different
+    // `${NAME}`s apart, but it cannot be kept *verbatim*: `templatize`
+    // rebuilds the whole include canonically, so a remote spelled any
+    // other way would key differently from its own template. Re-emit the
+    // canonical form from the captured name instead.
+    let masked = cb_id_filter_re().replace_all(masked.as_ref(), |caps: &regex_lite::Captures| {
+        format!(
+            "{{{{content_blocks.${{{name}}}{MANAGED_CB_ID_MASK}",
+            name = &caps[1]
+        )
+    });
     let stop = query_or_fragment_start(masked.as_ref()).unwrap_or(masked.len());
     masked[..stop].to_string()
 }
@@ -95,8 +107,14 @@ fn lid_filter_re() -> &'static Regex {
         // `| lid: 'X'` in either its live form or its templatized
         // `__BRAZESYNC__` form. `lid` is Braze's own filter, so matching it
         // by name anywhere is safe.
+        //
+        // The surrounding `\s*` is part of the mask: whitespace on either
+        // side of the filter is formatting, not identity. `templatize`
+        // rewrites from the `|` onward and so preserves what precedes it,
+        // but a filter respaced on the Braze side would otherwise key
+        // differently from the template and silently lose the live lid.
         let lid = format!("(?:{LID_VALUE_PATTERN}|{TOKEN})");
-        Regex::new(&format!(r#"\|\s*lid:\s*(?:"{lid}"|'{lid}')"#))
+        Regex::new(&format!(r#"\s*\|\s*lid:\s*(?:"{lid}"|'{lid}')\s*"#))
             .expect("lid filter regex is valid")
     })
 }
@@ -111,9 +129,15 @@ fn cb_id_filter_re() -> &'static Regex {
         // `| id: 'cbN'` would collapse two anchors that differ only in an
         // unrelated `id` filter, and `resolve_lid_batch`'s FIFO would then
         // hand each link the other's live lid.
+        //
+        // The whole include-up-to-the-value is consumed, capturing only
+        // `${NAME}`: every byte of it is formatting that `templatize`
+        // canonicalizes, so `normalize_url` re-emits it rather than
+        // keeping it. The include's closing `}}` is left in place — it is
+        // identical on both sides.
         let cb = format!("(?:cb[0-9]+|{TOKEN})");
         Regex::new(&format!(
-            r#"(\{{\{{\s*content_blocks\.\$\{{\s*[^\s}}|]+\s*\}}\s*)\|\s*id:\s*(?:"{cb}"|'{cb}')"#
+            r#"\{{\{{\s*content_blocks\.\$\{{\s*([^\s}}|]+)\s*\}}\s*\|\s*id:\s*(?:"{cb}"|'{cb}')\s*"#
         ))
         .expect("cb_id filter regex is valid")
     })
@@ -171,19 +195,18 @@ fn plaintext_url_re() -> &'static Regex {
         //      and `…{{x | lid: 'b'}}/two` collapse to one key and
         //      `resolve_lid_batch`'s FIFO hands each link the other's lid.
         //
-        // Spanning the tag also lets `normalize_url` mask the filter, so
-        // the key stops depending on the spacing `templatize` rewrites —
-        // everything from the `|` onward. Whitespace *before* the pipe is
-        // not absorbed (see `plaintext_url_anchors`), so this is not full
-        // formatting insensitivity.
+        // Spanning the tag also lets `normalize_url` mask the filter
+        // together with the whitespace around it, so the key stops
+        // depending on how the filter is spelled at all — by `templatize`
+        // on the way in, or by a dashboard edit on the way back.
         //
-        // The alternative only fires on a *closed*, brace-free `{{…}}`: a
-        // stray `{` falls through to the character class, which admits it
-        // anyway. A tag containing braces — notably this repo's own
-        // `{{content_blocks.${NAME} | id: 'cbN'}}` — is likewise *not* one
-        // atom, so a plaintext URL built from such an include still keys
-        // the pre-fix way.
-        Regex::new(r#"https?://(?:\{\{[^{}]*\}\}|[^\s<>"'])+"#)
+        // The alternative only fires on a *closed* `{{…}}`: a stray `{`
+        // falls through to the character class, which admits it anyway.
+        // One level of nesting is admitted for `${…}`, because this repo's
+        // own include form — `{{content_blocks.${NAME} | id: 'cbN'}}` —
+        // spells a brace inside the tag; without it that tag is not an
+        // atom and a URL built from an include keys the pre-fix way.
+        Regex::new(r#"https?://(?:\{\{(?:\$\{[^{}]*\}|[^{}])*\}\}|[^\s<>"'])+"#)
             .expect("plaintext URL regex is valid")
     })
 }
@@ -360,13 +383,14 @@ fn split_on_embedded_scheme(run: &str) -> Vec<(usize, &str)> {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i..].starts_with(b"{{") {
-            // Skip the whole tag rather than inspecting inside it. The
-            // first `}}` is the close for every tag `plaintext_url_re`
-            // matches as an atom, since `[^{}]*` admits no braces; a
-            // brace-bearing tag arrives here only via the character
-            // class, and lands mid-tag rather than past it. An unclosed
-            // `{{` ends the scan — splitting on a scheme inside what may
-            // be tag text is worse than not splitting.
+            // Skip the whole tag rather than inspecting inside it. Taking
+            // the first `}}` ends one byte early for a tag whose interior
+            // itself ends in `}` — `{{content_blocks.${NAME}}}` — leaving
+            // the scan on that `}`. Inert for both callers here: they look
+            // only for a scheme or a `?` / `#`, and nothing but the close
+            // follows. An unclosed `{{` ends the scan — splitting on a
+            // scheme inside what may be tag text is worse than not
+            // splitting.
             match liquid_tag_end(bytes, i) {
                 Some(end) => i = end,
                 None => break,
@@ -675,16 +699,16 @@ mod tests {
         );
         let keys: Vec<&str> = anchors.iter().map(|(_, u)| u.as_str()).collect();
         // The run covers the whole tag, so the suffix past it survives
-        // and the two links stay distinguishable. The filter itself is
-        // masked, which is what removes the dependence on the spacing
-        // `templatize` rewrites — note this is *not* symmetric across the
-        // pipe: the space before `|` survives into the first key, because
-        // `lid_filter_re` starts matching at the pipe.
+        // and the two links stay distinguishable. The filter is masked
+        // together with the whitespace around it, so the two spellings —
+        // spaced on the first link, compact on the second — reach the
+        // same key for the filter region and differ only where the links
+        // genuinely differ.
         assert_eq!(
             keys,
             vec![
-                "https://x.com/p{{sep}}lid={{x |<braze-managed>}}/alpha",
-                "https://x.com/p{{sep}}lid={{x|<braze-managed>}}/beta",
+                "https://x.com/p{{sep}}lid={{x|<braze-managed-lid>}}/alpha",
+                "https://x.com/p{{sep}}lid={{x|<braze-managed-lid>}}/beta",
             ]
         );
     }
@@ -727,13 +751,16 @@ mod tests {
             let anchors = plaintext_url_anchors(&body);
             assert_eq!(anchors.len(), 1, "{body}");
             assert_eq!(
-                anchors[0].1, "https://x.com/p{{x |<braze-managed>}}",
+                anchors[0].1, "https://x.com/p{{x|<braze-managed-lid>}}",
                 "{body}"
             );
         }
         // ...but plain characters after the tag still distinguish links.
         let anchors = plaintext_url_anchors("Go https://x.com/p{{x | lid: 'aaaaaaaaaaa'}}/alpha");
-        assert_eq!(anchors[0].1, "https://x.com/p{{x |<braze-managed>}}/alpha");
+        assert_eq!(
+            anchors[0].1,
+            "https://x.com/p{{x|<braze-managed-lid>}}/alpha"
+        );
     }
 
     #[test]
@@ -749,7 +776,7 @@ mod tests {
             keys,
             vec![
                 "https://a.example/one{{ sep }}",
-                "https://b.example/two{{y |<braze-managed>}}",
+                "https://b.example/two{{y|<braze-managed-lid>}}",
             ]
         );
         // The lid must pair with the link it sits on, not the first one.
@@ -757,7 +784,10 @@ mod tests {
             "Go https://a.example/one{{ sep }}https://b.example/two{{y | lid: 'bbbbbbbbbbb'}} end",
         );
         assert_eq!(pairs.len(), 1);
-        assert_eq!(pairs[0].url, "https://b.example/two{{y |<braze-managed>}}");
+        assert_eq!(
+            pairs[0].url,
+            "https://b.example/two{{y|<braze-managed-lid>}}"
+        );
     }
 
     #[test]
@@ -786,7 +816,7 @@ mod tests {
             keys,
             vec![
                 "https://a.example/one{{ sep | default: '?' }}",
-                "https://b.example/two{{y |<braze-managed>}}",
+                "https://b.example/two{{y|<braze-managed-lid>}}",
             ]
         );
 

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -720,11 +720,15 @@ mod tests {
 
     #[test]
     fn tag_whose_interior_ends_in_a_brace_still_scans_correctly() {
-        // `plaintext_url_re` now atomizes `{{content_blocks.${NAME}}}`, so
-        // `liquid_tag_end` sees a tag whose interior itself ends in `}` and
-        // stops one byte early. The diff asserts that is inert for both
-        // scanners; pin it, because the inertness is a property of the
-        // input shape rather than of the code.
+        // For `{{content_blocks.${NAME}}}` the interior itself ends in `}`,
+        // so `liquid_tag_end` takes the first `}}` one byte early and the
+        // scan resumes on the tag's last `}`. `split_on_embedded_scheme`
+        // argues that is inert (see its comment); pin it, because the
+        // inertness is a property of the input shape, not of the code.
+        // Reached from both directions — `plaintext_url_re` atomizes the
+        // shape here, and an HTML `href` carrying it goes through
+        // `href_iter` -> `normalize_url` -> `query_or_fragment_start`
+        // regardless of the plaintext run.
         let anchors = plaintext_url_anchors("Go https://x.com/{{content_blocks.${cta}}}?u=1 end");
         assert_eq!(
             anchors.iter().map(|(_, u)| u.as_str()).collect::<Vec<_>>(),
@@ -742,6 +746,12 @@ mod tests {
                 "https://b.example/two{{y|<braze-managed-lid>}}",
             ],
             "a scheme immediately after such a tag must still split"
+        );
+
+        // The HTML path reaches the same shape without any plaintext run.
+        assert_eq!(
+            normalize_url("https://x.com/{{content_blocks.${cta}}}?u=1"),
+            "https://x.com/{{content_blocks.${cta}}}"
         );
     }
 


### PR DESCRIPTION
Fixes #73. Both symptoms reproduced on `main` before the fix; each new test fails without its rule.

## Two independent gaps

**1. The atom cannot span a brace-bearing tag.** #72 made a Liquid tag one atom with `\{\{[^{}]*\}\}` — which cannot cross a tag whose interior spells a brace, i.e. this repo's own `${NAME}`. For `{{content_blocks.${NAME} | id: 'cbN'}}` the atom failed, the character class ate the tag byte by byte, and the run ended at the first interior space or quote — the pre-#72 behaviour. Now admits one level of `${…}` nesting.

**2. The include prefix was kept verbatim.** `cb_id_filter_re` preserved everything left of the `| id:` in the key, but `templatize` *rebuilds* the whole include canonically, so a remote spelled any other way keyed differently from its own template:

```
remote   key: https://x.com/{{content_blocks.${cta}|id
template key: https://x.com/{{content_blocks.${cta}
```

No bucket matched, and the live lid was replaced by a fallback slug on every apply — #68's impact. The regex now consumes the whole include-up-to-the-value, captures only `${NAME}`, and `normalize_url` re-emits the canonical form.

As #73 noted, **neither fix alone is enough**: (1) addresses the collapsed-anchor transposition, (2) addresses the destroyed lid.

## Whitespace is formatting, not identity

`lid_filter_re` now masks the whitespace on both sides of the filter too. lid correlation survived without this only because `templatize` rewrites from the `|` onward and so preserves what precedes it — but a filter **respaced on the Braze side** silently lost the live lid. Covered by `lid_survives_a_filter_respaced_on_the_braze_side`.

## Adjacent: the sentinel named the wrong filter

Both filters masked to one `MANAGED_FILTER_MASK`, so `anchor_for_display` rendered every mask as `| lid: '…'` — showing an operator `| lid:` where an include's `| id:` actually stood. Split into `MANAGED_LID_MASK` / `MANAGED_CB_ID_MASK` so each renders back as the filter it replaced. `url_path_tail` strips both, so neither reaches a live Braze identifier — pinned by `anchor_shown_to_an_operator_names_the_filter_it_replaced`, which also gives #71 the regression test it never had.

## Coverage

- `plaintext_lid_survives_a_content_blocks_include_in_the_url` — compact remote through `templatize_body` + `prepare_field`; live lid and cb_id must land back in the tokens' places
- `plaintext_urls_differing_after_a_content_blocks_include_keep_distinct_anchors` — remote order reversed
- `lid_survives_a_filter_respaced_on_the_braze_side`
- `anchor_shown_to_an_operator_names_the_filter_it_replaced`

Four existing expectations move because the space before the pipe is now absorbed — including `plaintext_run_spans_liquid_tags_and_keys_past_them`, which had pinned the two spellings as *different* keys. It now asserts they agree, which is the point.

Also corrected `split_on_embedded_scheme`'s comment: it claimed brace-bearing tags never arrive as atoms. They do now, and `liquid_tag_end` ends one byte early for `{{content_blocks.${NAME}}}` — inert for both callers, which look only for a scheme or `?` / `#`, and nothing but the close follows.

`cargo test` (all 11 binaries), `cargo clippy --all-targets -D warnings`, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching of plaintext URLs across Liquid tags, embedded expressions, and formatting changes.
  * Correctly distinguishes link identifiers from content-block identifiers.
  * Normalizes filter spacing and content-block includes for more consistent link handling.
  * Prevents internal masking markers from appearing in user-facing link anchors.
* **Tests**
  * Added coverage for URL correlation, content-block includes, filter spacing, and generated anchors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->