### PR TITLE
feat: add `diff --only-drift` to suppress in-sync resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,30 @@ The JSON shape is **frozen at v1.0** with an explicit `version: 1`
 field on the root. Future schema bumps will increment `version`, so
 CI consumers can branch on it.
 
+On a workspace with hundreds of resources, the table is mostly
+`no drift`. `diff --only-drift` keeps just the blocks a reviewer has to
+read — useful when CI posts the output into a pull request comment:
+
+```bash
+braze-sync diff --only-drift
+```
+
+```
+📝 Content Block: promo
+   ~ content changed (+5 -3)
+
+✅ Custom Attribute: visit_count
+   no drift
+   ℹ type mismatch: local number vs Braze string (run export to update)
+
+Summary: 1 changed, 384 in sync, 0 orphan, 0 destructive
+```
+
+Nothing is hidden that a reviewer needs: the `Summary:` trailer still
+counts every resource, and an in-sync resource that carries an
+informational line (like the type mismatch above) is kept. The flag is
+table-only — `--format json` always emits every resource.
+
 ## Verifying release artifacts
 
 Release archives from [GitHub Releases](https://github.com/uny/braze-sync/releases)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ read — useful when CI posts the output into a pull request comment:
 braze-sync diff --only-drift
 ```
 
-```
+```text
 📝 Content Block: promo
    ~ content changed (+5 -3)
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -147,27 +147,55 @@ comment limit. Pass `--only-drift` to keep just the blocks that need
 attention:
 
 ```yaml
-      - id: diff
-        run: |
-          braze-sync diff --env prod --only-drift > diff.txt
+  # A second job in the drift-check workflow above.
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # createComment needs this
+    steps:
+      - uses: actions/checkout@v4
+      - uses: uny/setup-braze-sync@v1
+      - run: braze-sync diff --env prod --only-drift > diff.txt
+        env:
+          BRAZE_PROD_API_KEY: ${{ secrets.BRAZE_PROD_API_KEY }}
       - uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            github.rest.issues.createComment({
+            let out = fs.readFileSync('diff.txt', 'utf8');
+            // A comment body over 65536 chars is rejected outright, so a
+            // workspace that drifts badly enough would post nothing at
+            // all. Clip instead, and say so.
+            const LIMIT = 65000;
+            if (out.length > LIMIT) {
+              out = out.slice(0, LIMIT) +
+                '\n… truncated — see the full diff in the step log\n';
+            }
+            // Resource names come from Braze and may contain backticks,
+            // so pick a fence longer than any run in the output rather
+            // than hard-coding three.
+            const runs = out.match(/`+/g) || [];
+            const fence = '`'.repeat(Math.max(3, ...runs.map((r) => r.length + 1)));
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '```\n' + fs.readFileSync('diff.txt', 'utf8') + '```',
+              body: `${fence}text\n${out}${fence}`,
             });
 ```
 
 `--only-drift` drops only the blocks whose entire body is `no drift`.
 An in-sync resource that still carries an informational line — a Custom
 Attribute type mismatch, for example — stays in the output, and the
-`Summary:` trailer keeps counting every resource, so the comment is
-still a complete account of the workspace. The flag does not affect
+`Summary:` trailer keeps counting every resource, so no drifting
+resource is missing from the comment. The flag does not affect
 `--format json`.
+
+One caveat on the redirect rather than the flag: `> diff.txt` captures
+stdout only, and `diff` writes its fallback-`lid` notices and other
+warnings to **stderr**. Append `2>&1` if the comment should carry those
+too; otherwise they stay in the step log.
 
 ## Secrets hygiene
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -138,6 +138,37 @@ jq '.summary' diff.json
 `destructive` and `orphan` are the two counts worth surfacing in PR
 comments — they are the changes the reviewer most needs to eyeball.
 
+## Posting the diff into a PR comment
+
+The table output is meant to be read by a human, but on a workspace
+with a few hundred resources almost every line is `no drift`, which
+buries the review material and eats into GitHub's 65536-character
+comment limit. Pass `--only-drift` to keep just the blocks that need
+attention:
+
+```yaml
+      - id: diff
+        run: |
+          braze-sync diff --env prod --only-drift > diff.txt
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '```\n' + fs.readFileSync('diff.txt', 'utf8') + '```',
+            });
+```
+
+`--only-drift` drops only the blocks whose entire body is `no drift`.
+An in-sync resource that still carries an informational line — a Custom
+Attribute type mismatch, for example — stays in the output, and the
+`Summary:` trailer keeps counting every resource, so the comment is
+still a complete account of the workspace. The flag does not affect
+`--format json`.
+
 ## Secrets hygiene
 
 - API keys live in CI secrets, never in `braze-sync.config.yaml`.

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -19,7 +19,7 @@ use crate::diff::email_template::{EmailTemplateDiff, EmailTemplateIdIndex};
 use crate::diff::plan::{self, PlanFile};
 use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::error::Error;
-use crate::format::OutputFormat;
+use crate::format::{OutputFormat, TableFormatter};
 use crate::resource::ResourceKind;
 use crate::values::{format_fallback_reports, FallbackReport};
 use anyhow::{anyhow, Context as _};
@@ -191,7 +191,10 @@ pub async fn run(
         "Plan (dry-run, pass --confirm to apply):"
     };
     eprintln!("{mode_label}");
-    print!("{}", format.formatter().format(&summary));
+    print!(
+        "{}",
+        format.formatter(TableFormatter::default()).format(&summary)
+    );
     let fallback_block = format_fallback_reports(&fallback_reports);
     if !fallback_block.is_empty() {
         eprint!("{fallback_block}");

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -19,7 +19,7 @@ use crate::diff::plan::PlanFile;
 use crate::diff::tag::diff as diff_tags;
 use crate::diff::{DiffSummary, ResourceDiff};
 use crate::error::Error;
-use crate::format::OutputFormat;
+use crate::format::{OutputFormat, TableFormatter};
 use crate::fs::{catalog_io, content_block_io, custom_attribute_io, email_template_io, tag_io};
 use crate::resource::{Catalog, ContentBlock, EmailTemplate, ResourceKind};
 use crate::values::{
@@ -49,6 +49,14 @@ pub struct DiffArgs {
     /// Exit with code 2 if any drift is detected. Intended for CI gates.
     #[arg(long)]
     pub fail_on_drift: bool,
+
+    /// Omit in-sync resources from the table output, keeping only the
+    /// blocks a reviewer has to read. In-sync resources that still carry
+    /// an informational line (e.g. a Custom Attribute type mismatch) are
+    /// kept, and the `Summary:` trailer still counts every resource.
+    /// No effect on `--format json`.
+    #[arg(long)]
+    pub only_drift: bool,
 
     /// Write a plan file (JSON) to this path. The file freezes the set of
     /// actionable ops so a later `apply --plan=<path>` can refuse to run
@@ -139,7 +147,11 @@ pub async fn run(
         }
     }
 
-    let formatted = format.formatter().format(&summary);
+    let formatted = format
+        .formatter(TableFormatter {
+            only_drift: args.only_drift,
+        })
+        .format(&summary);
     print!("{formatted}");
     let fallback_block = format_fallback_reports(&fallback_reports);
     if !fallback_block.is_empty() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -341,7 +341,18 @@ mod tests {
             panic!("expected Diff subcommand");
         };
         assert!(args.fail_on_drift);
+        assert!(!args.only_drift);
         assert_eq!(args.resource, None);
+    }
+
+    #[test]
+    fn parses_diff_with_only_drift() {
+        let cli = Cli::try_parse_from(["braze-sync", "diff", "--only-drift"]).unwrap();
+        let Command::Diff(args) = cli.command else {
+            panic!("expected Diff subcommand");
+        };
+        assert!(args.only_drift);
+        assert!(!args.fail_on_drift);
     }
 
     #[test]

--- a/src/format/fixtures.rs
+++ b/src/format/fixtures.rs
@@ -7,6 +7,7 @@ use crate::diff::catalog::diff_schema;
 use crate::diff::content_block::{diff as diff_content_block, ContentBlockDiff};
 use crate::diff::custom_attribute::{CustomAttributeDiff, CustomAttributeOp};
 use crate::diff::email_template::EmailTemplateDiff;
+use crate::diff::tag::{TagDiff, TagOp};
 use crate::diff::TextDiffSummary;
 use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::resource::{Catalog, CatalogField, CatalogFieldType, ContentBlock, ContentBlockState};
@@ -219,6 +220,19 @@ pub fn mostly_in_sync_with_one_change() -> DiffSummary {
 
     let et_orphan = EmailTemplateDiff::orphan("legacy_welcome");
 
+    // In sync and silent: the suppressible shape for this kind. Present
+    // so the `NO_DRIFT_BODY` exact-match contract is pinned for email
+    // templates too, not just catalogs and content blocks.
+    let et_in_sync = EmailTemplateDiff {
+        name: "receipt".into(),
+        op: DiffOp::Unchanged,
+        subject_changed: false,
+        body_html_diff: None,
+        body_plaintext_diff: None,
+        metadata_changed: false,
+        orphan: false,
+    };
+
     // In sync, but the hint must survive `--only-drift`.
     let ca = CustomAttributeDiff {
         name: "visit_count".into(),
@@ -226,13 +240,32 @@ pub fn mostly_in_sync_with_one_change() -> DiffSummary {
         hints: vec!["type mismatch: local number vs Braze string (run export to update)".into()],
     };
 
+    let tag_in_sync = TagDiff {
+        name: "transactional".into(),
+        op: TagOp::Unchanged,
+        hints: vec![],
+    };
+
+    // `tag::diff` cannot produce this today, but `TagDiff` permits it and
+    // the flag's contract is "an in-sync resource that still says
+    // something stays visible" — pin it for every kind that has hints,
+    // so the next producer of tag hints cannot silently lose the block.
+    let tag_with_hint = TagDiff {
+        name: "seasonal".into(),
+        op: TagOp::Unchanged,
+        hints: vec!["registered in two environments with different casing".into()],
+    };
+
     DiffSummary {
         diffs: vec![
             ResourceDiff::CatalogSchema(cs),
             ResourceDiff::ContentBlock(cb_in_sync),
             ResourceDiff::ContentBlock(cb),
+            ResourceDiff::EmailTemplate(et_in_sync),
             ResourceDiff::EmailTemplate(et_orphan),
             ResourceDiff::CustomAttribute(ca),
+            ResourceDiff::Tag(tag_in_sync),
+            ResourceDiff::Tag(tag_with_hint),
         ],
     }
 }

--- a/src/format/fixtures.rs
+++ b/src/format/fixtures.rs
@@ -175,6 +175,68 @@ pub fn all_kinds_mixed() -> DiffSummary {
     }
 }
 
+/// The shape `diff --only-drift` exists for: mostly in-sync resources,
+/// one real change, one orphan, and one in-sync resource that still has
+/// something to say. Only the bare `no drift` blocks may be suppressed.
+pub fn mostly_in_sync_with_one_change() -> DiffSummary {
+    let stable = Catalog {
+        name: "stable".into(),
+        description: None,
+        fields: vec![field("id", CatalogFieldType::String)],
+    };
+    let cs = diff_schema(Some(&stable), Some(&stable)).unwrap();
+
+    let cb_from = ContentBlock {
+        name: "promo".into(),
+        description: None,
+        content: "old".into(),
+        tags: vec![],
+        state: ContentBlockState::Active,
+    };
+    let cb_to = ContentBlock {
+        content: "new".into(),
+        ..cb_from.clone()
+    };
+    let cb = ContentBlockDiff {
+        name: "promo".into(),
+        op: DiffOp::Modified {
+            from: cb_from,
+            to: cb_to,
+        },
+        text_diff: Some(TextDiffSummary {
+            additions: 5,
+            deletions: 3,
+        }),
+        orphan: false,
+    };
+
+    let cb_in_sync = ContentBlockDiff {
+        name: "footer".into(),
+        op: DiffOp::Unchanged,
+        text_diff: None,
+        orphan: false,
+    };
+
+    let et_orphan = EmailTemplateDiff::orphan("legacy_welcome");
+
+    // In sync, but the hint must survive `--only-drift`.
+    let ca = CustomAttributeDiff {
+        name: "visit_count".into(),
+        op: CustomAttributeOp::Unchanged,
+        hints: vec!["type mismatch: local number vs Braze string (run export to update)".into()],
+    };
+
+    DiffSummary {
+        diffs: vec![
+            ResourceDiff::CatalogSchema(cs),
+            ResourceDiff::ContentBlock(cb_in_sync),
+            ResourceDiff::ContentBlock(cb),
+            ResourceDiff::EmailTemplate(et_orphan),
+            ResourceDiff::CustomAttribute(ca),
+        ],
+    }
+}
+
 /// Custom attribute that is Unchanged but carries a type-mismatch hint.
 /// Regression test: hints must render even when `has_changes()` is false.
 pub fn custom_attribute_unchanged_with_hint() -> DiffSummary {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -34,14 +34,19 @@ pub trait DiffFormatter {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-pub struct TableFormatter;
+pub struct TableFormatter {
+    /// Suppress in-sync resources from the output. Only blocks whose
+    /// entire body is `no drift` are dropped, so an unchanged resource
+    /// that still carries an informational line stays visible.
+    pub only_drift: bool,
+}
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct JsonFormatter;
 
 impl DiffFormatter for TableFormatter {
     fn format(&self, summary: &DiffSummary) -> String {
-        table::render(summary)
+        table::render(summary, self.only_drift)
     }
 }
 
@@ -52,10 +57,12 @@ impl DiffFormatter for JsonFormatter {
 }
 
 impl OutputFormat {
-    /// Pick the formatter implementation for this format.
-    pub fn formatter(self) -> Box<dyn DiffFormatter> {
+    /// Pick the formatter implementation for this format. `table`
+    /// carries the table-only knobs; the JSON schema is frozen and
+    /// ignores them, so `--format json` always emits every resource.
+    pub fn formatter(self, table: TableFormatter) -> Box<dyn DiffFormatter> {
         match self {
-            Self::Table => Box::new(TableFormatter),
+            Self::Table => Box::new(table),
             Self::Json => Box::new(JsonFormatter),
         }
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -27,8 +27,9 @@ pub enum OutputFormat {
     Json,
 }
 
-/// Format a [`DiffSummary`] for display. Implementations are stateless
-/// unit structs.
+/// Format a [`DiffSummary`] for display. Implementations are cheap
+/// `Copy` values; [`TableFormatter`] carries the table-only display
+/// knobs, [`JsonFormatter`] is a unit struct with none.
 pub trait DiffFormatter {
     fn format(&self, summary: &DiffSummary) -> String;
 }

--- a/src/format/snapshot_tests.rs
+++ b/src/format/snapshot_tests.rs
@@ -129,7 +129,20 @@ fn mostly_in_sync_only_drift_table() {
     );
 }
 
-/// `--only-drift` is a table-side filter; the JSON contract stays whole.
+/// The flag's most common real invocation: nothing drifted, so every
+/// block is suppressed and the output collapses to the trailer alone.
+#[test]
+fn all_in_sync_only_drift_table() {
+    insta::assert_snapshot!(
+        TableFormatter { only_drift: true }.format(&fixtures::catalog_schema_unchanged())
+    );
+}
+
+/// The fixture's JSON rendering, unaffected by `--only-drift` because
+/// `JsonFormatter` takes no knob. The guard against `only_drift` leaking
+/// into the frozen schema is the CLI test
+/// `diff_only_drift_does_not_affect_json_output`, which runs the real
+/// binary with both flags — this snapshot only pins the fixture's shape.
 #[test]
 fn mostly_in_sync_json() {
     insta::assert_snapshot!(JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change()));

--- a/src/format/snapshot_tests.rs
+++ b/src/format/snapshot_tests.rs
@@ -13,7 +13,7 @@ use super::{DiffFormatter, JsonFormatter, TableFormatter};
 
 #[test]
 fn empty_table() {
-    insta::assert_snapshot!(TableFormatter.format(&fixtures::empty()));
+    insta::assert_snapshot!(TableFormatter::default().format(&fixtures::empty()));
 }
 
 #[test]
@@ -28,7 +28,7 @@ fn empty_json() {
 #[test]
 fn catalog_schema_field_diffs_table() {
     insta::assert_snapshot!(
-        TableFormatter.format(&fixtures::catalog_schema_with_mixed_field_diffs())
+        TableFormatter::default().format(&fixtures::catalog_schema_with_mixed_field_diffs())
     );
 }
 
@@ -45,7 +45,7 @@ fn catalog_schema_field_diffs_json() {
 
 #[test]
 fn catalog_schema_unchanged_table() {
-    insta::assert_snapshot!(TableFormatter.format(&fixtures::catalog_schema_unchanged()));
+    insta::assert_snapshot!(TableFormatter::default().format(&fixtures::catalog_schema_unchanged()));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn catalog_schema_unchanged_json() {
 
 #[test]
 fn content_block_added_table() {
-    insta::assert_snapshot!(TableFormatter.format(&fixtures::content_block_added()));
+    insta::assert_snapshot!(TableFormatter::default().format(&fixtures::content_block_added()));
 }
 
 #[test]
@@ -73,7 +73,9 @@ fn content_block_added_json() {
 
 #[test]
 fn content_block_body_modified_table() {
-    insta::assert_snapshot!(TableFormatter.format(&fixtures::content_block_body_modified()));
+    insta::assert_snapshot!(
+        TableFormatter::default().format(&fixtures::content_block_body_modified())
+    );
 }
 
 #[test]
@@ -87,7 +89,7 @@ fn content_block_body_modified_json() {
 
 #[test]
 fn content_block_orphan_table() {
-    insta::assert_snapshot!(TableFormatter.format(&fixtures::content_block_orphan()));
+    insta::assert_snapshot!(TableFormatter::default().format(&fixtures::content_block_orphan()));
 }
 
 #[test]
@@ -101,12 +103,36 @@ fn content_block_orphan_json() {
 
 #[test]
 fn all_kinds_mixed_table() {
-    insta::assert_snapshot!(TableFormatter.format(&fixtures::all_kinds_mixed()));
+    insta::assert_snapshot!(TableFormatter::default().format(&fixtures::all_kinds_mixed()));
 }
 
 #[test]
 fn all_kinds_mixed_json() {
     insta::assert_snapshot!(JsonFormatter.format(&fixtures::all_kinds_mixed()));
+}
+
+// =====================================================================
+// mostly in-sync summary, rendered with and without --only-drift
+// =====================================================================
+
+#[test]
+fn mostly_in_sync_table() {
+    insta::assert_snapshot!(
+        TableFormatter::default().format(&fixtures::mostly_in_sync_with_one_change())
+    );
+}
+
+#[test]
+fn mostly_in_sync_only_drift_table() {
+    insta::assert_snapshot!(
+        TableFormatter { only_drift: true }.format(&fixtures::mostly_in_sync_with_one_change())
+    );
+}
+
+/// `--only-drift` is a table-side filter; the JSON contract stays whole.
+#[test]
+fn mostly_in_sync_json() {
+    insta::assert_snapshot!(JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change()));
 }
 
 // =====================================================================
@@ -116,7 +142,7 @@ fn all_kinds_mixed_json() {
 #[test]
 fn custom_attribute_unchanged_with_hint_table() {
     insta::assert_snapshot!(
-        TableFormatter.format(&fixtures::custom_attribute_unchanged_with_hint())
+        TableFormatter::default().format(&fixtures::custom_attribute_unchanged_with_hint())
     );
 }
 

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__all_in_sync_only_drift_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__all_in_sync_only_drift_table.snap
@@ -1,0 +1,5 @@
+---
+source: src/format/snapshot_tests.rs
+expression: "TableFormatter\n{ only_drift: true }.format(&fixtures::catalog_schema_unchanged())"
+---
+Summary: 0 changed, 1 in sync, 0 orphan, 0 destructive

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__all_kinds_mixed_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__all_kinds_mixed_table.snap
@@ -1,6 +1,6 @@
 ---
 source: src/format/snapshot_tests.rs
-expression: "TableFormatter.format(&fixtures::all_kinds_mixed())"
+expression: "TableFormatter::default().format(&fixtures::all_kinds_mixed())"
 ---
 📋 Catalog Schema: cardiology
    + field: score (number)

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__catalog_schema_field_diffs_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__catalog_schema_field_diffs_table.snap
@@ -1,6 +1,6 @@
 ---
 source: src/format/snapshot_tests.rs
-expression: "TableFormatter.format(&fixtures::catalog_schema_with_mixed_field_diffs())"
+expression: "TableFormatter::default().format(&fixtures::catalog_schema_with_mixed_field_diffs())"
 ---
 📋 Catalog Schema: cardiology
    ~ field: is_active (string → boolean)

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__catalog_schema_unchanged_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__catalog_schema_unchanged_table.snap
@@ -1,6 +1,6 @@
 ---
 source: src/format/snapshot_tests.rs
-expression: "TableFormatter.format(&fixtures::catalog_schema_unchanged())"
+expression: "TableFormatter::default().format(&fixtures::catalog_schema_unchanged())"
 ---
 ✅ Catalog Schema: stable
    no drift

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_added_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_added_table.snap
@@ -1,6 +1,6 @@
 ---
 source: src/format/snapshot_tests.rs
-expression: "TableFormatter.format(&fixtures::content_block_added())"
+expression: "TableFormatter::default().format(&fixtures::content_block_added())"
 ---
 📝 Content Block: fresh_promo
    + new content block

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_body_modified_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_body_modified_table.snap
@@ -1,6 +1,6 @@
 ---
 source: src/format/snapshot_tests.rs
-expression: "TableFormatter.format(&fixtures::content_block_body_modified())"
+expression: "TableFormatter::default().format(&fixtures::content_block_body_modified())"
 ---
 📝 Content Block: promo
    ~ content changed (+1 -1)

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_orphan_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_orphan_table.snap
@@ -1,6 +1,6 @@
 ---
 source: src/format/snapshot_tests.rs
-expression: "TableFormatter.format(&fixtures::content_block_orphan())"
+expression: "TableFormatter::default().format(&fixtures::content_block_orphan())"
 ---
 📝 Content Block: legacy_promo
    ⚠ orphaned (exists in Braze, not in Git)

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__custom_attribute_unchanged_with_hint_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__custom_attribute_unchanged_with_hint_table.snap
@@ -1,6 +1,6 @@
 ---
 source: src/format/snapshot_tests.rs
-expression: "TableFormatter.format(&fixtures::custom_attribute_unchanged_with_hint())"
+expression: "TableFormatter::default().format(&fixtures::custom_attribute_unchanged_with_hint())"
 ---
 ✅ Custom Attribute: visit_count
    no drift

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__empty_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__empty_table.snap
@@ -1,5 +1,5 @@
 ---
 source: src/format/snapshot_tests.rs
-expression: "TableFormatter.format(&fixtures::empty())"
+expression: "TableFormatter::default().format(&fixtures::empty())"
 ---
 Summary: 0 changed, 0 in sync, 0 orphan, 0 destructive

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_json.snap
@@ -6,7 +6,7 @@ expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
   "version": 1,
   "summary": {
     "changed": 2,
-    "in_sync": 3,
+    "in_sync": 6,
     "destructive": 0,
     "orphan": 1
   },
@@ -35,6 +35,14 @@ expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
     },
     {
       "kind": "email_template",
+      "name": "receipt",
+      "op": "unchanged",
+      "subject_changed": false,
+      "metadata_changed": false,
+      "orphan": false
+    },
+    {
+      "kind": "email_template",
       "name": "legacy_welcome",
       "op": "unchanged",
       "subject_changed": false,
@@ -47,6 +55,19 @@ expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
       "op": "unchanged",
       "hints": [
         "type mismatch: local number vs Braze string (run export to update)"
+      ]
+    },
+    {
+      "kind": "tag",
+      "name": "transactional",
+      "op": "unchanged"
+    },
+    {
+      "kind": "tag",
+      "name": "seasonal",
+      "op": "unchanged",
+      "hints": [
+        "registered in two environments with different casing"
       ]
     }
   ]

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_json.snap
@@ -1,0 +1,53 @@
+---
+source: src/format/snapshot_tests.rs
+expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
+---
+{
+  "version": 1,
+  "summary": {
+    "changed": 2,
+    "in_sync": 3,
+    "destructive": 0,
+    "orphan": 1
+  },
+  "diffs": [
+    {
+      "kind": "catalog_schema",
+      "name": "stable",
+      "op": "unchanged",
+      "field_diffs": []
+    },
+    {
+      "kind": "content_block",
+      "name": "footer",
+      "op": "unchanged",
+      "orphan": false
+    },
+    {
+      "kind": "content_block",
+      "name": "promo",
+      "op": "modified",
+      "orphan": false,
+      "text_diff": {
+        "additions": 5,
+        "deletions": 3
+      }
+    },
+    {
+      "kind": "email_template",
+      "name": "legacy_welcome",
+      "op": "unchanged",
+      "subject_changed": false,
+      "metadata_changed": false,
+      "orphan": true
+    },
+    {
+      "kind": "custom_attribute",
+      "name": "visit_count",
+      "op": "unchanged",
+      "hints": [
+        "type mismatch: local number vs Braze string (run export to update)"
+      ]
+    }
+  ]
+}

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_only_drift_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_only_drift_table.snap
@@ -1,0 +1,17 @@
+---
+source: src/format/snapshot_tests.rs
+expression: "TableFormatter\n{ only_drift: true }.format(&fixtures::mostly_in_sync_with_one_change())"
+---
+📝 Content Block: promo
+   ~ content changed (+5 -3)
+
+📧 Email Template: legacy_welcome
+   ⚠ orphaned (exists in Braze, not in Git)
+
+✅ Custom Attribute: visit_count
+   no drift
+   ℹ type mismatch: local number vs Braze string (run export to update)
+
+Summary: 2 changed, 3 in sync, 1 orphan, 0 destructive
+
+ℹ 1 Braze resource(s) not present in Git. Archive them in the Braze dashboard if intended, or add them to exclude_patterns to keep them.

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_only_drift_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_only_drift_table.snap
@@ -12,6 +12,10 @@ expression: "TableFormatter\n{ only_drift: true }.format(&fixtures::mostly_in_sy
    no drift
    ℹ type mismatch: local number vs Braze string (run export to update)
 
-Summary: 2 changed, 3 in sync, 1 orphan, 0 destructive
+✅ Tag: seasonal
+   no drift
+   ℹ registered in two environments with different casing
+
+Summary: 2 changed, 6 in sync, 1 orphan, 0 destructive
 
 ℹ 1 Braze resource(s) not present in Git. Archive them in the Braze dashboard if intended, or add them to exclude_patterns to keep them.

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_table.snap
@@ -11,6 +11,9 @@ expression: "TableFormatter::default().format(&fixtures::mostly_in_sync_with_one
 📝 Content Block: promo
    ~ content changed (+5 -3)
 
+✅ Email Template: receipt
+   no drift
+
 📧 Email Template: legacy_welcome
    ⚠ orphaned (exists in Braze, not in Git)
 
@@ -18,6 +21,13 @@ expression: "TableFormatter::default().format(&fixtures::mostly_in_sync_with_one
    no drift
    ℹ type mismatch: local number vs Braze string (run export to update)
 
-Summary: 2 changed, 3 in sync, 1 orphan, 0 destructive
+✅ Tag: transactional
+   no drift
+
+✅ Tag: seasonal
+   no drift
+   ℹ registered in two environments with different casing
+
+Summary: 2 changed, 6 in sync, 1 orphan, 0 destructive
 
 ℹ 1 Braze resource(s) not present in Git. Archive them in the Braze dashboard if intended, or add them to exclude_patterns to keep them.

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_table.snap
@@ -1,0 +1,23 @@
+---
+source: src/format/snapshot_tests.rs
+expression: "TableFormatter::default().format(&fixtures::mostly_in_sync_with_one_change())"
+---
+✅ Catalog Schema: stable
+   no drift
+
+✅ Content Block: footer
+   no drift
+
+📝 Content Block: promo
+   ~ content changed (+5 -3)
+
+📧 Email Template: legacy_welcome
+   ⚠ orphaned (exists in Braze, not in Git)
+
+✅ Custom Attribute: visit_count
+   no drift
+   ℹ type mismatch: local number vs Braze string (run export to update)
+
+Summary: 2 changed, 3 in sync, 1 orphan, 0 destructive
+
+ℹ 1 Braze resource(s) not present in Git. Archive them in the Braze dashboard if intended, or add them to exclude_patterns to keep them.

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -72,14 +72,13 @@ fn render_header(out: &mut String, diff: &ResourceDiff) {
 fn render_body(diff: &ResourceDiff) -> String {
     let mut out = String::new();
 
+    // The per-kind renderers emit nothing for an unchanged, non-orphan
+    // diff *except* the informational hints some kinds carry (Custom
+    // Attribute type mismatch, Tag hints), so the same match serves both
+    // branches. Special-casing one kind here is what let a Tag hint be
+    // dropped — and, under `only_drift`, take its whole block with it.
     if !diff.has_changes() {
         out.push_str(NO_DRIFT_BODY);
-        // Custom Attributes may carry informational hints (e.g. type
-        // mismatch) even when unchanged.
-        if let ResourceDiff::CustomAttribute(d) = diff {
-            render_custom_attribute(&mut out, d);
-        }
-        return out;
     }
 
     match diff {

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -12,11 +12,23 @@ use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::resource::{CatalogField, ResourceKind};
 use std::fmt::Write as _;
 
-pub fn render(summary: &DiffSummary) -> String {
+/// The entire body of an in-sync resource that carries no extra
+/// information. `only_drift` suppresses exactly the blocks whose body
+/// equals this — an unchanged resource that still rendered an
+/// informational line (e.g. a Custom Attribute type mismatch) has a
+/// longer body and stays visible.
+const NO_DRIFT_BODY: &str = "   no drift\n";
+
+pub fn render(summary: &DiffSummary, only_drift: bool) -> String {
     let mut out = String::new();
 
     for diff in &summary.diffs {
-        render_one(&mut out, diff);
+        let body = render_body(diff);
+        if only_drift && body == NO_DRIFT_BODY {
+            continue;
+        }
+        render_header(&mut out, diff);
+        out.push_str(&body);
         out.push('\n');
     }
 
@@ -44,33 +56,40 @@ pub fn render(summary: &DiffSummary) -> String {
     out
 }
 
-fn render_one(out: &mut String, diff: &ResourceDiff) {
-    let unchanged = !diff.has_changes();
-    let icon = if unchanged {
-        "✅"
-    } else {
+fn render_header(out: &mut String, diff: &ResourceDiff) {
+    let icon = if diff.has_changes() {
         kind_icon(diff.kind())
+    } else {
+        "✅"
     };
     let label = kind_label(diff.kind());
     let _ = writeln!(out, "{icon} {label}: {}", diff.name());
+}
 
-    if unchanged {
-        out.push_str("   no drift\n");
+/// Render the indented lines under a resource header. Built separately
+/// from the header so `only_drift` can decide whether the block is worth
+/// printing at all by inspecting what the body actually says.
+fn render_body(diff: &ResourceDiff) -> String {
+    let mut out = String::new();
+
+    if !diff.has_changes() {
+        out.push_str(NO_DRIFT_BODY);
         // Custom Attributes may carry informational hints (e.g. type
         // mismatch) even when unchanged.
         if let ResourceDiff::CustomAttribute(d) = diff {
-            render_custom_attribute(out, d);
+            render_custom_attribute(&mut out, d);
         }
-        return;
+        return out;
     }
 
     match diff {
-        ResourceDiff::CatalogSchema(d) => render_catalog_schema(out, d),
-        ResourceDiff::ContentBlock(d) => render_content_block(out, d),
-        ResourceDiff::EmailTemplate(d) => render_email_template(out, d),
-        ResourceDiff::CustomAttribute(d) => render_custom_attribute(out, d),
-        ResourceDiff::Tag(d) => render_tag(out, d),
+        ResourceDiff::CatalogSchema(d) => render_catalog_schema(&mut out, d),
+        ResourceDiff::ContentBlock(d) => render_content_block(&mut out, d),
+        ResourceDiff::EmailTemplate(d) => render_email_template(&mut out, d),
+        ResourceDiff::CustomAttribute(d) => render_custom_attribute(&mut out, d),
+        ResourceDiff::Tag(d) => render_tag(&mut out, d),
     }
+    out
 }
 
 fn kind_icon(kind: ResourceKind) -> &'static str {

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -860,3 +860,161 @@ async fn email_template_diff_no_drift_when_placeholders_resolve_to_remote() {
         "expected no drift after values resolution, got:\n{stdout}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_only_drift_suppresses_in_sync_resources() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "catalogs": [
+                {"name": "stable", "fields": [{"name": "id", "type": "string"}]},
+                {"name": "drift", "fields": [{"name": "id", "type": "string"}]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(tmp.path(), "stable", &[("id", "string")]);
+    write_local_schema(
+        tmp.path(),
+        "drift",
+        &[("id", "string"), ("extra", "number")],
+    );
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "catalog_schema", "--only-drift"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.contains("no drift"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("Catalog Schema: stable"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("Catalog Schema: drift"), "stdout: {stdout}");
+    assert!(stdout.contains("+ field: extra"), "stdout: {stdout}");
+    // The trailer still accounts for the suppressed resource.
+    assert!(
+        stdout.contains("Summary: 1 changed, 1 in sync"),
+        "stdout: {stdout}"
+    );
+}
+
+/// An in-sync resource that still carries an informational line is NOT
+/// suppressed — only blocks whose whole body is `no drift` are.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_only_drift_keeps_in_sync_resource_with_hint() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/custom_attributes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "attributes": [
+                {"name": "stable", "data_type": "string", "status": "Active"},
+                {"name": "stale_type", "data_type": "string", "status": "Active"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_custom_attribute_registry(
+        tmp.path(),
+        "attributes:\n  \
+         - name: stable\n    type: string\n  \
+         - name: stale_type\n    type: number\n",
+    );
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "custom_attribute", "--only-drift"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        !stdout.contains("Custom Attribute: stable"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Custom Attribute: stale_type"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("ℹ type mismatch"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Summary: 0 changed, 2 in sync"),
+        "stdout: {stdout}"
+    );
+}
+
+/// `--only-drift` is a table-side filter; the frozen JSON schema keeps
+/// every resource so machine consumers see an unchanged contract.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_only_drift_does_not_affect_json_output() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "catalogs": [
+                {"name": "stable", "fields": [{"name": "id", "type": "string"}]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(tmp.path(), "stable", &[("id", "string")]);
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "diff",
+                "--resource",
+                "catalog_schema",
+                "--only-drift",
+                "--format",
+                "json",
+            ])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["diffs"].as_array().unwrap().len(), 1);
+    assert_eq!(parsed["summary"]["in_sync"], 1);
+}


### PR DESCRIPTION
Closes #81.

## What

`diff --only-drift` omits in-sync resources from the table output, keeping only the blocks a reviewer has to read.

```
📝 Content Block: promo
   ~ content changed (+5 -3)

