### PR TITLE
fix: key lid anchors independently of intra-tag whitespace

### DIFF
--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -64,11 +64,11 @@ For every `apply` and `diff`:
    treated as formatting rather than identity wherever it separates the
    tag's structure, so the ordinary dashboard reformat — `{{x|lid:'…'}}`
    to `{{ x | lid: '…' }}` and back — keys the same and keeps the live
-   `lid`. Whitespace that is part of a *value* is kept, because two
-   spellings there really are two different links: inside a quoted
+   `lid`. Whitespace inside the tag's two *literal* regions is kept,
+   because two spellings there really are two different links: a quoted
    argument (`{{ sep | default: ' - ' }}` vs `{{ sep | default: '-' }}`)
-   and between the characters of a name (`${first name}` vs
-   `${firstname}`) stay distinct anchors, as they must.
+   and a `${…}` name (`${first name}` vs `${firstname}`, and likewise
+   `${Plan (US)}` vs `${Plan(US)}`) stay distinct anchors, as they must.
    Two narrower cases still key on their spacing, and a reformat there
    falls back to a generated `lid`: an *unclosed* `{{`, whose extent is
    unknown, and a tag carrying a literal `}}` inside a quoted argument,

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -60,14 +60,14 @@ For every `apply` and `diff`:
    string and fragment dropped, and with any `| lid:` / `| id:` filter
    inside it masked out — so a URL assembled from Liquid (e.g.
    `href="{{ item.url }}{{ sep }}lid={{ x | lid: '…' }}"`, which has no
-   literal `?`) still correlates. The whitespace immediately around a
-   masked filter is masked with it, so respacing the filter itself —
-   `{{x|lid:'…'}}` to `{{x | lid: '…' }}` — survives a dashboard edit.
-   Whitespace *elsewhere* in the tag is not normalized, so a reformat
-   that also moves the bytes before the `|` (`{{x|…}}` to `{{ x | …}}`,
-   note the space after `{{`) still keys differently and falls back to a
-   generated `lid`. The general fix is tracked in
-   <https://github.com/uny/braze-sync/issues/77>.
+   literal `?`) still correlates. Whitespace *anywhere* inside a
+   `{{…}}` is treated as formatting rather than identity, so any
+   dashboard reformat of the tag — `{{x|lid:'…'}}` to
+   `{{ x | lid: '…' }}` and back — keys the same and keeps the live
+   `lid`. The one exception is whitespace inside a quoted argument,
+   which is part of the value: `{{ sep | default: ' - ' }}` and
+   `{{ sep | default: '-' }}` stay two distinct anchors, as they must,
+   since they render two different links.
    In plaintext the bare URL is read through whole `{{…}}` tags —
    including an embedded `${NAME}` — for the same reason, so the anchor
    keeps the plain text following the tag and links that differ only

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -69,11 +69,18 @@ For every `apply` and `diff`:
    argument (`{{ sep | default: ' - ' }}` vs `{{ sep | default: '-' }}`)
    and a `${…}` name (`${first name}` vs `${firstname}`, and likewise
    `${Plan (US)}` vs `${Plan(US)}`) stay distinct anchors, as they must.
+   The padding *around* a name is formatting, though, so `${ plan }` and
+   `${plan}` are one anchor.
    Two narrower cases still key on their spacing, and a reformat there
    falls back to a generated `lid`: an *unclosed* `{{`, whose extent is
    unknown, and a tag carrying a literal `}}` inside a quoted argument,
    which ends the tag early. Both are rare enough that widening the rule
    was judged not worth the risk of merging two distinct links.
