### PR TITLE
test: state the correlation round-trip invariant once, over a table

### DIFF
--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -7,6 +7,8 @@ pub mod braze_managed;
 pub mod correlation;
 pub mod integration;
 pub mod placeholder;
+#[cfg(test)]
+mod roundtrip;
 pub mod templatize;
 
 pub use braze_managed::{prepare_field, LidFallback, PreparedTemplate};

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -55,6 +55,19 @@ fn cb_ids(body: &str) -> Vec<String> {
         .collect()
 }
 
+/// Count `| lid:` filter occurrences, whatever value spelling follows.
+///
+/// Deliberately blind to the value: that is what lets it catch a lid
+/// `templatize` failed to recognize, which is the one thing a count taken
+/// from the correlation regexes cannot do. Anchoring on the preceding
+/// pipe keeps prose (`<p>lid: see below</p>`) out of the count, and
+/// tolerating whitespace keeps a raw `{{x|lid:'…'}}` in it.
+fn lid_filters(body: &str) -> usize {
+    body.match_indices("lid:")
+        .filter(|(i, _)| body[..*i].trim_end().ends_with('|'))
+        .count()
+}
+
 fn sorted(mut v: Vec<String>) -> Vec<String> {
     v.sort();
     v
@@ -88,10 +101,10 @@ fn assert_survives_reformat(authored: &str, remote: &str, field: FieldKind) {
     // `templatize`'s own detector are the same pattern, so comparing their
     // counts holds for *any* input — including one whose lid spelling
     // neither side recognizes, which is exactly the row that would slip.
-    // `lid` is Braze-reserved, so counting the bare filter name is
+    // `lid` is Braze-reserved, so counting the filter by name alone is
     // independent of both patterns and does catch it.
     assert_eq!(
-        t.new_body.matches("lid:").count(),
+        lid_filters(&t.new_body),
         t.new_body.matches("lid: '__BRAZESYNC__'").count(),
         "templatize left a raw lid filter behind — its detector does not \
          recognize that spelling, so the row tests nothing for that link: {authored}"
@@ -467,4 +480,26 @@ fn lid_in_a_non_anchor_element_body_has_no_template_side_anchor() {
         "must not POST a slug: {:?}",
         p.fallbacks
     );
+}
+
+#[test]
+fn the_vacuity_guard_is_not_itself_vacuous() {
+    // The guard this replaced compared two counts taken from the same
+    // regex, so it held for every input. A guard nobody tests is how that
+    // goes unnoticed, so this pins both directions.
+
+    // Prose that merely contains `lid:` is not a filter and must not fire.
+    let prose =
+        r#"<p>lid: see below</p><a href="https://x.com/s">{{x | lid: '__BRAZESYNC__'}}</a>"#;
+    assert_eq!(lid_filters(prose), 1);
+
+    // A raw filter whose value spelling `templatize` does not recognize is
+    // left behind, and the guard must see it — `lids()` cannot, because it
+    // does not recognize that spelling either.
+    let body = r#"<a href="https://x.com/a">{{x | lid: 'liveaaaaaaaa1'}}</a>
+                  <a href="https://x.com/b">{{y|lid:'Live-2'}}</a>"#;
+    let t = templatize_body(body, FieldKind::EmailHtmlBody);
+    assert_eq!(lids(body).len(), 1, "the correlation regex misses it too");
+    assert_eq!(lid_filters(&t.new_body), 2, "got: {}", t.new_body);
+    assert_eq!(t.new_body.matches("lid: '__BRAZESYNC__'").count(), 1);
 }

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -14,19 +14,28 @@
 //! anchor loses one link's lid, whereas a merged anchor hands each link
 //! the other's live lid through `resolve_lid_batch`'s FIFO.
 //!
-//! Scope: this covers the *comparison* layer end to end, including the
-//! `templatize` → `prepare_field` seam, which the per-file unit tests do
-//! not — they hand-write the templatized body, so a case that fails to
-//! templatize at all still looks like it passes. That trap is real: an
-//! include whose `${NAME}` contains whitespace is skipped by *both*
-//! sides' name patterns, which reads as a correlation hole and is not one
-//! (#85, pinned by `whitespace_named_include_is_not_managed_today`).
+//! Scope: this covers the *comparison* layer end to end, driving the
+//! `templatize` → `prepare_field` seam rather than hand-writing the
+//! templatized body. Most per-file unit tests do hand-write it, so a case
+//! that fails to templatize at all reads green there — but not all of
+//! them: `braze_managed`'s `plaintext_lid_round_trips_whatever_the_filter_spacing`
+//! and `plaintext_lid_survives_a_content_blocks_include_in_the_url` drive
+//! the same seam, and assert full-body equality against
+//! `t.new_body.replace(TOKEN, …)`, which is *stricter* than the multiset
+//! recovery asserted here. This table is breadth over those two, not a
+//! replacement for them.
 //!
-//! The table also turned up #84, an asymmetry in which elements each side
-//! accepts as an anchor. Both are pinned here rather than fixed: they are
-//! boundaries of the current design, not members of the normalization
-//! family, and a test that states a boundary is what stops it being
-//! rediscovered as a bug.
+//! The table also turned up two boundaries, pinned here rather than fixed
+//! because each changes correlation semantics and wants its own
+//! regression cases — a test that states a boundary is what stops it
+//! being rediscovered as a bug:
+//!
+//! - #84, an asymmetry in which elements each side accepts as an anchor.
+//!   Fails safe (fatal `UnresolvedLid`).
+//! - #85, an include whose `${NAME}` contains whitespace, skipped by
+//!   *both* sides' name patterns. Does **not** fail safe: see
+//!   `whitespace_named_include_is_not_managed_today`, which pins the
+//!   destructive case rather than the benign one.
 
 use crate::values::braze_managed::prepare_field;
 use crate::values::correlation::{extract_cb_id_values, extract_lid_values_unanchored};
@@ -67,21 +76,34 @@ fn assert_survives_reformat(authored: &str, remote: &str, field: FieldKind) {
     let t = templatize_body(authored, field);
 
     // Guard before the real assertions: a case that templatizes nothing
-    // would satisfy everything below vacuously. Both counts are checked
-    // because a body can carry lids and cb_ids independently.
+    // would satisfy everything below vacuously.
     assert!(
         t.new_body.contains(TOKEN),
         "case templatized nothing, so it cannot test correlation: {authored}"
     );
+
+    // `contains(TOKEN)` only rules out templatizing *nothing*; a row that
+    // templatizes one of two links would still ride through. Closing that
+    // needs a check the correlation regexes cannot supply: `lids()` and
+    // `templatize`'s own detector are the same pattern, so comparing their
+    // counts holds for *any* input — including one whose lid spelling
+    // neither side recognizes, which is exactly the row that would slip.
+    // `lid` is Braze-reserved, so counting the bare filter name is
+    // independent of both patterns and does catch it.
     assert_eq!(
-        t.lid_rewrites,
-        lids(authored).len(),
-        "templatize skipped a live lid in: {authored}"
+        t.new_body.matches("lid:").count(),
+        t.new_body.matches("lid: '__BRAZESYNC__'").count(),
+        "templatize left a raw lid filter behind — its detector does not \
+         recognize that spelling, so the row tests nothing for that link: {authored}"
     );
+    // The same argument does not extend to `id:`: it is not reserved, so a
+    // template may carry its own. Here the counts are a drift check between
+    // `templatize::cb_id_match_re` and `correlation::cb_id_include_re`,
+    // which are duplicated patterns that must stay in step.
     assert_eq!(
         t.cb_id_rewrites,
         cb_ids(authored).len(),
-        "templatize skipped a live cb_id in: {authored}"
+        "the two cb_id patterns have drifted apart in: {authored}"
     );
 
     let p = prepare_field(&t.new_body, Some(remote), field);
@@ -110,10 +132,15 @@ fn assert_survives_reformat(authored: &str, remote: &str, field: FieldKind) {
 
 /// The other half: each live value must land on the link it belongs to.
 ///
-/// [`assert_survives_reformat`] cannot see a transposition — two anchors
-/// merged into one bucket still consume every remote value, so nothing is
-/// lost and no fallback fires. `expected` names fragments that must appear
-/// verbatim in the resolved body, which pins value-to-link placement.
+/// [`assert_survives_reformat`] catches a *merge* only incidentally: two
+/// anchors collapsed into one bucket lose no value and fire no fallback,
+/// but `resolve_lid_batch` does warn on a bucket holding more than one
+/// remote occurrence, and that assertion is already made above. What it
+/// cannot see is a transposition that preserves bucket sizes — template
+/// keys `k1, k2` against remote keys `k2, k1`, where every bucket holds
+/// exactly one value and no warning fires. `expected` names fragments that
+/// must appear verbatim in the resolved body, which pins value-to-link
+/// placement independently of either signal.
 ///
 /// These cases put the two links in *opposite* order on the remote side,
 /// so a merged bucket hands out the wrong value rather than accidentally
@@ -175,9 +202,12 @@ fn identity_round_trip_across_shapes() {
             "Go https://x.com/{{content_blocks.${cta} | id: 'cb1'}}/p{{sep}}lid={{x | lid: 'liveaaaaaaaa1'}} now",
             FieldKind::EmailPlainBody,
         ),
-        // Two plaintext links with only a tag between them.
+        // Two plaintext links with only a tag between them and no
+        // whitespace at all, so the single `plaintext_url_re` run has to be
+        // cut by `split_on_embedded_scheme`. Written with a space, the run
+        // would end at the space instead and this row would pin nothing.
         (
-            "https://x.com/one{{x | lid: 'liveaaaaaaaa1'}} https://x.com/two{{y | lid: 'liveaaaaaaaa2'}}",
+            "https://x.com/one{{x | lid: 'liveaaaaaaaa1'}}https://x.com/two{{y | lid: 'liveaaaaaaaa2'}}",
             FieldKind::EmailPlainBody,
         ),
         // No anchor exists; resolution is positional.
@@ -341,31 +371,52 @@ fn respelling_never_merges_two_distinct_links() {
 
 #[test]
 fn whitespace_named_include_is_not_managed_today() {
-    // Known gap (#85), pinned so it stays visible rather than being
-    // rediscovered as a correlation bug — which is how it reads from
-    // `correlation.rs`
-    // alone, whose doc says such an include "does not mask and its lid
-    // anchors do not correlate".
+    // Known gap (#85). `templatize` captures the include name with the
+    // same `[^\s}|]+` as `correlation`, so an include whose `${NAME}` holds
+    // whitespace is never templatized: the raw `cbN` stays in the committed
+    // body and is never re-fetched.
     //
-    // The second half does not follow. `templatize` captures the name with
-    // the same `[^\s}|]+`, so an include whose `${NAME}` holds whitespace
-    // is never templatized at all: both sides keep the literal `cbN`, the
-    // keys agree, and the lid resolves normally. What is actually lost is
-    // cb_id *management* — the raw `cb1` stays in the committed body and
-    // is never re-fetched from the remote.
-    let authored = r#"<a href="https://x.com/p">{{x | lid: 'liveaaaaaaaa1'}}</a>
-                      {{content_blocks.${Plan (US)} | id: 'cb1'}}"#;
+    // Losing `cb_id` management is the benign half, and on its own it reads
+    // like the whole story — while the remote still spells `cb1`, both keys
+    // carry the same literal bytes and the lid resolves fine:
+    let authored = r#"<a href="https://x.com/{{content_blocks.${Plan (US)} | id: 'cb1'}}/p">{{x | lid: 'liveaaaaaaaa1'}}</a>"#;
     let t = templatize_body(authored, FieldKind::ContentBlock);
     assert_eq!(t.lid_rewrites, 1);
     assert_eq!(t.cb_id_rewrites, 0, "the gap: the include is left raw");
     assert!(t.new_body.contains("| id: 'cb1'"), "got: {}", t.new_body);
 
-    // The lid still round-trips, so this is not a member of the
-    // #68/#70/#73/#77 family.
     let p = prepare_field(&t.new_body, Some(authored), FieldKind::ContentBlock);
     assert!(p.errors.is_empty(), "{:?}", p.errors);
     assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
     assert_eq!(lids(&p.body), vec!["liveaaaaaaaa1".to_string()]);
+
+    // But it is not the whole story, and `correlation.rs`'s doc — "does not
+    // mask and its lid anchors do not correlate" — is right to warn. The
+    // unmasked `cbN` is *inside the anchor key*, so the moment Braze
+    // reassigns the content block the two keys diverge, the anchor misses,
+    // and the live lid is overwritten by a slug with `errors` empty — which
+    // `integration.rs` reports as a Notice while applying it. That makes
+    // #85 a destructive-write gap, not merely a management one, so it is
+    // pinned here as the failure it is rather than as accepted behaviour.
+    let remote_reassigned = authored.replace("| id: 'cb1'", "| id: 'cb7'");
+    let p = prepare_field(
+        &t.new_body,
+        Some(&remote_reassigned),
+        FieldKind::ContentBlock,
+    );
+    assert!(p.errors.is_empty(), "still silent: {:?}", p.errors);
+    assert_eq!(
+        p.fallbacks.len(),
+        1,
+        "the live lid is replaced by a fallback slug: {:?}",
+        p.fallbacks
+    );
+    assert_eq!(
+        lids(&p.body),
+        vec!["p".to_string()],
+        "slug from the URL path tail, POSTed over 'liveaaaaaaaa1': {}",
+        p.body
+    );
 }
 
 #[test]

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -1,0 +1,419 @@
+//! Round-trip invariant for Braze-managed value correlation.
+//!
+//! Every regression in the #68 / #70 / #73 / #77 family is an instance of
+//! one property:
+//!
+//! > Templatize a body, hand the resolver that template plus a remote body
+//! > spelling the same links, and every live managed value comes back.
+//!
+//! Each of those issues pinned the property by example, after the fact.
+//! This module states it once and runs it over a table, so a new spelling
+//! is a table row rather than a new test — and so the *negative* half
+//! (distinct links must not merge) is exercised with the same weight as
+//! the positive half. Over-normalizing is the worse failure: a missed
+//! anchor loses one link's lid, whereas a merged anchor hands each link
+//! the other's live lid through `resolve_lid_batch`'s FIFO.
+//!
+//! Scope: this covers the *comparison* layer end to end, including the
+//! `templatize` → `prepare_field` seam, which the per-file unit tests do
+//! not — they hand-write the templatized body, so a case that fails to
+//! templatize at all still looks like it passes. That trap is real: an
+//! include whose `${NAME}` contains whitespace is skipped by *both*
+//! sides' name patterns, which reads as a correlation hole and is not one
+//! (#85, pinned by `whitespace_named_include_is_not_managed_today`).
+//!
+//! The table also turned up #84, an asymmetry in which elements each side
+//! accepts as an anchor. Both are pinned here rather than fixed: they are
+//! boundaries of the current design, not members of the normalization
+//! family, and a test that states a boundary is what stops it being
+//! rediscovered as a bug.
+
+use crate::values::braze_managed::prepare_field;
+use crate::values::correlation::{extract_cb_id_values, extract_lid_values_unanchored};
+use crate::values::placeholder::TOKEN;
+use crate::values::templatize::{templatize_body, FieldKind};
+
+/// Live lid values in appearance order.
+fn lids(body: &str) -> Vec<String> {
+    extract_lid_values_unanchored(body)
+}
+
+/// Live `cbN` values in appearance order.
+fn cb_ids(body: &str) -> Vec<String> {
+    extract_cb_id_values(body)
+        .into_iter()
+        .map(|c| c.value)
+        .collect()
+}
+
+fn sorted(mut v: Vec<String>) -> Vec<String> {
+    v.sort();
+    v
+}
+
+/// The invariant, for a body that reaches Braze and comes back respelled.
+///
+/// `authored` is the body as it stood when `templatize` ran; `remote` is
+/// what Braze hands back. They denote the same links, possibly spelled
+/// differently — the dashboard reformats on save, and `templatize` itself
+/// rewrites the filter, so the two are rarely byte-identical even when
+/// nobody edited anything.
+///
+/// Recovery is asserted as a multiset, not a sequence: a remote may list
+/// the links in a different order than the template, and the property
+/// under test here is that no value is *lost*. Whether each value lands on
+/// the right link is the separate concern of [`assert_keeps_pairing`].
+fn assert_survives_reformat(authored: &str, remote: &str, field: FieldKind) {
+    let t = templatize_body(authored, field);
+
+    // Guard before the real assertions: a case that templatizes nothing
+    // would satisfy everything below vacuously. Both counts are checked
+    // because a body can carry lids and cb_ids independently.
+    assert!(
+        t.new_body.contains(TOKEN),
+        "case templatized nothing, so it cannot test correlation: {authored}"
+    );
+    assert_eq!(
+        t.lid_rewrites,
+        lids(authored).len(),
+        "templatize skipped a live lid in: {authored}"
+    );
+    assert_eq!(
+        t.cb_id_rewrites,
+        cb_ids(authored).len(),
+        "templatize skipped a live cb_id in: {authored}"
+    );
+
+    let p = prepare_field(&t.new_body, Some(remote), field);
+    assert!(p.errors.is_empty(), "{:?} for: {authored}", p.errors);
+    // A fallback here is the family's signature failure: the anchor missed,
+    // so a generated slug is about to be POSTed over a live identifier.
+    assert!(
+        p.fallbacks.is_empty(),
+        "live value replaced by a fallback slug: {:?}\n  authored: {authored}\n  remote:   {remote}",
+        p.fallbacks
+    );
+    assert!(p.warnings.is_empty(), "{:?} for: {authored}", p.warnings);
+    assert_eq!(
+        sorted(lids(&p.body)),
+        sorted(lids(remote)),
+        "lid values not recovered\n  authored: {authored}\n  remote:   {remote}\n  got:      {}",
+        p.body
+    );
+    assert_eq!(
+        sorted(cb_ids(&p.body)),
+        sorted(cb_ids(remote)),
+        "cb_id values not recovered\n  authored: {authored}\n  remote:   {remote}\n  got:      {}",
+        p.body
+    );
+}
+
+/// The other half: each live value must land on the link it belongs to.
+///
+/// [`assert_survives_reformat`] cannot see a transposition — two anchors
+/// merged into one bucket still consume every remote value, so nothing is
+/// lost and no fallback fires. `expected` names fragments that must appear
+/// verbatim in the resolved body, which pins value-to-link placement.
+///
+/// These cases put the two links in *opposite* order on the remote side,
+/// so a merged bucket hands out the wrong value rather than accidentally
+/// the right one.
+fn assert_keeps_pairing(authored: &str, remote: &str, field: FieldKind, expected: &[&str]) {
+    assert_survives_reformat(authored, remote, field);
+    let t = templatize_body(authored, field);
+    let p = prepare_field(&t.new_body, Some(remote), field);
+    for fragment in expected {
+        assert!(
+            p.body.contains(fragment),
+            "expected {fragment:?} in resolved body\n  got: {}",
+            p.body
+        );
+    }
+}
+
+#[test]
+fn identity_round_trip_across_shapes() {
+    // The floor: nothing was reformatted, so any failure here is a bug in
+    // the templatize/resolve seam itself rather than in normalization.
+    let cases: &[(&str, FieldKind)] = &[
+        (
+            r#"<a href="https://x.com/sale">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::ContentBlock,
+        ),
+        (
+            r#"<a href="https://x.com/a">{{x | lid: 'liveaaaaaaaa1'}}</a>
+               <a href="https://x.com/b">{{y | lid: 'liveaaaaaaaa2'}}</a>"#,
+            FieldKind::EmailHtmlBody,
+        ),
+        // #68: the query separator is Liquid, so the key holds no literal `?`.
+        (
+            r#"<a href="https://x.com/p{{sep}}lid={{x | lid: 'liveaaaaaaaa1'}}">go</a>"#,
+            FieldKind::ContentBlock,
+        ),
+        // #73: an include inside the URL puts braces inside the tag.
+        (
+            r#"<a href="https://x.com/{{content_blocks.${cta} | id: 'cb1'}}/p">go</a>{{x | lid: 'liveaaaaaaaa1'}}"#,
+            FieldKind::ContentBlock,
+        ),
+        // Non-anchor element: VML / SVG CTAs route through the same path,
+        // for the shape where the lid sits inside the href — see
+        // `lid_in_a_non_anchor_element_body_has_no_template_side_anchor`.
+        (
+            r#"<v:roundrect href="https://x.com/p?lid={{x | lid: 'liveaaaaaaaa1'}}">go</v:roundrect>"#,
+            FieldKind::EmailHtmlBody,
+        ),
+        // #70: plaintext, where the run's extent is the fragile part.
+        (
+            "Go https://x.com/promo {{x | lid: 'liveaaaaaaaa1'}} now",
+            FieldKind::EmailPlainBody,
+        ),
+        (
+            "Go https://x.com/p{{sep}}lid={{x | lid: 'liveaaaaaaaa1'}} now",
+            FieldKind::EmailPlainBody,
+        ),
+        (
+            "Go https://x.com/{{content_blocks.${cta} | id: 'cb1'}}/p{{sep}}lid={{x | lid: 'liveaaaaaaaa1'}} now",
+            FieldKind::EmailPlainBody,
+        ),
+        // Two plaintext links with only a tag between them.
+        (
+            "https://x.com/one{{x | lid: 'liveaaaaaaaa1'}} https://x.com/two{{y | lid: 'liveaaaaaaaa2'}}",
+            FieldKind::EmailPlainBody,
+        ),
+        // No anchor exists; resolution is positional.
+        (
+            "Sale {{x | lid: 'liveaaaaaaaa1'}}",
+            FieldKind::EmailSubject,
+        ),
+    ];
+    for (body, field) in cases {
+        assert_survives_reformat(body, body, *field);
+    }
+}
+
+#[test]
+fn survives_every_respelling_the_dashboard_can_introduce() {
+    // The positive half of the family. Each row is the same link spelled
+    // two ways; the live lid must come through rather than be replaced by
+    // a generated slug. Rows are grouped by the spelling axis so a new
+    // axis is a new row, not a new test.
+    let cases: &[(&str, &str, FieldKind)] = &[
+        // #68 / #70: the filter itself respaced. `templatize` canonicalizes
+        // to `| lid: '…'`, so this axis moves on almost every real body.
+        (
+            r#"<a href="https://x.com/p{{sep}}lid={{x|lid:'liveaaaaaaaa1'}}">go</a>"#,
+            r#"<a href="https://x.com/p{{sep}}lid={{ x | lid: 'liveaaaaaaaa1' }}">go</a>"#,
+            FieldKind::ContentBlock,
+        ),
+        // #77: whitespace the filter mask does not reach — after `{{`,
+        // before `}}`, and around an unrelated filter.
+        (
+            r#"<a href="https://x.com/p{{sep}}lid={{x|lid:'liveaaaaaaaa1'}}">go</a>"#,
+            r#"<a href="https://x.com/p{{ sep }}lid={{ x | lid: 'liveaaaaaaaa1' }}">go</a>"#,
+            FieldKind::ContentBlock,
+        ),
+        (
+            "Go https://x.com/p{{sep|default:'?'}}lid={{x|lid:'liveaaaaaaaa1'}} now",
+            "Go https://x.com/p{{ sep | default: '?' }}lid={{ x | lid: 'liveaaaaaaaa1' }} now",
+            FieldKind::EmailPlainBody,
+        ),
+        // Liquid whitespace control added or removed around a variable.
+        (
+            r#"<a href="https://x.com/{{-sep-}}p">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            r#"<a href="https://x.com/{{- sep -}}p">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::ContentBlock,
+        ),
+        // Padding around a `${NAME}` is formatting; the name is the same.
+        (
+            r#"<a href="https://x.com/{{custom_attribute.${plan}}}/p">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            r#"<a href="https://x.com/{{ custom_attribute.${ plan } }}/p">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::ContentBlock,
+        ),
+        // Quote style on the managed value itself. Both patterns accept
+        // either, so this must not depend on which the dashboard emits.
+        (
+            r#"<a href="https://x.com/sale">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            r#"<a href="https://x.com/sale">{{x | lid: "liveaaaaaaaa1"}}</a>"#,
+            FieldKind::ContentBlock,
+        ),
+        // The include respaced. `templatize` rebuilds it canonically, so
+        // the key has to be derived from the name rather than the bytes.
+        (
+            r#"<a href="https://x.com/{{content_blocks.${cta} | id: 'cb1'}}/p">go</a>{{x | lid: 'liveaaaaaaaa1'}}"#,
+            r#"<a href="https://x.com/{{content_blocks.${cta}|id:'cb1'}}/p">go</a>{{x | lid: 'liveaaaaaaaa1'}}"#,
+            FieldKind::ContentBlock,
+        ),
+        // Attribute quote style, and an attribute reordered around it.
+        (
+            r#"<a href="https://x.com/sale" class="cta">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            r#"<a class="cta" href='https://x.com/sale'>{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::ContentBlock,
+        ),
+        // A query string appears (or changes) on the remote side. The key
+        // cuts at the first `?` outside a tag, so tracking params added in
+        // the dashboard must not cost the lid.
+        (
+            r#"<a href="https://x.com/sale">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            r#"<a href="https://x.com/sale?utm_source=braze">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::ContentBlock,
+        ),
+    ];
+    for (authored, remote, field) in cases {
+        assert_survives_reformat(authored, remote, *field);
+    }
+}
+
+#[test]
+fn respelling_never_merges_two_distinct_links() {
+    // The negative half, and the one that matters more: a merge is silent
+    // and hands each link the other's live identifier. Every row differs
+    // in exactly one byte-level detail that the normalizer must treat as
+    // identity rather than formatting, and every remote lists the links in
+    // reverse order so a merged FIFO bucket transposes rather than
+    // accidentally agreeing.
+    let cases: &[(&str, &str, FieldKind, &[&str])] = &[
+        // Spaces inside a quoted argument are the value, not layout.
+        (
+            "https://x.com/{{sep|default:' - '}}{{x|lid:'liveaaaaaaaa1'}} \
+             https://x.com/{{sep|default:'-'}}{{x|lid:'liveaaaaaaaa2'}}",
+            "https://x.com/{{ sep | default: '-' }}{{ x | lid: 'liveaaaaaaaa2' }} \
+             https://x.com/{{ sep | default: ' - ' }}{{ x | lid: 'liveaaaaaaaa1' }}",
+            FieldKind::EmailPlainBody,
+            &[
+                "{{sep|default:' - '}}{{x| lid: 'liveaaaaaaaa1'}}",
+                "{{sep|default:'-'}}{{x| lid: 'liveaaaaaaaa2'}}",
+            ],
+        ),
+        // Whitespace *between* the bytes of a `${NAME}` is part of the name.
+        (
+            "https://x.com/{{custom_attribute.${first name}}}{{x|lid:'liveaaaaaaaa1'}} \
+             https://x.com/{{custom_attribute.${firstname}}}{{x|lid:'liveaaaaaaaa2'}}",
+            "https://x.com/{{ custom_attribute.${firstname} }}{{ x | lid: 'liveaaaaaaaa2' }} \
+             https://x.com/{{ custom_attribute.${first name} }}{{ x | lid: 'liveaaaaaaaa1' }}",
+            FieldKind::EmailPlainBody,
+            &[
+                "{{custom_attribute.${first name}}}{{x| lid: 'liveaaaaaaaa1'}}",
+                "{{custom_attribute.${firstname}}}{{x| lid: 'liveaaaaaaaa2'}}",
+            ],
+        ),
+        // Plain text after the managed tag distinguishes two links; the run
+        // spans the tag precisely so this stays visible.
+        (
+            "https://x.com/p{{x|lid:'liveaaaaaaaa1'}}/alpha \
+             https://x.com/p{{x|lid:'liveaaaaaaaa2'}}/beta",
+            "https://x.com/p{{ x | lid: 'liveaaaaaaaa2' }}/beta \
+             https://x.com/p{{ x | lid: 'liveaaaaaaaa1' }}/alpha",
+            FieldKind::EmailPlainBody,
+            &[
+                "{{x| lid: 'liveaaaaaaaa1'}}/alpha",
+                "{{x| lid: 'liveaaaaaaaa2'}}/beta",
+            ],
+        ),
+        // Two different include names in two different links.
+        (
+            r#"<a href="https://x.com/{{content_blocks.${a} | id: 'cb1'}}">{{x | lid: 'liveaaaaaaaa1'}}</a>
+               <a href="https://x.com/{{content_blocks.${b} | id: 'cb2'}}">{{y | lid: 'liveaaaaaaaa2'}}</a>"#,
+            r#"<a href="https://x.com/{{content_blocks.${b}|id:'cb2'}}">{{y | lid: 'liveaaaaaaaa2'}}</a>
+               <a href="https://x.com/{{content_blocks.${a}|id:'cb1'}}">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::ContentBlock,
+            &[
+                r#"{{content_blocks.${a} | id: 'cb1'}}">{{x | lid: 'liveaaaaaaaa1'}}"#,
+                r#"{{content_blocks.${b} | id: 'cb2'}}">{{y | lid: 'liveaaaaaaaa2'}}"#,
+            ],
+        ),
+        // Different path tails, same everything else.
+        (
+            r#"<a href="https://x.com/alpha">{{x | lid: 'liveaaaaaaaa1'}}</a>
+               <a href="https://x.com/beta">{{x | lid: 'liveaaaaaaaa2'}}</a>"#,
+            r#"<a href="https://x.com/beta">{{x | lid: 'liveaaaaaaaa2'}}</a>
+               <a href="https://x.com/alpha">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::EmailHtmlBody,
+            &[
+                r#"https://x.com/alpha">{{x | lid: 'liveaaaaaaaa1'}}"#,
+                r#"https://x.com/beta">{{x | lid: 'liveaaaaaaaa2'}}"#,
+            ],
+        ),
+    ];
+    for (authored, remote, field, expected) in cases {
+        assert_keeps_pairing(authored, remote, *field, expected);
+    }
+}
+
+#[test]
+fn whitespace_named_include_is_not_managed_today() {
+    // Known gap (#85), pinned so it stays visible rather than being
+    // rediscovered as a correlation bug — which is how it reads from
+    // `correlation.rs`
+    // alone, whose doc says such an include "does not mask and its lid
+    // anchors do not correlate".
+    //
+    // The second half does not follow. `templatize` captures the name with
+    // the same `[^\s}|]+`, so an include whose `${NAME}` holds whitespace
+    // is never templatized at all: both sides keep the literal `cbN`, the
+    // keys agree, and the lid resolves normally. What is actually lost is
+    // cb_id *management* — the raw `cb1` stays in the committed body and
+    // is never re-fetched from the remote.
+    let authored = r#"<a href="https://x.com/p">{{x | lid: 'liveaaaaaaaa1'}}</a>
+                      {{content_blocks.${Plan (US)} | id: 'cb1'}}"#;
+    let t = templatize_body(authored, FieldKind::ContentBlock);
+    assert_eq!(t.lid_rewrites, 1);
+    assert_eq!(t.cb_id_rewrites, 0, "the gap: the include is left raw");
+    assert!(t.new_body.contains("| id: 'cb1'"), "got: {}", t.new_body);
+
+    // The lid still round-trips, so this is not a member of the
+    // #68/#70/#73/#77 family.
+    let p = prepare_field(&t.new_body, Some(authored), FieldKind::ContentBlock);
+    assert!(p.errors.is_empty(), "{:?}", p.errors);
+    assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
+    assert_eq!(lids(&p.body), vec!["liveaaaaaaaa1".to_string()]);
+}
+
+#[test]
+fn lid_in_a_non_anchor_element_body_has_no_template_side_anchor() {
+    // Second known boundary (#84), found by the table above. The two sides
+    // do not agree on which elements can carry an anchor:
+    //
+    // - remote: `correlation::href_re` takes `href` / `src` / `action` on
+    //   *any* element, so it extracts a pair here;
+    // - template: once the lid sits past the `>`, `lid_anchor_for` falls
+    //   through to `braze_managed::anchor_href_re`, which is `<a>`-only.
+    //
+    // A VML CTA whose lid is inside the href is supported (that shape stays
+    // within the open tag and goes through `url_attr_re`); one whose lid is
+    // in the element *body* is not.
+    //
+    // Pinned rather than fixed because it fails in the safe direction: the
+    // result is a fatal `UnresolvedLid`, so the operator is stopped rather
+    // than having a live identifier quietly overwritten by a slug. Widening
+    // `anchor_href_re` to match `href_re` would resolve it, but that changes
+    // which element encloses an anchor and so is a correlation-semantics
+    // change, not a test fix.
+    let body = r#"<v:rect href="https://x.com/sale">{{x | lid: 'liveaaaaaaaa1'}}</v:rect>"#;
+    let t = templatize_body(body, FieldKind::EmailHtmlBody);
+    assert_eq!(t.lid_rewrites, 1);
+
+    // The remote side does find the pair.
+    assert_eq!(
+        crate::values::correlation::extract_html_lid_values(body)
+            .into_iter()
+            .map(|c| c.value)
+            .collect::<Vec<_>>(),
+        vec!["liveaaaaaaaa1".to_string()],
+    );
+
+    // The template side does not, and says so loudly.
+    let p = prepare_field(&t.new_body, Some(body), FieldKind::EmailHtmlBody);
+    assert!(
+        p.errors.iter().any(|e| matches!(
+            e,
+            crate::values::placeholder::ResolutionError::UnresolvedLid { .. }
+        )),
+        "expected a fatal UnresolvedLid, got: {:?}",
+        p.errors
+    );
+    assert!(
+        p.fallbacks.is_empty(),
+        "must not POST a slug: {:?}",
+        p.fallbacks
+    );
+}


### PR DESCRIPTION
Tests only — no behavior change. `cargo test` 431 lib tests green, `clippy --all-targets -D warnings` clean.

The first of the three cheap steps identified in the [#79 analysis](https://github.com/uny/braze-sync/issues/79#issuecomment-5301613436), and the one both second opinions put first.

## What

Every regression in the #68 / #70 / #73 / #77 family is an instance of one property:

> Templatize a body, hand the resolver that template plus a remote body spelling the same links, and every live managed value comes back.

Each of those issues pinned it by example, after the fact. `src/values/roundtrip.rs` states it once and runs it over a table, so a new spelling is a row rather than a new test.

Two halves, weighted equally:

- **`assert_survives_reformat`** — no value lost. A fallback here is the family's signature failure: the anchor missed, so a generated slug is about to be POSTed over a live identifier. Recovery is asserted as a multiset, since a remote may order links differently.
- **`assert_keeps_pairing`** — no two distinct links merge. `assert_survives_reformat` cannot see a transposition: merged anchors still consume every remote value, so nothing is lost and no fallback fires. These rows list the links in *reverse* order on the remote side, so a merged bucket transposes rather than accidentally agreeing.

The negative half is the one that matters more — over-normalizing hands each link the other's live lid, where under-normalizing only loses one.

Coverage: 10 identity shapes, 9 respelling axes (filter respacing, #77-style intra-tag whitespace, `{{- -}}`, `${ name }` padding, quote style on the managed value, include respacing, attribute order/quoting, query added remotely), 5 non-merge axes.

## Mutation-checked

A test that cannot fail is worth nothing, so both directions were verified against deliberate breakage:

| mutation | result |
|---|---|
| disable #78's despacing pass (under-normalize) | positive **and** negative fail |
| make that pass quote-unaware (over-normalize) | **only** the negative fails |

The second is the dangerous direction, and only the negative rows catch it — which is the argument for spending half the table on them.

## Vacuous-pass guard

The harness asserts `templatize`'s rewrite counts before anything else. The existing per-file tests hand-write the templatized body, so a case that never templatizes at all still reads green — and that trap is exactly what produced both boundaries below. It also produced a wrong reading during the #79 analysis, which the issue comment corrects.

## Two boundaries pinned, not fixed

Both surfaced by the table; neither is a member of the normalization family, and both get their own issue:

- **#84** — the template side only recognizes `<a>` once the lid sits in an element body, while the remote side accepts any element with a URL attribute. Fails safe: fatal `UnresolvedLid`, no slug POSTed. Fixing it changes which element encloses an anchor, i.e. correlation semantics, so it wants its own regression cases.
- **#85** — a content block name containing whitespace is skipped by both sides' `${NAME}` patterns, so the include is never templatized. Reads as a correlation hole from `correlation.rs` alone and is not one: the lid resolves fine, and what is actually lost is `cb_id` management. The misleading half of the `correlation.rs:141-145` comment should be corrected as part of that issue.

A test that states a boundary is what stops it being rediscovered as a bug.

Refs #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end regression coverage for managed value correlation across formatting and respelling variations.
  * Verified link identifiers, content pairing, and value handling across HTML, plaintext, subjects, content blocks, query strings, includes, and attributes.
  * Added coverage for whitespace-containing includes and non-anchor elements, including expected unresolved-link and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->