✅ Custom Attribute: visit_count
   no drift
   ℹ type mismatch: local number vs Braze string (run export to update)

Summary: 1 changed, 384 in sync, 0 orphan, 0 destructive
```

## Why the filter is narrow

The suppression rule is **a block is dropped only when its entire body is exactly `no drift`** — not `if unchanged { return }`. An unchanged resource can still carry an informational line: the unchanged branch calls `render_custom_attribute`, so a Custom Attribute whose local type is stale renders an `ℹ type mismatch` hint under a `✅` header. Dropping it would be a silent loss of signal.

To make that rule expressible, the body is now built separately from the header (`render_body` / `render_header`), so the filter inspects what the block actually says instead of re-deriving it from the diff shape.

## What is not lost

- The `Summary:` trailer counts every resource either way, suppressed or not.
- The always-on orphan report is untouched.
- Table-only. `--format json` is a frozen v1 contract and still emits every resource, so machine consumers see no change.

## Tests

- Snapshot pair over one fixture rendered with and without the flag (in-sync catalog, in-sync content block, a real change, an orphan, and an in-sync custom attribute with a hint), plus its JSON snapshot showing the schema is unaffected.
- Three integration tests: in-sync resources suppressed while the trailer still counts them; an in-sync resource with a hint survives; `--only-drift --format json` still emits every resource.

`cargo test` (424 unit + all integration suites), `cargo clippy --all-targets -D warnings`, and `cargo fmt` are clean.

No CHANGELOG entry — this repo writes those in the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `diff --only-drift` to show only resources with detected changes in table output.
  * Informational entries remain visible, and summary counts are preserved.
  * JSON output continues to include all resources.

* **Documentation**
  * Added usage details, examples, and guidance for posting filtered diff results to GitHub pull requests.

* **Bug Fixes**
  * Apply plan output now renders consistently using the standard table format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->