+   Separately, a content block whose *name* contains a space
+   (`{{content_blocks.${Plan (US)} | id: '…'}}`) does not correlate at
+   all — no `${NAME}` pattern in braze-sync accepts one — so its `cb_id`
+   and any `lid` anchored on that URL both fall back. That predates this
+   rule and is unchanged by it.
    In plaintext the bare URL is read through whole `{{…}}` tags —
    including an embedded `${NAME}` — for the same reason, so the anchor
    keeps the plain text following the tag and links that differ only

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -60,14 +60,20 @@ For every `apply` and `diff`:
    string and fragment dropped, and with any `| lid:` / `| id:` filter
    inside it masked out — so a URL assembled from Liquid (e.g.
    `href="{{ item.url }}{{ sep }}lid={{ x | lid: '…' }}"`, which has no
-   literal `?`) still correlates. Whitespace *anywhere* inside a
-   `{{…}}` is treated as formatting rather than identity, so any
-   dashboard reformat of the tag — `{{x|lid:'…'}}` to
-   `{{ x | lid: '…' }}` and back — keys the same and keeps the live
-   `lid`. The one exception is whitespace inside a quoted argument,
-   which is part of the value: `{{ sep | default: ' - ' }}` and
-   `{{ sep | default: '-' }}` stay two distinct anchors, as they must,
-   since they render two different links.
+   literal `?`) still correlates. Whitespace inside a closed `{{…}}` is
+   treated as formatting rather than identity wherever it separates the
+   tag's structure, so the ordinary dashboard reformat — `{{x|lid:'…'}}`
+   to `{{ x | lid: '…' }}` and back — keys the same and keeps the live
+   `lid`. Whitespace that is part of a *value* is kept, because two
+   spellings there really are two different links: inside a quoted
+   argument (`{{ sep | default: ' - ' }}` vs `{{ sep | default: '-' }}`)
+   and between the characters of a name (`${first name}` vs
+   `${firstname}`) stay distinct anchors, as they must.
+   Two narrower cases still key on their spacing, and a reformat there
+   falls back to a generated `lid`: an *unclosed* `{{`, whose extent is
+   unknown, and a tag carrying a literal `}}` inside a quoted argument,
+   which ends the tag early. Both are rare enough that widening the rule
+   was judged not worth the risk of merging two distinct links.
    In plaintext the bare URL is read through whole `{{…}}` tags —
    including an embedded `${NAME}` — for the same reason, so the anchor
    keeps the plain text following the tag and links that differ only

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -1075,23 +1075,34 @@ mod tests {
         // the spaces inside `default: '…'`, which are the value — if the
         // normalization collapsed them the two anchors would share one
         // FIFO bucket and each link would take the other's live lid.
-        let template = "https://x.com/{{sep|default:' - '}}{{a|lid:'__BRAZESYNC__'}} \
-                        https://x.com/{{sep|default:'-'}}{{b|lid:'__BRAZESYNC__'}}";
-        let remote = "https://x.com/{{ sep | default: ' - ' }}{{ a | lid: 'liveeeeeeee1' }} \
-                      https://x.com/{{ sep | default: '-' }}{{ b | lid: 'liveeeeeeee2' }}";
+        //
+        // Three details are what make this test able to *fail*. The lid
+        // tag spells the same variable on both links, so the quoted
+        // argument is genuinely the only difference (a `{{a|…}}` /
+        // `{{b|…}}` pair would key apart on the name alone, whatever the
+        // normalization did with the quotes). The remote lists the links
+        // in the opposite order, so a merged bucket hands out the wrong
+        // value rather than accidentally the right one. And `warnings` is
+        // asserted empty, since a shared bucket also trips the
+        // "N remote lid occurrences" notice.
+        let template = "https://x.com/{{sep|default:' - '}}{{x|lid:'__BRAZESYNC__'}} \
+                        https://x.com/{{sep|default:'-'}}{{x|lid:'__BRAZESYNC__'}}";
+        let remote = "https://x.com/{{ sep | default: '-' }}{{ x | lid: 'liveeeeeeee2' }} \
+                      https://x.com/{{ sep | default: ' - ' }}{{ x | lid: 'liveeeeeeee1' }}";
         let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
         assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.warnings.is_empty(), "{:?}", p.warnings);
         assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
         // Each keeps its own lid: not transposed, not collapsed.
         assert!(
             p.body
-                .contains("{{sep|default:' - '}}{{a|lid:'liveeeeeeee1'}}"),
+                .contains("{{sep|default:' - '}}{{x|lid:'liveeeeeeee1'}}"),
             "got: {}",
             p.body
         );
         assert!(
             p.body
-                .contains("{{sep|default:'-'}}{{b|lid:'liveeeeeeee2'}}"),
+                .contains("{{sep|default:'-'}}{{x|lid:'liveeeeeeee2'}}"),
             "got: {}",
             p.body
         );

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -1042,6 +1042,62 @@ mod tests {
         assert!(p.body.contains("'liveeeeeeee1'"), "got: {}", p.body);
     }
     #[test]
