### PR TITLE
fix: mask content_blocks.${NAME} even when NAME holds whitespace (#85)

### DIFF
--- a/src/cli/templatize.rs
+++ b/src/cli/templatize.rs
@@ -33,6 +33,15 @@ pub async fn run(args: &TemplatizeArgs, cfg: &ConfigFile, config_dir: &Path) -> 
             .context("loading local content_blocks for templatize")?;
         for mut cb in blocks {
             let result = templatize_body(&cb.content, FieldKind::ContentBlock);
+            // Collected before the rewrite-count check: a body can carry a
+            // warning (e.g. an invalid cb_id name, #85) with zero rewrites,
+            // and that must still reach the operator rather than being
+            // dropped by the "nothing to do" skip below.
+            for w in &result.warnings {
+                summary
+                    .warnings
+                    .push(format!("content_block '{}': {w}", cb.name));
+            }
             if result.lid_rewrites + result.cb_id_rewrites == 0 {
                 if cb.content.contains("__BRAZESYNC__") {
                     summary.skipped.push(format!(
@@ -41,11 +50,6 @@ pub async fn run(args: &TemplatizeArgs, cfg: &ConfigFile, config_dir: &Path) -> 
                     ));
                 }
                 continue;
-            }
-            for w in &result.warnings {
-                summary
-                    .warnings
-                    .push(format!("content_block '{}': {w}", cb.name));
             }
             summary.touched_resources += 1;
             summary.lid_rewrites += result.lid_rewrites;
@@ -86,16 +90,8 @@ pub async fn run(args: &TemplatizeArgs, cfg: &ConfigFile, config_dir: &Path) -> 
                     .as_ref()
                     .map(|r| r.lid_rewrites + r.cb_id_rewrites)
                     .unwrap_or(0);
-            if total_rewrites == 0 {
-                if already_templated {
-                    summary.skipped.push(format!(
-                        "email_template '{}' already templated — skipping",
-                        et.name
-                    ));
-                }
-                continue;
-            }
-
+            // Collected before the rewrite-count check — see the matching
+            // comment in the content_block loop above (#85).
             for (field, warnings) in [
                 ("subject", &subject_r.warnings),
                 ("body_html", &body_html_r.warnings),
@@ -113,6 +109,16 @@ pub async fn run(args: &TemplatizeArgs, cfg: &ConfigFile, config_dir: &Path) -> 
                         .warnings
                         .push(format!("email_template '{}' (preheader): {w}", et.name));
                 }
+            }
+
+            if total_rewrites == 0 {
+                if already_templated {
+                    summary.skipped.push(format!(
+                        "email_template '{}' already templated — skipping",
+                        et.name
+                    ));
+                }
+                continue;
             }
 
             summary.touched_resources += 1;

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -484,6 +484,17 @@ fn cb_id_filter_re() -> &'static Regex {
     RE.get_or_init(|| {
         // Captures `${NAME}` so we can re-emit the documented form
         // (`{{content_blocks.${NAME}}}`) without the cb_id filter.
+        //
+        // Deliberately kept at `[^\s}|]+`, unlike `correlation::
+        // cb_id_filter_re` (#85): a `__BRAZESYNC__` token only ever exists
+        // here because `templatize` put it there, and `templatize` never
+        // manages an include whose name holds whitespace (Braze forbids
+        // it in a real content block name). Widening this pattern would
+        // only matter for a hand-authored `__BRAZESYNC__` with an invalid
+        // name — and for that, staying narrow is the safer outcome: the
+        // filter is left un-stripped and the body is POSTed with a
+        // dangling `| id: '__BRAZESYNC__'`, which Braze will reject
+        // loudly, rather than silently re-emitting an invalid include.
         Regex::new(
             r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*['"]__BRAZESYNC__['"]\s*\}\}"#,
         )
@@ -506,6 +517,12 @@ fn cb_id_name_at(body: &str, offset: usize) -> Option<String> {
 fn cb_id_template_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
+        // Deliberately kept at `[^\s}|]+` — see `cb_id_filter_re` above
+        // (#85). Used by `cb_id_name_at` to look up a `__BRAZESYNC__` cb_id
+        // placeholder's NAME; `templatize` never creates one for a name
+        // holding whitespace, so a lookup miss here (from a hand-authored
+        // body) should surface as the existing fatal `UnresolvedCbId`
+        // rather than resolve as if the name were valid.
         Regex::new(
             r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*['"]__BRAZESYNC__['"]\s*\}\}"#,
         )

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -119,11 +119,15 @@ pub fn normalize_url(url: &str) -> String {
 ///
 /// A quoted string is not the only literal region inside a tag, so
 /// `${…}` is treated as a second one. Braze addresses a personalization
-/// or content block whose name contains spaces as `${my attribute}` —
-/// unquoted, yet every byte between the braces is the name, punctuation
-/// and all. Dropping there would key `${my attribute}` and
-/// `${myattribute}` alike, and one FIFO bucket for two links is the same
-/// corruption the quote rule exists to prevent.
+/// attribute whose name contains spaces as `${my attribute}` — unquoted,
+/// yet every byte between the braces is the name, punctuation and all.
+/// (A *content block*'s own name cannot itself contain whitespace — Braze
+/// restricts it to alphanumerics, `-`, and `_` — but `${…}` is despaced
+/// the same regardless of what precedes it, since this pass has no way to
+/// know which entity a given `${…}` addresses.) Dropping the space here
+/// would key `${my attribute}` and `${myattribute}` alike, and one FIFO
+/// bucket for two links is the same corruption the quote rule exists to
+/// prevent.
 ///
 /// So the rule is regional, not per-character: whitespace inside quotes
 /// or *between the bytes of* a `${…}` name is content and is copied
@@ -138,11 +142,13 @@ pub fn normalize_url(url: &str) -> String {
 /// the rest of its tag verbatim, the same conservative direction as an
 /// unterminated quote.
 ///
-/// A name whose *interior* holds a space is preserved here but is not
-/// otherwise supported: every `${NAME}` pattern in this crate captures
-/// `[^\s}|]+`, so a `content_blocks.${Plan (US)}` include does not mask
-/// and its `lid` anchors do not correlate — as on `main`, and unchanged
-/// by this pass.
+/// A name whose *interior* holds a space is preserved here, and — since
+/// #85 — [`cb_id_filter_re`] captures it too, so a `content_blocks.${Plan
+/// (US)}` include now masks like any other and no longer costs a nearby
+/// `lid` its anchor. `templatize::cb_id_match_re` still declines to
+/// manage such an include (a real content block can never be named with
+/// whitespace), so its `cbN` stays raw and unmanaged going forward — but
+/// masking no longer depends on that being fixed.
 fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
     let bytes = url.as_bytes();
     if !bytes.windows(2).any(|w| w == b"{{") {
@@ -275,9 +281,20 @@ fn cb_id_filter_re() -> &'static Regex {
         // canonicalizes, so `normalize_url` re-emits it rather than
         // keeping it. The include's closing `}}` is left in place — it is
         // identical on both sides.
+        //
+        // The name is captured broadly (`[^}}|]*`, not `[^\s}}|]+`) so a
+        // whitespace-holding `${NAME}` still masks (#85). Braze forbids
+        // whitespace in a real content block name, so such an include can
+        // never correlate against a live `cbN` — but the raw `cbN` must
+        // still be masked out of the key, or a *different*, well-formed
+        // anchor sharing the same tag (typically a `lid`) inherits its
+        // instability once Braze renumbers it. Padding around the name is
+        // already gone by the time this runs — `normalize_url` calls
+        // `strip_liquid_tag_whitespace` first — so no further trimming is
+        // needed here.
         let cb = format!("(?:cb[0-9]+|{TOKEN})");
         Regex::new(&format!(
-            r#"\{{\{{\s*content_blocks\.\$\{{\s*([^\s}}|]+)\s*\}}\s*\|\s*id:\s*(?:"{cb}"|'{cb}')\s*"#
+            r#"\{{\{{\s*content_blocks\.\$\{{([^}}|]*)\}}\s*\|\s*id:\s*(?:"{cb}"|'{cb}')\s*"#
         ))
         .expect("cb_id filter regex is valid")
     })
@@ -359,6 +376,16 @@ fn cb_id_include_re() -> &'static Regex {
         // Matches existing dependency-graph regex in
         // src/diff/content_block_order.rs but tightened to require
         // `| id: '…'` form (we need the cbN value, not just NAME).
+        //
+        // Deliberately kept at `[^\s}|]+`, unlike `cb_id_filter_re` (#85):
+        // this feeds `extract_cb_id_values`, which pairs a *managed*
+        // `__BRAZESYNC__` placeholder's NAME (from `cb_id_name_at`, also
+        // still `[^\s}|]+`) with the remote's live `cbN`. `templatize`
+        // never manages an include whose name holds whitespace, so no
+        // placeholder ever needs this pattern to see one — widening it
+        // would only let `extract_cb_id_values` count an include
+        // `cb_id_match_re` skipped, breaking the invariant (asserted in
+        // `roundtrip.rs`) that the two counts stay in lockstep.
         Regex::new(
             r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*(?:"(cb[0-9]+)"|'(cb[0-9]+)')\s*\}\}"#,
         )
@@ -946,6 +973,36 @@ mod tests {
         assert_ne!(
             normalize_url("{{content_blocks.${a} | id: 'cb1'}}"),
             normalize_url("{{content_blocks.${b} | id: 'cb2'}}")
+        );
+    }
+
+    #[test]
+    fn cb_id_filter_masks_a_name_containing_whitespace() {
+        // #85: a real content block can never be named with whitespace,
+        // but the raw `cbN` must still be masked out of the key so a
+        // *different*, well-formed anchor sharing the same tag does not
+        // inherit the instability once Braze renumbers it.
+        assert_eq!(
+            normalize_url("{{content_blocks.${Plan (US)} | id: 'cb1'}}"),
+            normalize_url("{{content_blocks.${Plan (US)} | id: 'cb7'}}")
+        );
+        // Padding around the name is still formatting...
+        assert_eq!(
+            normalize_url("{{content_blocks.${ Plan (US) } | id: 'cb1'}}"),
+            normalize_url("{{content_blocks.${Plan (US)} | id: 'cb1'}}")
+        );
+        // ...but whitespace *inside* the name is not: "a b" and "ab" stay
+        // distinct anchors, or two links collapse onto one FIFO bucket.
+        assert_ne!(
+            normalize_url("{{content_blocks.${a b} | id: 'cb1'}}"),
+            normalize_url("{{content_blocks.${ab} | id: 'cb1'}}")
+        );
+        // A blank name (all padding, nothing left after trim) still masks
+        // rather than falling through unmatched — the capture group is
+        // `*`, not `+`, precisely so an empty `${}` cannot reopen this gap.
+        assert_eq!(
+            normalize_url("{{content_blocks.${   } | id: 'cb1'}}"),
+            normalize_url("{{content_blocks.${} | id: 'cb7'}}")
         );
     }
 

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -32,10 +32,12 @@
 //!
 //! - #84, an asymmetry in which elements each side accepts as an anchor.
 //!   Fails safe (fatal `UnresolvedLid`).
-//! - #85, an include whose `${NAME}` contains whitespace, skipped by
-//!   *both* sides' name patterns. Does **not** fail safe: see
-//!   `whitespace_named_include_is_not_managed_today`, which pins the
-//!   destructive case rather than the benign one.
+//! - #85 (fixed): an include whose `${NAME}` contains whitespace is still
+//!   left unmanaged by `templatize` — Braze forbids whitespace in a real
+//!   content block name, so such an include can never be templatized —
+//!   but `correlation::cb_id_filter_re` now masks the raw `cbN` out of
+//!   the anchor key regardless, so a nearby `lid` no longer inherits its
+//!   instability. See `whitespace_named_include_no_longer_corrupts_a_live_lid`.
 
 use crate::values::braze_managed::prepare_field;
 use crate::values::correlation::{extract_cb_id_values, extract_lid_values_unanchored};
@@ -364,6 +366,25 @@ fn respelling_never_merges_two_distinct_links() {
                 r#"{{content_blocks.${b} | id: 'cb2'}}">{{y | lid: 'liveaaaaaaaa2'}}"#,
             ],
         ),
+        // #85: an include's `${NAME}` may itself contain whitespace. It
+        // stays unmanaged by `templatize` (Braze forbids whitespace in a
+        // real content block name), but the masking that stabilizes a
+        // nearby lid's anchor key must still tell "a b" and "ab" apart —
+        // trim removes padding only, never interior bytes — or the two
+        // lids collapse onto one FIFO bucket. The cb_id value is held
+        // fixed (not reassigned) so the unmanaged include's raw `cbN`
+        // trivially matches remote; only the lid pairing is under test.
+        (
+            r#"<a href="https://x.com/{{content_blocks.${a b} | id: 'cb1'}}">{{x | lid: 'liveaaaaaaaa1'}}</a>
+               <a href="https://x.com/{{content_blocks.${ab} | id: 'cb1'}}">{{y | lid: 'liveaaaaaaaa2'}}</a>"#,
+            r#"<a href="https://x.com/{{content_blocks.${ab}|id:'cb1'}}">{{y | lid: 'liveaaaaaaaa2'}}</a>
+               <a href="https://x.com/{{content_blocks.${a b}|id:'cb1'}}">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::ContentBlock,
+            &[
+                r#"{{content_blocks.${a b} | id: 'cb1'}}">{{x | lid: 'liveaaaaaaaa1'}}"#,
+                r#"{{content_blocks.${ab} | id: 'cb1'}}">{{y | lid: 'liveaaaaaaaa2'}}"#,
+            ],
+        ),
         // Different path tails, same everything else.
         (
             r#"<a href="https://x.com/alpha">{{x | lid: 'liveaaaaaaaa1'}}</a>
@@ -383,51 +404,56 @@ fn respelling_never_merges_two_distinct_links() {
 }
 
 #[test]
-fn whitespace_named_include_is_not_managed_today() {
-    // Known gap (#85). `templatize` captures the include name with the
-    // same `[^\s}|]+` as `correlation`, so an include whose `${NAME}` holds
-    // whitespace is never templatized: the raw `cbN` stays in the committed
-    // body and is never re-fetched.
-    //
-    // Losing `cb_id` management is the benign half, and on its own it reads
-    // like the whole story — while the remote still spells `cb1`, both keys
-    // carry the same literal bytes and the lid resolves fine:
+fn whitespace_named_include_no_longer_corrupts_a_live_lid() {
+    // #85, fixed. `templatize` still declines to manage an include whose
+    // `${NAME}` holds whitespace — Braze forbids whitespace in a real
+    // content block name, so such an include can never denote one — but
+    // it now says so via a warning instead of staying silent, and
+    // `correlation::cb_id_filter_re` masks the raw `cbN` out of the
+    // anchor key regardless of whether the name is manageable. A nearby
+    // `lid` no longer inherits the instability of an include that can
+    // never correlate.
     let authored = r#"<a href="https://x.com/{{content_blocks.${Plan (US)} | id: 'cb1'}}/p">{{x | lid: 'liveaaaaaaaa1'}}</a>"#;
     let t = templatize_body(authored, FieldKind::ContentBlock);
     assert_eq!(t.lid_rewrites, 1);
-    assert_eq!(t.cb_id_rewrites, 0, "the gap: the include is left raw");
+    assert_eq!(
+        t.cb_id_rewrites, 0,
+        "still not managed — Braze cannot name a content block with whitespace"
+    );
     assert!(t.new_body.contains("| id: 'cb1'"), "got: {}", t.new_body);
+    assert!(
+        t.warnings.iter().any(|w| w.contains("whitespace")),
+        "expected a warning about the invalid content block name, got: {:?}",
+        t.warnings
+    );
 
     let p = prepare_field(&t.new_body, Some(authored), FieldKind::ContentBlock);
     assert!(p.errors.is_empty(), "{:?}", p.errors);
     assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
     assert_eq!(lids(&p.body), vec!["liveaaaaaaaa1".to_string()]);
 
-    // But it is not the whole story, and `correlation.rs`'s doc — "does not
-    // mask and its lid anchors do not correlate" — is right to warn. The
-    // unmasked `cbN` is *inside the anchor key*, so the moment Braze
-    // reassigns the content block the two keys diverge, the anchor misses,
-    // and the live lid is overwritten by a slug with `errors` empty — which
-    // `integration.rs` reports as a Notice while applying it. That makes
-    // #85 a destructive-write gap, not merely a management one, so it is
-    // pinned here as the failure it is rather than as accepted behaviour.
+    // Braze reassigns the (never-managed) cb_id. This used to overwrite
+    // the live lid with a path-tail slug, because the raw `cbN` sat
+    // inside the anchor key and the reassignment made the template-side
+    // and remote-side keys diverge. It no longer does: `cb_id_filter_re`
+    // masks the `cbN` out of the key regardless, so the key stays stable
+    // and the lid anchor still matches.
     let remote_reassigned = authored.replace("| id: 'cb1'", "| id: 'cb7'");
     let p = prepare_field(
         &t.new_body,
         Some(&remote_reassigned),
         FieldKind::ContentBlock,
     );
-    assert!(p.errors.is_empty(), "still silent: {:?}", p.errors);
-    assert_eq!(
-        p.fallbacks.len(),
-        1,
-        "the live lid is replaced by a fallback slug: {:?}",
+    assert!(p.errors.is_empty(), "{:?}", p.errors);
+    assert!(
+        p.fallbacks.is_empty(),
+        "the live lid must survive cb_id reassignment: {:?}",
         p.fallbacks
     );
     assert_eq!(
         lids(&p.body),
-        vec!["p".to_string()],
-        "slug from the URL path tail, POSTed over 'liveaaaaaaaa1': {}",
+        vec!["liveaaaaaaaa1".to_string()],
+        "the live lid must not be overwritten by a slug: {}",
         p.body
     );
 }

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -459,6 +459,45 @@ fn whitespace_named_include_no_longer_corrupts_a_live_lid() {
 }
 
 #[test]
+fn blank_named_include_no_longer_corrupts_a_live_lid() {
+    // Same fix, the other invalid-name case: an all-padding/empty
+    // `${NAME}` (`cb_id_filter_re`'s capture is `*`, not `+`, precisely
+    // so this masks too). Unit-tested in isolation elsewhere
+    // (`correlation::cb_id_filter_masks_a_name_containing_whitespace`,
+    // `templatize::cb_id_include_with_blank_name_is_left_untemplated_with_warning`)
+    // but not previously driven through the full templatize → resolve →
+    // reassign round trip the way the whitespace case is above.
+    let authored = r#"<a href="https://x.com/{{content_blocks.${} | id: 'cb1'}}/p">{{x | lid: 'liveaaaaaaaa1'}}</a>"#;
+    let t = templatize_body(authored, FieldKind::ContentBlock);
+    assert_eq!(t.lid_rewrites, 1);
+    assert_eq!(t.cb_id_rewrites, 0, "a blank name is never managed");
+    assert!(
+        t.warnings.iter().any(|w| w.contains("is empty")),
+        "expected a warning about the blank content block name, got: {:?}",
+        t.warnings
+    );
+
+    let remote_reassigned = authored.replace("| id: 'cb1'", "| id: 'cb7'");
+    let p = prepare_field(
+        &t.new_body,
+        Some(&remote_reassigned),
+        FieldKind::ContentBlock,
+    );
+    assert!(p.errors.is_empty(), "{:?}", p.errors);
+    assert!(
+        p.fallbacks.is_empty(),
+        "the live lid must survive cb_id reassignment: {:?}",
+        p.fallbacks
+    );
+    assert_eq!(
+        lids(&p.body),
+        vec!["liveaaaaaaaa1".to_string()],
+        "the live lid must not be overwritten by a slug: {}",
+        p.body
+    );
+}
+
+#[test]
 fn lid_in_a_non_anchor_element_body_has_no_template_side_anchor() {
     // Second known boundary (#84), found by the table above. The two sides
     // do not agree on which elements can carry an anchor:

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -76,8 +76,15 @@ pub fn templatize_body(body: &str, field: FieldKind) -> TemplatizedField {
     for m in cb_id_match_re().captures_iter(body) {
         let whole = m.get(0).expect("group 0 always present");
         let name = m.get(1).expect("name capture present").as_str();
-        let trimmed = name.trim_ascii();
-        let has_internal_whitespace = trimmed.bytes().any(|b| b.is_ascii_whitespace());
+        // `trim_matches`/`is_cb_id_whitespace` here, not `str::trim_ascii` /
+        // `u8::is_ascii_whitespace` — the latter excludes U+000B (vertical
+        // tab), while the narrow `[^\s}|]+` regexes this name is later
+        // checked against (`braze_managed::cb_id_template_re` et al.) use
+        // regex `\s`, which includes it. A name differing only in a `\v`
+        // must agree on both sides, or a name this pass treats as clean
+        // can still fail to resolve at apply time via those regexes.
+        let trimmed = name.trim_matches(is_cb_id_whitespace);
+        let has_internal_whitespace = trimmed.chars().any(is_cb_id_whitespace);
         if trimmed.is_empty() || has_internal_whitespace {
             // Braze content block names cannot be empty or contain
             // whitespace, so this include can never denote a real content
@@ -91,8 +98,12 @@ pub fn templatize_body(body: &str, field: FieldKind) -> TemplatizedField {
             } else {
                 "contains whitespace"
             };
+            // Escaped for display: the capture is now broad enough to
+            // admit control bytes (e.g. a stray newline), and this string
+            // is later written verbatim to the terminal by the CLI.
+            let shown = escape_for_warning(trimmed);
             warnings.push(format!(
-                "cb_id include at byte {}: content block name `{trimmed}` {problem}, \
+                "cb_id include at byte {}: content block name `{shown}` {problem}, \
                  which Braze does not allow — leaving this include untemplated; \
                  fix the name or the reference",
                 whole.start()
@@ -123,6 +134,30 @@ pub fn templatize_body(body: &str, field: FieldKind) -> TemplatizedField {
 struct DetectionSpan {
     range: std::ops::Range<usize>,
     replacement: String,
+}
+
+/// Whitespace per regex_lite's ASCII `\s` class (`[\t\n\v\f\r ]`) — not
+/// `char::is_ascii_whitespace`, which excludes U+000B vertical tab. This
+/// is the definition the narrow `[^\s}|]+` cb_id regexes use, so a name's
+/// validity here must agree with what those regexes will later match.
+fn is_cb_id_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t'..='\r')
+}
+
+/// Escape control bytes for safe interpolation into a warning string that
+/// the CLI writes verbatim to the terminal. The name capture is broad
+/// enough to admit a stray newline or escape byte; this keeps one from
+/// injecting a line into the operator's summary output.
+fn escape_for_warning(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_control() {
+                format!("\\u{{{:x}}}", c as u32)
+            } else {
+                c.to_string()
+            }
+        })
+        .collect()
 }
 
 fn lid_match_re() -> &'static Regex {
@@ -210,6 +245,25 @@ mod tests {
     }
 
     #[test]
+    fn cb_id_include_with_vertical_tab_in_name_is_left_untemplated_with_warning() {
+        // regex_lite's `\s` (used by the still-narrow `[^\s}|]+` regexes
+        // in braze_managed.rs) includes U+000B vertical tab, but Rust's
+        // `is_ascii_whitespace`/`trim_ascii` do not. A name that is
+        // "clean" only by the latter definition would be managed here
+        // with no warning, then permanently fail to resolve at apply
+        // time via those still-narrow regexes.
+        let body = "{{content_blocks.${Plan\u{000B}US} | id: 'cb1'}}";
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.cb_id_rewrites, 0, "must not silently manage it");
+        assert_eq!(r.new_body, body, "left untouched");
+        assert!(
+            r.warnings.iter().any(|w| w.contains("whitespace")),
+            "got: {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
     fn cb_id_include_with_blank_name_is_left_untemplated_with_warning() {
         let body = "{{content_blocks.${   } | id: 'cb1'}}";
         let r = templatize_body(body, FieldKind::ContentBlock);
@@ -218,6 +272,26 @@ mod tests {
         assert!(
             r.warnings.iter().any(|w| w.contains("is empty")),
             "got: {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn cb_id_warning_escapes_control_bytes_in_the_name() {
+        // The name capture is broad enough to admit a raw newline; the
+        // warning is later written verbatim to the terminal by the CLI
+        // (`eprintln!`), so a literal `\n` here must not inject a line.
+        let body = "{{content_blocks.${evil\nfake: all clear} | id: 'cb1'}}";
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.cb_id_rewrites, 0);
+        assert!(
+            r.warnings.iter().all(|w| !w.contains('\n')),
+            "a literal newline must not reach the warning text: {:?}",
+            r.warnings
+        );
+        assert!(
+            r.warnings.iter().any(|w| w.contains("\\u{a}")),
+            "the newline must be visibly escaped: {:?}",
             r.warnings
         );
     }

--- a/src/values/templatize.rs
+++ b/src/values/templatize.rs
@@ -76,9 +76,32 @@ pub fn templatize_body(body: &str, field: FieldKind) -> TemplatizedField {
     for m in cb_id_match_re().captures_iter(body) {
         let whole = m.get(0).expect("group 0 always present");
         let name = m.get(1).expect("name capture present").as_str();
+        let trimmed = name.trim_ascii();
+        let has_internal_whitespace = trimmed.bytes().any(|b| b.is_ascii_whitespace());
+        if trimmed.is_empty() || has_internal_whitespace {
+            // Braze content block names cannot be empty or contain
+            // whitespace, so this include can never denote a real content
+            // block. Leave it raw rather than manage it — but say so,
+            // instead of the silent gap #85 used to be
+            // (`correlation::cb_id_filter_re` still masks the raw `cbN`
+            // out of any nearby anchor key, so this does not corrupt an
+            // unrelated lid the way it used to).
+            let problem = if trimmed.is_empty() {
+                "is empty"
+            } else {
+                "contains whitespace"
+            };
+            warnings.push(format!(
+                "cb_id include at byte {}: content block name `{trimmed}` {problem}, \
+                 which Braze does not allow — leaving this include untemplated; \
+                 fix the name or the reference",
+                whole.start()
+            ));
+            continue;
+        }
         spans.push(DetectionSpan {
             range: whole.range(),
-            replacement: format!("{{{{content_blocks.${{{name}}} | id: '__BRAZESYNC__'}}}}"),
+            replacement: format!("{{{{content_blocks.${{{trimmed}}} | id: '__BRAZESYNC__'}}}}"),
         });
         cb_id_rewrites += 1;
     }
@@ -116,8 +139,14 @@ fn lid_match_re() -> &'static Regex {
 fn cb_id_match_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
+        // `${NAME}` is captured broadly (`[^}|]*`, not `[^\s}|]+`) so an
+        // include whose name holds whitespace is still detected. Braze
+        // forbids whitespace in a real content block name, so such an
+        // include can never be managed — but it must be *seen* here to
+        // warn about it (#85) rather than silently skipped, which is what
+        // let the raw `cbN` sit unmanaged with no diagnostic at all.
         Regex::new(
-            r#"\{\{\s*content_blocks\.\$\{\s*([^\s}|]+)\s*\}\s*\|\s*id:\s*(?:"cb[0-9]+"|'cb[0-9]+')\s*\}\}"#,
+            r#"\{\{\s*content_blocks\.\$\{([^}|]*)\}\s*\|\s*id:\s*(?:"cb[0-9]+"|'cb[0-9]+')\s*\}\}"#,
         )
         .expect("cb_id match regex is valid")
     })
@@ -154,6 +183,48 @@ mod tests {
     #[test]
     fn rewrites_cb_id_include() {
         let body = "{{content_blocks.${promo_banner} | id: 'cb42'}}";
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert!(
+            r.new_body
+                .contains("{{content_blocks.${promo_banner} | id: '__BRAZESYNC__'}}"),
+            "got: {}",
+            r.new_body
+        );
+        assert_eq!(r.cb_id_rewrites, 1);
+    }
+
+    #[test]
+    fn cb_id_include_with_whitespace_in_name_is_left_untemplated_with_warning() {
+        // #85: Braze forbids whitespace in a content block name, so this
+        // include can never denote a real one. It must not be silently
+        // skipped — that was the bug.
+        let body = "{{content_blocks.${Plan (US)} | id: 'cb1'}}";
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.cb_id_rewrites, 0);
+        assert_eq!(r.new_body, body, "left untouched");
+        assert!(
+            r.warnings.iter().any(|w| w.contains("whitespace")),
+            "got: {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn cb_id_include_with_blank_name_is_left_untemplated_with_warning() {
+        let body = "{{content_blocks.${   } | id: 'cb1'}}";
+        let r = templatize_body(body, FieldKind::ContentBlock);
+        assert_eq!(r.cb_id_rewrites, 0);
+        assert_eq!(r.new_body, body, "left untouched");
+        assert!(
+            r.warnings.iter().any(|w| w.contains("is empty")),
+            "got: {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn cb_id_include_name_padding_is_trimmed() {
+        let body = "{{content_blocks.${ promo_banner } | id: 'cb42'}}";
         let r = templatize_body(body, FieldKind::ContentBlock);
         assert!(
             r.new_body

--- a/tests/cli_templatize.rs
+++ b/tests/cli_templatize.rs
@@ -9,6 +9,7 @@ mod common;
 
 use assert_cmd::Command;
 use common::write_local_content_block;
+use predicates::prelude::*;
 use std::fs;
 
 /// Write a config that declares two envs so the skeleton path is exercised.
@@ -249,5 +250,37 @@ fn templatize_does_not_overwrite_existing_skeleton() {
     assert!(
         dev.contains("existinglid1"),
         "existing dev value must be preserved, got:\n{dev}"
+    );
+}
+
+#[test]
+fn templatize_warns_on_whitespace_named_cb_id_even_with_nothing_else_to_rewrite() {
+    // #85: a content block whose *only* content is an invalid (whitespace-
+    // named) cb_id include has zero rewrites, so it must not fall through
+    // the "nothing to do" skip before its warning is collected — that was
+    // the bug: the warning existed in `templatize_body`'s return value but
+    // never reached the operator because the CLI's per-resource loop
+    // `continue`d past the warning-collection step whenever rewrites == 0.
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_multi_env_config(tmp.path());
+    write_local_content_block(
+        tmp.path(),
+        "promo",
+        "{{content_blocks.${Plan (US)} | id: 'cb1'}}",
+    );
+
+    Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap()])
+        .args(["templatize"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("contains whitespace"));
+
+    // Left untouched — the include is not manageable, so nothing rewrites.
+    let body = fs::read_to_string(tmp.path().join("content_blocks").join("promo.liquid")).unwrap();
+    assert!(
+        body.contains("| id: 'cb1'"),
+        "unmanageable include must be left raw, got:\n{body}"
     );
 }


### PR DESCRIPTION
## Summary
- `correlation::cb_id_filter_re` (used by `normalize_url` to build the anchor key that pairs a template lid placeholder with its live remote value) required `${NAME}` to contain no whitespace at all. When a `content_blocks.${NAME}` include's name held whitespace, the whole include failed to match, so its raw `cbN` stayed embedded in the anchor key. Once Braze reassigned that cbN, the template-side and remote-side keys diverged, the neighboring `lid`'s anchor missed, and its live value was silently overwritten by a generated slug (no error, no non-zero exit code).
- Braze's own naming rules (confirmed against public API docs) forbid whitespace in a real content block name, so such an include can never be `templatize`-managed either way — but the masking that stabilizes a neighboring anchor's key must not depend on that. `cb_id_filter_re`'s capture is widened to `[^}|]*` (also covering an all-padding/empty name) so it matches and masks regardless.
- `templatize::cb_id_match_re` is widened the same way so it can *detect* such an include and warn about it instead of staying silent — it still declines to manage it.
- `correlation::cb_id_include_re` and `braze_managed`'s two cb_id regexes are deliberately left narrow (see comments added at each site for why): widening them would either break the drift invariant `roundtrip.rs` already asserts, or let a hand-authored malformed placeholder resolve as if it were valid instead of failing loudly via the existing `UnresolvedCbId` path.
- Corrects a stale doc comment in `correlation.rs` that conflated Braze's personalization-attribute naming (spaces allowed) with content block naming (alphanumeric/dash/underscore only).

Closes #85.

## Test plan
- [x] `cargo test` — 436 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `roundtrip.rs::whitespace_named_include_no_longer_corrupts_a_live_lid` — rewritten from a destructive-behavior pin to assert the live lid survives `cb1 → cb7` reassignment
- [x] `roundtrip.rs::respelling_never_merges_two_distinct_links` — new row: `${a b}` vs `${ab}` stay distinct anchors (trim removes padding only, never interior bytes)
- [x] `correlation.rs::cb_id_filter_masks_a_name_containing_whitespace` — direct unit test of the masking fix, including the empty/all-padding-name edge case
- [x] `templatize.rs` — new unit tests for the whitespace/blank-name warning path and padding-trim behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of content-block names containing whitespace, blank names, and extra padding.
  * Prevented invalid names from disrupting nearby template references or correlation.
  * Preserved valid references while leaving unsupported placeholders unchanged and issuing warnings.
  * Ensured warnings are shown even when no template rewrites are performed.

* **Documentation**
  * Clarified expected behavior for whitespace-containing content-block names and invalid placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->