### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [0.18.0] — 2026-08-14
+
+### Added
+
+- **`diff --only-drift`** omits in-sync resources from the table output.
+  On a workspace of a few hundred resources the `✅ … / no drift` blocks
+  are the overwhelming majority of the output — a reported measurement
+  had 1141 of 1190 lines saying nothing — which buries the review
+  material when CI posts a `diff` into a pull request comment, and
+  pushes the comment toward GitHub's 65536-character limit. The flag
+  suppresses only blocks whose entire body is `no drift`, so an in-sync
+  resource that still carries an informational line (e.g. a Custom
+  Attribute type mismatch) stays visible; the `Summary:` trailer and the
+  always-on orphan report still account for every resource. Table output
+  only — the frozen v1 JSON schema is unaffected. Fixes #81.
+
 ## [0.17.1] — 2026-08-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
Release prep for **v0.18.0**.

## Contents

One user-visible change since v0.17.1:

- `diff --only-drift` — #82, closing #81.

A new CLI flag adds to the public surface, so this is a **minor** bump, not a patch.

## This PR

- `Cargo.toml` / `Cargo.lock`: `0.17.1` → `0.18.0`
- `CHANGELOG.md`: `## [0.18.0] — 2026-08-14` with the `Added` entry

No code changes. `cargo check` and `cargo package` are clean.

## After merge

Tagging is what actually releases — `.github/workflows/release.yml` fires on `v*` and builds/signs the artifacts and publishes to crates.io:

```
git checkout main && git pull
git tag -a v0.18.0 -m "v0.18.0" && git push origin v0.18.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)