+    fn lid_survives_a_tag_respaced_away_from_the_filter() {
+        // #77's reproduction: the dashboard moved bytes the filter masks
+        // do not reach — the space after `{{`, and the one before `}}`.
+        // Both spellings are the same link, on the HTML and the plaintext
+        // path alike, so the live lid must come through rather than the
+        // `p_sep_lid_x` fallback slug.
+        let cases = [
+            (
+                r#"<a href="https://x.com/p{{sep}}lid={{x|lid:'__BRAZESYNC__'}}">go</a>"#,
+                r#"<a href="https://x.com/p{{ sep }}lid={{ x | lid: 'liveeeeeeee1' }}">go</a>"#,
+                FieldKind::ContentBlock,
+            ),
+            (
+                "Go https://x.com/p{{sep}}lid={{x|lid:'__BRAZESYNC__'}} now",
+                "Go https://x.com/p{{ sep }}lid={{ x | lid: 'liveeeeeeee1' }} now",
+                FieldKind::EmailPlainBody,
+            ),
+        ];
+        for (template, remote, field) in cases {
+            let p = prepare_field(template, Some(remote), field);
+            assert!(p.errors.is_empty(), "{:?}", p.errors);
+            assert!(p.warnings.is_empty(), "{:?}", p.warnings);
+            assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
+            assert!(p.body.contains("'liveeeeeeee1'"), "got: {}", p.body);
+        }
+    }
+
+    #[test]
+    fn respacing_does_not_merge_links_differing_inside_a_quoted_argument() {
+        // The other side of the same pass. These two links differ only by
+        // the spaces inside `default: '…'`, which are the value — if the
+        // normalization collapsed them the two anchors would share one
+        // FIFO bucket and each link would take the other's live lid.
+        let template = "https://x.com/{{sep|default:' - '}}{{a|lid:'__BRAZESYNC__'}} \
+                        https://x.com/{{sep|default:'-'}}{{b|lid:'__BRAZESYNC__'}}";
+        let remote = "https://x.com/{{ sep | default: ' - ' }}{{ a | lid: 'liveeeeeeee1' }} \
+                      https://x.com/{{ sep | default: '-' }}{{ b | lid: 'liveeeeeeee2' }}";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailPlainBody);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
+        // Each keeps its own lid: not transposed, not collapsed.
+        assert!(
+            p.body
+                .contains("{{sep|default:' - '}}{{a|lid:'liveeeeeeee1'}}"),
+            "got: {}",
+            p.body
+        );
+        assert!(
+            p.body
+                .contains("{{sep|default:'-'}}{{b|lid:'liveeeeeeee2'}}"),
+            "got: {}",
+            p.body
+        );
+    }
+
+    #[test]
     fn anchor_shown_to_an_operator_names_the_filter_it_replaced() {
         // The anchor key masks both managed filters. Rendering it back for
         // a human must not relabel a `| id:` inside an include as `| lid:`,

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -117,15 +117,21 @@ pub fn normalize_url(url: &str) -> String {
 ///   space inside a URL, so the pass does not carry the cost of tracking
 ///   raw spans.
 ///
-/// Quotes are not the only place unquoted whitespace is identity, which
-/// is why the drop is **neighbour-aware**: a run flanked by name bytes on
-/// both sides is kept. Braze addresses a personalization or content block
-/// whose name contains spaces as `${my attribute}` — unquoted, yet every
-/// byte of it is the name. Dropping there would key `${my attribute}` and
+/// A quoted string is not the only literal region inside a tag, so
+/// `${…}` is treated as a second one. Braze addresses a personalization
+/// or content block whose name contains spaces as `${my attribute}` —
+/// unquoted, yet every byte between the braces is the name, punctuation
+/// and all. Dropping there would key `${my attribute}` and
 /// `${myattribute}` alike, and one FIFO bucket for two links is the same
-/// corruption the quote rule exists to prevent. Whitespace that touches
-/// `{`, `}`, `|`, `:`, `,`, a quote, or the tag edge is the formatting
-/// this pass is here to remove, and is dropped.
+/// corruption the quote rule exists to prevent.
+///
+/// So the rule is regional, not per-character: whitespace inside quotes
+/// or inside `${…}` is content and is copied verbatim; whitespace
+/// anywhere else in the tag is formatting and is dropped. That keeps
+/// Liquid's own whitespace control (`{{- sep -}}` and `{{-sep-}}` key
+/// alike) without having to reason about which punctuation may appear in
+/// a name. An unterminated `${` keeps the rest of its tag verbatim, the
+/// same conservative direction as an unterminated quote.
 fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
     let bytes = url.as_bytes();
     if !bytes.windows(2).any(|w| w == b"{{") {
@@ -151,70 +157,44 @@ fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
         let interior = &bytes[i + "{{".len()..end - "}}".len()];
         out.extend_from_slice(b"{{");
         let mut quote: Option<u8> = None;
+        let mut in_name = false;
         let mut j = 0;
         while j < interior.len() {
             let byte = interior[j];
-            match quote {
-                Some(open) => {
-                    if byte == open {
-                        quote = None;
-                    }
-                    out.push(byte);
-                    j += 1;
+            if let Some(open) = quote {
+                if byte == open {
+                    quote = None;
                 }
-                None if byte == b'\'' || byte == b'"' => {
-                    quote = Some(byte);
-                    out.push(byte);
-                    j += 1;
+                out.push(byte);
+                j += 1;
+            } else if in_name {
+                // Verbatim to the closing brace, whitespace included, and
+                // not collapsed either: `${a  b}` and `${a b}` are two
+                // different names.
+                if byte == b'}' {
+                    in_name = false;
                 }
-                None if byte.is_ascii_whitespace() => {
-                    // Take the whole run at once: whether it is formatting
-                    // depends on what sits either side of it, not on the
-                    // individual byte.
-                    let run_end = interior[j..]
-                        .iter()
-                        .position(|b| !b.is_ascii_whitespace())
-                        .map(|rel| j + rel)
-                        .unwrap_or(interior.len());
-                    let inside_a_name = j > 0
-                        && run_end < interior.len()
-                        && is_name_byte(interior[j - 1])
-                        && is_name_byte(interior[run_end]);
-                    if inside_a_name {
-                        // Verbatim, not collapsed to a single space:
-                        // `${a  b}` and `${a b}` are different names.
-                        out.extend_from_slice(&interior[j..run_end]);
-                    }
-                    j = run_end;
-                }
-                None => {
-                    out.push(byte);
-                    j += 1;
-                }
+                out.push(byte);
+                j += 1;
+            } else if byte == b'\'' || byte == b'"' {
+                quote = Some(byte);
+                out.push(byte);
+                j += 1;
+            } else if interior[j..].starts_with(b"${") {
+                in_name = true;
+                out.extend_from_slice(b"${");
+                j += "${".len();
+            } else if byte.is_ascii_whitespace() {
+                j += 1;
+            } else {
+                out.push(byte);
+                j += 1;
             }
         }
         out.extend_from_slice(b"}}");
         i = end;
     }
     Cow::Owned(String::from_utf8(out).expect("only ASCII whitespace was dropped"))
-}
-
-/// A byte that can spell part of a name, so whitespace between two of
-/// them may be identity rather than layout.
-///
-/// Every non-ASCII byte counts: a `${…}` name may be written in any
-/// script, and a continuation byte must never read as a separator.
-/// Liquid's own separators (`|`, `:`, `,`, `.`, the braces, quotes) are
-/// deliberately excluded — whitespace touching one of those is the
-/// formatting this pass removes.
-///
-/// `-` is excluded with them, though a name may contain one: it is also
-/// Liquid's whitespace-control marker, and treating it as a name byte
-/// would key `{{- sep -}}` apart from `{{-sep-}}` — reinstating the very
-/// miss this pass fixes, for a far commoner spelling than a name with a
-/// space on either side of a hyphen.
-fn is_name_byte(byte: u8) -> bool {
-    !byte.is_ascii() || byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 /// If a Liquid output tag opens at `i`, the index just past its `}}`.
@@ -832,13 +812,13 @@ mod tests {
     }
 
     #[test]
-    fn normalize_preserves_whitespace_between_name_bytes() {
-        // Quotes are not the only place unquoted whitespace is identity.
-        // Braze spells a personalization or content block whose name has
-        // spaces as `${my attribute}` — no quotes anywhere, yet every byte
-        // is the name. Dropping there merges two different links onto one
-        // anchor and `resolve_lid_batch`'s FIFO transposes their live
-        // lids, which is the failure the quote rule exists to prevent.
+    fn normalize_preserves_whitespace_inside_a_name() {
+        // Quotes are not the only literal region inside a tag. Braze
+        // spells a personalization or content block whose name has spaces
+        // as `${my attribute}` — no quotes anywhere, yet every byte is the
+        // name. Dropping there merges two different links onto one anchor
+        // and `resolve_lid_batch`'s FIFO transposes their live lids, which
+        // is the failure the quote rule exists to prevent.
         assert_ne!(
             normalize_url("https://x.com/{{custom_attribute.${first name}}}/p"),
             normalize_url("https://x.com/{{custom_attribute.${firstname}}}/p")
@@ -865,12 +845,24 @@ mod tests {
             normalize_url("https://x.com/{{ 日本 | upcase }}/p"),
             "https://x.com/{{日本|upcase}}/p"
         );
-        // `-` is a separator here, not a name byte: it is Liquid's
-        // whitespace-control marker, and respacing one of those must keep
-        // correlating.
+        // Punctuation inside a name is name too — the region is what
+        // decides, not the character class, so a name is safe whatever it
+        // is spelled with.
+        assert_ne!(
+            normalize_url("https://x.com/{{custom_attribute.${Plan (US)}}}/p"),
+            normalize_url("https://x.com/{{custom_attribute.${Plan(US)}}}/p")
+        );
+        // Outside a name the same bytes are formatting, so Liquid's
+        // whitespace control still correlates across a respacing.
         assert_eq!(
             normalize_url("https://x.com/{{- sep -}}/p"),
             normalize_url("https://x.com/{{-sep-}}/p")
+        );
+        // An unterminated `${` keeps the rest of its tag verbatim, the
+        // same conservative direction as an unterminated quote.
+        assert_eq!(
+            normalize_url("https://x.com/{{ a.${oops | upcase }}/p"),
+            "https://x.com/{{a.${oops | upcase }}/p"
         );
     }
 

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -11,6 +11,7 @@
 //! - cb_id: anchor = `${NAME}` in the same Liquid include.
 
 use regex_lite::Regex;
+use std::borrow::Cow;
 use std::sync::OnceLock;
 
 use crate::values::placeholder::TOKEN;
@@ -55,7 +56,12 @@ pub(crate) const MANAGED_CB_ID_MASK: &str = "|<braze-managed-id>";
 /// truncate the key mid-tag, collapsing every link that differs only
 /// past that tag onto one anchor.
 pub fn normalize_url(url: &str) -> String {
-    let masked = lid_filter_re().replace_all(url, MANAGED_LID_MASK);
+    // Before masking: the masks are what let both sides agree on how the
+    // filter is spelled, and this is the same argument applied to the
+    // rest of the tag. Running it first also means the mask patterns see
+    // an already-despaced tag, so their own `\s*` simply matches empty.
+    let despaced = strip_liquid_tag_whitespace(url);
+    let masked = lid_filter_re().replace_all(&despaced, MANAGED_LID_MASK);
     // The include prefix has to stay in the key to keep two different
     // `${NAME}`s apart, but it cannot be kept *verbatim*: `templatize`
     // rebuilds the whole include canonically, so a remote spelled any
@@ -69,6 +75,82 @@ pub fn normalize_url(url: &str) -> String {
     });
     let stop = query_or_fragment_start(masked.as_ref()).unwrap_or(masked.len());
     masked[..stop].to_string()
+}
+
+/// Drop whitespace that sits inside a closed `{{…}}` and outside a
+/// quoted string.
+///
+/// Whitespace inside an output tag is formatting, not identity: a
+/// dashboard reformat may respace any position in the tag, and every
+/// respelling denotes the same link. Keeping those bytes in the key made
+/// the anchor miss and the live `lid` be replaced by a generated slug
+/// (#77). `cb_id` already tolerated this across its whole include, so
+/// this is what aligns `lid` with it rather than a new liberty.
+///
+/// **Quote-aware** is the whole difficulty. The spaces in
+/// `{{ sep | default: ' - ' }}` are the value, not layout, so collapsing
+/// them would key that tag the same as `{{ sep | default: '-' }}` — two
+/// genuinely different links sharing one anchor, which is worse than the
+/// bug being fixed, because `resolve_lid_batch`'s FIFO would then hand
+/// each link the other's live lid. Text between quotes is therefore
+/// copied verbatim. Liquid has no string escapes, so a quote of the
+/// opening kind always closes the run.
+///
+/// Scope is deliberately narrow:
+///
+/// - Only `{{…}}`. A `{%…%}` tag has statement syntax where a space can
+///   separate two bare tokens (`{% if a contains b %}`), so removing
+///   whitespace there could change meaning.
+/// - Only *closed* tags. An unclosed `{{` is left verbatim, matching
+///   [`liquid_tag_end`]'s policy: its extent is unknown, and despacing
+///   to end-of-input could reach text that is not tag interior at all.
+/// - An unterminated quote inside a tag keeps the rest of that tag
+///   verbatim, which is the conservative direction — it preserves
+///   distinctions rather than merging them.
+///
+/// Within `{{…}}` the tokens are separated by `|`, `:` and `,`, so bare
+/// tokens are not run together by this. Two tags that differ *only* by
+/// whitespace between bare tokens (`{{a b}}` vs `{{ab}}`) do collapse
+/// onto one key; neither is valid Liquid.
+fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
+    let bytes = url.as_bytes();
+    if !bytes.windows(2).any(|w| w == b"{{") {
+        return Cow::Borrowed(url);
+    }
+    // Byte-oriented, but UTF-8 safe: only ASCII whitespace is dropped,
+    // and no byte of a multi-byte sequence is ASCII.
+    let mut out: Vec<u8> = Vec::with_capacity(url.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let Some(end) = liquid_tag_end(bytes, i) else {
+            // Not a tag opening here, or one that never closes. In the
+            // latter case nothing further can close either, so the
+            // remainder is copied as-is.
+            if bytes[i..].starts_with(b"{{") {
+                out.extend_from_slice(&bytes[i..]);
+                break;
+            }
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        };
+        let interior = &bytes[i + "{{".len()..end - "}}".len()];
+        out.extend_from_slice(b"{{");
+        let mut quote: Option<u8> = None;
+        for &byte in interior {
+            match quote {
+                Some(open) if byte == open => quote = None,
+                Some(_) => {}
+                None if byte == b'\'' || byte == b'"' => quote = Some(byte),
+                None if byte.is_ascii_whitespace() => continue,
+                None => {}
+            }
+            out.push(byte);
+        }
+        out.extend_from_slice(b"}}");
+        i = end;
+    }
+    Cow::Owned(String::from_utf8(out).expect("only ASCII whitespace was dropped"))
 }
 
 /// If a Liquid output tag opens at `i`, the index just past its `}}`.
@@ -324,17 +406,11 @@ fn href_iter(body: &str) -> Vec<(usize, String)> {
 /// [`bound_after_managed_tag`].
 ///
 /// [`lid_filter_re`] absorbs the whitespace on *both* sides of the
-/// filter, so respacing the filter itself survives a dashboard edit.
-/// What it does **not** absorb is whitespace elsewhere in the tag —
-/// notably between `{{` and the expression. Those bytes stay verbatim in
-/// the key, and correlation survives only because `templatize_body`
-/// rewrites from the `|` onward and leaves them untouched, so both sides
-/// carry the same spelling. A reformat that moves them (`{{x|lid:…}}`
-/// edited to `{{ x | lid: … }}` — note the space after `{{`) therefore
-/// still does *not* correlate; the anchor misses and the live lid is
-/// replaced by a fallback slug. Normalizing whitespace across the whole
-/// tag would close that, but it has to be quote-aware — the space in
-/// `{{ sep | default: ' - ' }}` is identity, not formatting.
+/// filter, and [`strip_liquid_tag_whitespace`] absorbs the rest of it
+/// inside the tag, so the key does not depend on how the tag is spaced
+/// at all — however `templatize` writes it, however a dashboard edit
+/// rewrites it. Whitespace inside a quoted argument is the one part
+/// that stays: there it is the value, not layout.
 pub(crate) fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
     plaintext_url_re()
         .find_iter(body)
@@ -591,7 +667,7 @@ mod tests {
         );
         assert_eq!(
             normalize_url("https://x/{{ sep | default: '?' }}/alpha"),
-            "https://x/{{ sep | default: '?' }}/alpha"
+            "https://x/{{sep|default:'?'}}/alpha"
         );
         // The brace-free spelling already behaved this way — the two
         // must not disagree.
@@ -627,12 +703,100 @@ mod tests {
     }
 
     #[test]
+    fn normalize_ignores_whitespace_anywhere_inside_a_liquid_tag() {
+        // The masks cover the whitespace hugging the managed filter, but a
+        // dashboard reformat moves bytes elsewhere in the tag too. Every
+        // one of these spellings denotes the same link, so all must key
+        // alike (#77) — otherwise the anchor misses and the live lid is
+        // replaced by a generated slug.
+        let canonical = normalize_url("https://x.com/p{{sep}}lid={{x|lid:'__BRAZESYNC__'}}");
+        for respaced in [
+            // space after `{{`
+            "https://x.com/p{{ sep}}lid={{ x|lid:'liveeeeeeee1'}}",
+            // space before `}}`
+            "https://x.com/p{{sep }}lid={{x|lid:'liveeeeeeee1' }}",
+            // the issue's reproduction: both, plus around the filter
+            "https://x.com/p{{ sep }}lid={{ x | lid: 'liveeeeeeee1' }}",
+            // newlines and tabs count as formatting too
+            "https://x.com/p{{\n\tsep\n}}lid={{ x\t| lid: 'liveeeeeeee1' }}",
+        ] {
+            assert_eq!(normalize_url(respaced), canonical, "respaced: {respaced}");
+        }
+
+        // Between two *unmanaged* filters, which no mask reaches.
+        assert_eq!(
+            normalize_url("https://x.com/{{ a | append: 'b' | upcase }}"),
+            normalize_url("https://x.com/{{a|append:'b'|upcase}}")
+        );
+
+        // This is what `cb_id` already tolerated across its whole
+        // include; the point of the pass is that `lid` now matches it.
+        assert_eq!(
+            normalize_url("{{content_blocks.${base} | id: 'cb42'}}/go"),
+            normalize_url("{{content_blocks.${base}|id:'cb42'}}/go")
+        );
+    }
+
+    #[test]
+    fn normalize_preserves_whitespace_inside_a_quoted_argument() {
+        // The negative half of the pass, and the more dangerous one: the
+        // spaces in `' - '` are the value, not layout. Collapsing them
+        // would key two genuinely different links alike, and
+        // `resolve_lid_batch`'s FIFO would hand each the other's live lid
+        // — strictly worse than the miss #77 fixes.
+        assert_ne!(
+            normalize_url("https://x.com/{{ sep | default: ' - ' }}/a"),
+            normalize_url("https://x.com/{{ sep | default: '-' }}/a")
+        );
+        assert_eq!(
+            normalize_url("https://x.com/{{ sep | default: ' - ' }}/a"),
+            "https://x.com/{{sep|default:' - '}}/a"
+        );
+        // Double quotes delimit just the same, and a quote of the other
+        // kind inside is ordinary text.
+        assert_eq!(
+            normalize_url(r#"https://x.com/{{ sep | default: " it's here " }}"#),
+            r#"https://x.com/{{sep|default:" it's here "}}"#
+        );
+        // An unterminated quote keeps the rest of the tag verbatim —
+        // preserving a distinction is the safe direction.
+        assert_eq!(
+            normalize_url("https://x.com/{{ sep | default: ' oops }}/a"),
+            "https://x.com/{{sep|default:' oops }}/a"
+        );
+    }
+
+    #[test]
+    fn normalize_leaves_whitespace_outside_a_closed_output_tag_alone() {
+        // Only `{{…}}` is despaced. A `{%…%}` tag has statement syntax
+        // where a space separates bare tokens, and text outside any tag
+        // is the URL itself.
+        assert_eq!(
+            normalize_url("https://x.com/{% if a contains b %}/p"),
+            "https://x.com/{% if a contains b %}/p"
+        );
+        // An unclosed `{{` has unknown extent, so its whitespace is
+        // copied verbatim — same policy as `liquid_tag_end`'s other
+        // callers. (Filter masking is independent of this and still
+        // applies to an unclosed tag, so keep one out of the way here.)
+        assert_eq!(
+            normalize_url("https://x.com/{{ oops | upcase"),
+            "https://x.com/{{ oops | upcase"
+        );
+        // Multi-byte text in a tag survives the byte-level scan.
+        assert_eq!(
+            normalize_url("https://x.com/{{ sep | default: 'あ い' }}/日本"),
+            "https://x.com/{{sep|default:'あ い'}}/日本"
+        );
+    }
+
+    #[test]
     fn normalize_leaves_unrelated_filters_intact() {
         // Only the value shapes templatize round-trips are masked, so an
         // unrelated `id`-named filter still distinguishes two anchors.
         assert_eq!(
             normalize_url("{{ a | id: 'not-a-cb-id' }}"),
-            "{{ a | id: 'not-a-cb-id' }}"
+            "{{a|id:'not-a-cb-id'}}"
         );
         assert_ne!(
             normalize_url("{{ a | upcase }}"),
@@ -817,7 +981,7 @@ mod tests {
         assert_eq!(
             keys,
             vec![
-                "https://a.example/one{{ sep }}",
+                "https://a.example/one{{sep}}",
                 "https://b.example/two{{y|<braze-managed-lid>}}",
             ]
         );
@@ -857,7 +1021,7 @@ mod tests {
         assert_eq!(
             keys,
             vec![
-                "https://a.example/one{{ sep | default: '?' }}",
+                "https://a.example/one{{sep|default:'?'}}",
                 "https://b.example/two{{y|<braze-managed-lid>}}",
             ]
         );
@@ -869,7 +1033,7 @@ mod tests {
         assert_eq!(anchors.len(), 1);
         assert_eq!(
             anchors[0].1,
-            "https://x.com/{{ u | default: 'https://cdn.example/i' }}/end"
+            "https://x.com/{{u|default:'https://cdn.example/i'}}/end"
         );
     }
 

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -107,11 +107,25 @@ pub fn normalize_url(url: &str) -> String {
 /// - An unterminated quote inside a tag keeps the rest of that tag
 ///   verbatim, which is the conservative direction — it preserves
 ///   distinctions rather than merging them.
+/// - A `}}` *inside* a quoted argument ends the tag early, because
+///   [`liquid_tag_end`] is not quote-aware. The bytes past it keep their
+///   spacing, so `{{ u | append: '}}' }}` still keys differently from
+///   `{{u|append:'}}'}}`. Both sides missed before this pass too, so it
+///   is an uncovered case, not a regression.
+/// - Literal `{{…}}` text inside a `{% raw %}` block is despaced like
+///   any other tag. Reaching that needs a raw block *and* a literal
+///   space inside a URL, so the pass does not carry the cost of tracking
+///   raw spans.
 ///
-/// Within `{{…}}` the tokens are separated by `|`, `:` and `,`, so bare
-/// tokens are not run together by this. Two tags that differ *only* by
-/// whitespace between bare tokens (`{{a b}}` vs `{{ab}}`) do collapse
-/// onto one key; neither is valid Liquid.
+/// Quotes are not the only place unquoted whitespace is identity, which
+/// is why the drop is **neighbour-aware**: a run flanked by name bytes on
+/// both sides is kept. Braze addresses a personalization or content block
+/// whose name contains spaces as `${my attribute}` — unquoted, yet every
+/// byte of it is the name. Dropping there would key `${my attribute}` and
+/// `${myattribute}` alike, and one FIFO bucket for two links is the same
+/// corruption the quote rule exists to prevent. Whitespace that touches
+/// `{`, `}`, `|`, `:`, `,`, a quote, or the tag edge is the formatting
+/// this pass is here to remove, and is dropped.
 fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
     let bytes = url.as_bytes();
     if !bytes.windows(2).any(|w| w == b"{{") {
@@ -137,20 +151,70 @@ fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
         let interior = &bytes[i + "{{".len()..end - "}}".len()];
         out.extend_from_slice(b"{{");
         let mut quote: Option<u8> = None;
-        for &byte in interior {
+        let mut j = 0;
+        while j < interior.len() {
+            let byte = interior[j];
             match quote {
-                Some(open) if byte == open => quote = None,
-                Some(_) => {}
-                None if byte == b'\'' || byte == b'"' => quote = Some(byte),
-                None if byte.is_ascii_whitespace() => continue,
-                None => {}
+                Some(open) => {
+                    if byte == open {
+                        quote = None;
+                    }
+                    out.push(byte);
+                    j += 1;
+                }
+                None if byte == b'\'' || byte == b'"' => {
+                    quote = Some(byte);
+                    out.push(byte);
+                    j += 1;
+                }
+                None if byte.is_ascii_whitespace() => {
+                    // Take the whole run at once: whether it is formatting
+                    // depends on what sits either side of it, not on the
+                    // individual byte.
+                    let run_end = interior[j..]
+                        .iter()
+                        .position(|b| !b.is_ascii_whitespace())
+                        .map(|rel| j + rel)
+                        .unwrap_or(interior.len());
+                    let inside_a_name = j > 0
+                        && run_end < interior.len()
+                        && is_name_byte(interior[j - 1])
+                        && is_name_byte(interior[run_end]);
+                    if inside_a_name {
+                        // Verbatim, not collapsed to a single space:
+                        // `${a  b}` and `${a b}` are different names.
+                        out.extend_from_slice(&interior[j..run_end]);
+                    }
+                    j = run_end;
+                }
+                None => {
+                    out.push(byte);
+                    j += 1;
+                }
             }
-            out.push(byte);
         }
         out.extend_from_slice(b"}}");
         i = end;
     }
     Cow::Owned(String::from_utf8(out).expect("only ASCII whitespace was dropped"))
+}
+
+/// A byte that can spell part of a name, so whitespace between two of
+/// them may be identity rather than layout.
+///
+/// Every non-ASCII byte counts: a `${…}` name may be written in any
+/// script, and a continuation byte must never read as a separator.
+/// Liquid's own separators (`|`, `:`, `,`, `.`, the braces, quotes) are
+/// deliberately excluded — whitespace touching one of those is the
+/// formatting this pass removes.
+///
+/// `-` is excluded with them, though a name may contain one: it is also
+/// Liquid's whitespace-control marker, and treating it as a name byte
+/// would key `{{- sep -}}` apart from `{{-sep-}}` — reinstating the very
+/// miss this pass fixes, for a far commoner spelling than a name with a
+/// space on either side of a hyphen.
+fn is_name_byte(byte: u8) -> bool {
+    !byte.is_ascii() || byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 /// If a Liquid output tag opens at `i`, the index just past its `}}`.
@@ -406,11 +470,12 @@ fn href_iter(body: &str) -> Vec<(usize, String)> {
 /// [`bound_after_managed_tag`].
 ///
 /// [`lid_filter_re`] absorbs the whitespace on *both* sides of the
-/// filter, and [`strip_liquid_tag_whitespace`] absorbs the rest of it
-/// inside the tag, so the key does not depend on how the tag is spaced
-/// at all — however `templatize` writes it, however a dashboard edit
-/// rewrites it. Whitespace inside a quoted argument is the one part
-/// that stays: there it is the value, not layout.
+/// filter, and [`strip_liquid_tag_whitespace`] absorbs the structural
+/// whitespace elsewhere in the tag, so the key stops depending on how
+/// `templatize` writes the tag or how a dashboard edit rewrites it. What
+/// stays is whitespace that is part of a *value* — inside a quoted
+/// argument, or between the characters of a `${…}` name — plus the
+/// narrower cases that function's own doc lists.
 pub(crate) fn plaintext_url_anchors(body: &str) -> Vec<(usize, String)> {
     plaintext_url_re()
         .find_iter(body)
@@ -763,6 +828,49 @@ mod tests {
         assert_eq!(
             normalize_url("https://x.com/{{ sep | default: ' oops }}/a"),
             "https://x.com/{{sep|default:' oops }}/a"
+        );
+    }
+
+    #[test]
+    fn normalize_preserves_whitespace_between_name_bytes() {
+        // Quotes are not the only place unquoted whitespace is identity.
+        // Braze spells a personalization or content block whose name has
+        // spaces as `${my attribute}` — no quotes anywhere, yet every byte
+        // is the name. Dropping there merges two different links onto one
+        // anchor and `resolve_lid_batch`'s FIFO transposes their live
+        // lids, which is the failure the quote rule exists to prevent.
+        assert_ne!(
+            normalize_url("https://x.com/{{custom_attribute.${first name}}}/p"),
+            normalize_url("https://x.com/{{custom_attribute.${firstname}}}/p")
+        );
+        assert_eq!(
+            normalize_url("https://x.com/{{ custom_attribute.${first name} }}/p"),
+            "https://x.com/{{custom_attribute.${first name}}}/p"
+        );
+        // Kept verbatim, not collapsed: the width of the run is part of
+        // the name too.
+        assert_ne!(
+            normalize_url("https://x.com/{{${a  b}}}"),
+            normalize_url("https://x.com/{{${a b}}}")
+        );
+        // A name may be written in any script, so no non-ASCII byte may
+        // read as a separator.
+        assert_ne!(
+            normalize_url("https://x.com/{{${購入 日}}}"),
+            normalize_url("https://x.com/{{${購入日}}}")
+        );
+        // Whitespace touching a Liquid separator or the tag edge is still
+        // formatting, multi-byte tokens included.
+        assert_eq!(
+            normalize_url("https://x.com/{{ 日本 | upcase }}/p"),
+            "https://x.com/{{日本|upcase}}/p"
+        );
+        // `-` is a separator here, not a name byte: it is Liquid's
+        // whitespace-control marker, and respacing one of those must keep
+        // correlating.
+        assert_eq!(
+            normalize_url("https://x.com/{{- sep -}}/p"),
+            normalize_url("https://x.com/{{-sep-}}/p")
         );
     }
 

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -126,12 +126,23 @@ pub fn normalize_url(url: &str) -> String {
 /// corruption the quote rule exists to prevent.
 ///
 /// So the rule is regional, not per-character: whitespace inside quotes
-/// or inside `${…}` is content and is copied verbatim; whitespace
-/// anywhere else in the tag is formatting and is dropped. That keeps
-/// Liquid's own whitespace control (`{{- sep -}}` and `{{-sep-}}` key
-/// alike) without having to reason about which punctuation may appear in
-/// a name. An unterminated `${` keeps the rest of its tag verbatim, the
-/// same conservative direction as an unterminated quote.
+/// or *between the bytes of* a `${…}` name is content and is copied
+/// verbatim; whitespace anywhere else in the tag is formatting and is
+/// dropped. That keeps Liquid's own whitespace control (`{{- sep -}}` and
+/// `{{-sep-}}` key alike) without having to reason about which
+/// punctuation may appear in a name.
+///
+/// The padding *around* a name is formatting like any other, so it goes:
+/// `${ plan }` is the same name as `${plan}`, and this repo's own
+/// [`cb_id_filter_re`] reads it that way too. An unterminated `${` keeps
+/// the rest of its tag verbatim, the same conservative direction as an
+/// unterminated quote.
+///
+/// A name whose *interior* holds a space is preserved here but is not
+/// otherwise supported: every `${NAME}` pattern in this crate captures
+/// `[^\s}|]+`, so a `content_blocks.${Plan (US)}` include does not mask
+/// and its `lid` anchors do not correlate — as on `main`, and unchanged
+/// by this pass.
 fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
     let bytes = url.as_bytes();
     if !bytes.windows(2).any(|w| w == b"{{") {
@@ -157,7 +168,6 @@ fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
         let interior = &bytes[i + "{{".len()..end - "}}".len()];
         out.extend_from_slice(b"{{");
         let mut quote: Option<u8> = None;
-        let mut in_name = false;
         let mut j = 0;
         while j < interior.len() {
             let byte = interior[j];
@@ -167,23 +177,27 @@ fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
                 }
                 out.push(byte);
                 j += 1;
-            } else if in_name {
-                // Verbatim to the closing brace, whitespace included, and
-                // not collapsed either: `${a  b}` and `${a b}` are two
-                // different names.
-                if byte == b'}' {
-                    in_name = false;
-                }
-                out.push(byte);
-                j += 1;
             } else if byte == b'\'' || byte == b'"' {
                 quote = Some(byte);
                 out.push(byte);
                 j += 1;
             } else if interior[j..].starts_with(b"${") {
-                in_name = true;
+                let start = j + "${".len();
+                let Some(close) = interior[start..].iter().position(|&b| b == b'}') else {
+                    // Unterminated `${`: the rest of the tag is kept
+                    // verbatim, as for an unterminated quote.
+                    out.extend_from_slice(&interior[j..]);
+                    break;
+                };
+                let name = &interior[start..start + close];
                 out.extend_from_slice(b"${");
-                j += "${".len();
+                // The padding around a name is formatting like any other —
+                // `${ plan }` is the same name as `${plan}` — but what is
+                // *between* the name's own bytes is identity, and not
+                // collapsed either: `${a  b}` and `${a b}` differ.
+                out.extend_from_slice(name.trim_ascii());
+                out.push(b'}');
+                j = start + close + 1;
             } else if byte.is_ascii_whitespace() {
                 j += 1;
             } else {
@@ -857,6 +871,13 @@ mod tests {
         assert_eq!(
             normalize_url("https://x.com/{{- sep -}}/p"),
             normalize_url("https://x.com/{{-sep-}}/p")
+        );
+        // The padding *around* a name is formatting like any other, so a
+        // respacing of it still correlates — only what sits between the
+        // name's own bytes is identity.
+        assert_eq!(
+            normalize_url("https://x.com/{{custom_attribute.${plan}|lid:'__BRAZESYNC__'}}/p"),
+            normalize_url("https://x.com/{{ custom_attribute.${ plan } | lid: 'abc123def45' }}/p")
         );
         // An unterminated `${` keeps the rest of its tag verbatim, the
         // same conservative direction as an unterminated quote.


### PR DESCRIPTION
Closes #77.

## Problem

Whitespace inside a `{{…}}` is formatting, not identity, but the anchor key kept it verbatim in every position the managed-filter masks did not reach — notably the bytes before the `|`. A dashboard reformat of `{{x|lid:'…'}}` into `{{ x | lid: '…' }}` therefore keyed differently from the template, `by_url.get_mut` missed, and the live lid was replaced by a generated fallback slug.

Correlation had survived at all only by accident of spelling: `templatize_body` rewrites from the `|` onward and leaves the preceding bytes alone, so both sides happened to carry the same formatting.

## Fix

Normalize whitespace across the whole closed `{{…}}` span in `normalize_url`, before masking. `cb_id` already tolerated exactly this across its entire include (`cb_id_filter_re` matches from `\{\{\s*content_blocks` and re-emits a canonical prefix), so this aligns `lid` with the existing `cb_id` tolerance rather than granting a new liberty — the asymmetry the issue flagged.

**Quote-aware is the load-bearing part.** The spaces in `{{ sep | default: ' - ' }}` are the value, and collapsing them would key that link the same as `{{ sep | default: '-' }}` — one FIFO bucket for two different links, so `resolve_lid_batch` would hand each the other's live lid. That is strictly worse than the miss being fixed, so text between quotes is copied verbatim, and an unterminated quote keeps the rest of its tag verbatim too.

Scope stays narrow for the same reason:

- Only `{{…}}`. A `{%…%}` has statement syntax where a space separates bare tokens (`{% if a contains b %}`).
- Only *closed* tags. An unclosed `{{` has unknown extent — same policy as the other `liquid_tag_end` callers.

The scan is byte-oriented but UTF-8 safe: only ASCII whitespace is dropped, and no byte of a multi-byte sequence is ASCII.

## Tests

All four cases the issue asks for, plus its own reproduction end-to-end:

- `normalize_ignores_whitespace_anywhere_inside_a_liquid_tag` — space after `{{`, before `}}`, both, newlines/tabs, between unmanaged filters, and the `cb_id` parity assertion
- `normalize_preserves_whitespace_inside_a_quoted_argument` — the negative test (`' - '` ≠ `'-'`), both quote styles, unterminated quote
- `normalize_leaves_whitespace_outside_a_closed_output_tag_alone` — `{%…%}`, unclosed tag, multi-byte text
- `lid_survives_a_tag_respaced_away_from_the_filter` — the issue's repro at `prepare_field`, on both the HTML and plaintext paths: live `liveeeeeeee1` comes through instead of the `p_sep_lid_x` slug
- `respacing_does_not_merge_links_differing_inside_a_quoted_argument` — two links differing only in `default: '…'` keep their own lids, neither transposed nor collapsed

Four existing assertions spelled intra-tag spacing into expected keys and were updated to the normalized form; no behavior they covered changed. Notably `{{sep|default:'?'}}` still keeps its quoted `?` and still does not cut there.

## Docs

`docs/per-env-values.md` and the `plaintext_url_anchors` doc comment both documented the limitation; both rewritten to state the new tolerance and the quoted-argument exception.

## Verification

`cargo test` (11 binaries), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link and anchor matching when Liquid tags are reformatted with different spacing.
  * Preserved distinct results for quoted filter arguments, including arguments containing whitespace.
  * Improved correlation for managed filters in HTML and plaintext links.
  * Added safer handling for statement tags, incomplete tags, and UTF-8 content.
  * Updated documentation to reflect the improved matching behavior and removed outdated limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->