### PR TITLE
Gate the lid fallback: non-zero diff exit, --allow-fallback for apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ across all v1.x releases.
 | `5` | Rate limit retries exhausted |
 | `6` | Destructive change blocked (pass `--allow-destructive`) |
 | `7` | Plan/apply mismatch (`apply --plan` ops drift) |
-| `8` | Fallback gate (unmatched placeholder + unconsumed remote lid; `apply --allow-fallback` to proceed) |
+| `8` | Fallback gate (unmatched placeholder + unconsumed remote lid). Unlike `2`, `diff` has no opt-in flag for this — it always exits `8` when the gate fires; `apply` requires `--allow-fallback` |
 
 ## Output formats
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ across all v1.x releases.
 | `5` | Rate limit retries exhausted |
 | `6` | Destructive change blocked (pass `--allow-destructive`) |
 | `7` | Plan/apply mismatch (`apply --plan` ops drift) |
+| `8` | Fallback gate (unmatched placeholder + unconsumed remote lid; `apply --allow-fallback` to proceed) |
 
 ## Output formats
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -60,6 +60,7 @@ Exit-code contract:
 | `4` | API key is invalid | Fail & page the operator |
 | `5` | Rate limit retries exhausted | Retry the job |
 | `6` | Destructive change blocked (see `apply --allow-destructive`) | Fail the build / block merge |
+| `8` | Fallback gate: unmatched placeholder + unconsumed remote lid value (see `apply --allow-fallback`). Unlike code `2`, this fires unconditionally — plain `diff` has no opt-in flag for it | Fail the build / block merge |
 
 ## Apply on merge
 
@@ -117,6 +118,13 @@ on:
       - if: ${{ !inputs.allow_destructive }}
         run: braze-sync apply --env prod --confirm
 ```
+
+The fallback gate (exit `8`) works the same way: it fires when a
+template placeholder had no matching remote value *and* the remote
+body left a lid value unconsumed — a shape that can indicate a link
+merge/reorder rather than a plain new link. Review the flagged
+resource(s) in the `diff`/`apply` output before re-running with
+`--allow-fallback`; there is no auto-retry path for this one.
 
 ## Consuming `--format json`
 

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -54,6 +54,13 @@ pub struct ApplyArgs {
     #[arg(long)]
     pub allow_destructive: bool,
 
+    /// Permit applying when the fallback gate fired: some field had an
+    /// unmatched template placeholder and an unconsumed remote lid
+    /// value at the same time (see the Notice block). Required in
+    /// addition to `--confirm`.
+    #[arg(long)]
+    pub allow_fallback: bool,
+
     /// Load a plan file produced by `diff --plan-out=<path>` and refuse
     /// to apply if the freshly-computed plan does not match. Exits with
     /// code 7 on mismatch.
@@ -225,6 +232,18 @@ pub async fn run(
 
     if summary.destructive_count() > 0 && !args.allow_destructive {
         return Err(Error::DestructiveBlocked.into());
+    }
+
+    let gated_fallback_count: usize = fallback_reports
+        .iter()
+        .filter(|r| r.gated)
+        .map(|r| r.fallbacks.len())
+        .sum();
+    if gated_fallback_count > 0 && !args.allow_fallback {
+        return Err(Error::FallbackGated {
+            count: gated_fallback_count,
+        }
+        .into());
     }
 
     check_for_unsupported_ops(&summary)?;

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -21,7 +21,7 @@ use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::error::Error;
 use crate::format::{OutputFormat, TableFormatter};
 use crate::resource::ResourceKind;
-use crate::values::{format_fallback_reports, FallbackReport};
+use crate::values::{format_fallback_reports, gated_fallback_count, FallbackReport};
 use anyhow::{anyhow, Context as _};
 use clap::Args;
 use std::path::{Path, PathBuf};
@@ -234,16 +234,9 @@ pub async fn run(
         return Err(Error::DestructiveBlocked.into());
     }
 
-    let gated_fallback_count: usize = fallback_reports
-        .iter()
-        .filter(|r| r.gated)
-        .map(|r| r.fallbacks.len())
-        .sum();
-    if gated_fallback_count > 0 && !args.allow_fallback {
-        return Err(Error::FallbackGated {
-            count: gated_fallback_count,
-        }
-        .into());
+    let gated_count = gated_fallback_count(&fallback_reports);
+    if gated_count > 0 && !args.allow_fallback {
+        return Err(Error::FallbackGated { count: gated_count }.into());
     }
 
     check_for_unsupported_ops(&summary)?;

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -23,8 +23,8 @@ use crate::format::{OutputFormat, TableFormatter};
 use crate::fs::{catalog_io, content_block_io, custom_attribute_io, email_template_io, tag_io};
 use crate::resource::{Catalog, ContentBlock, EmailTemplate, ResourceKind};
 use crate::values::{
-    format_failures, format_fallback_reports, resolve_content_block_with_remote,
-    resolve_email_template_with_remote, FallbackReport,
+    format_failures, format_fallback_reports, gated_fallback_count,
+    resolve_content_block_with_remote, resolve_email_template_with_remote, FallbackReport,
 };
 use anyhow::Context as _;
 use clap::Args;
@@ -174,16 +174,9 @@ pub async fn run(
         );
     }
 
-    let gated_fallback_count: usize = fallback_reports
-        .iter()
-        .filter(|r| r.gated)
-        .map(|r| r.fallbacks.len())
-        .sum();
-    if gated_fallback_count > 0 {
-        return Err(Error::FallbackGated {
-            count: gated_fallback_count,
-        }
-        .into());
+    let gated_count = gated_fallback_count(&fallback_reports);
+    if gated_count > 0 {
+        return Err(Error::FallbackGated { count: gated_count }.into());
     }
 
     if args.fail_on_drift && summary.changed_count() > 0 {

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -174,6 +174,18 @@ pub async fn run(
         );
     }
 
+    let gated_fallback_count: usize = fallback_reports
+        .iter()
+        .filter(|r| r.gated)
+        .map(|r| r.fallbacks.len())
+        .sum();
+    if gated_fallback_count > 0 {
+        return Err(Error::FallbackGated {
+            count: gated_fallback_count,
+        }
+        .into());
+    }
+
     if args.fail_on_drift && summary.changed_count() > 0 {
         return Err(Error::DriftDetected {
             count: summary.changed_count(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -290,6 +290,7 @@ fn exit_code_for(err: &anyhow::Error) -> i32 {
                 Error::DriftDetected { .. } => return 2,
                 Error::Config(_) | Error::MissingEnv(_) => return 3,
                 Error::RateLimitExhausted { .. } => return 5,
+                Error::FallbackGated { .. } => return 8,
                 Error::Io(_)
                 | Error::YamlParse { .. }
                 | Error::CsvParse { .. }
@@ -448,6 +449,12 @@ mod tests {
     fn exit_code_for_destructive_blocked() {
         let err = anyhow::Error::new(Error::DestructiveBlocked);
         assert_eq!(exit_code_for(&err), 6);
+    }
+
+    #[test]
+    fn exit_code_for_fallback_gated() {
+        let err = anyhow::Error::new(Error::FallbackGated { count: 1 });
+        assert_eq!(exit_code_for(&err), 8);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,4 +50,11 @@ pub enum Error {
 
     #[error("Rate limit exhausted after {retries} retries")]
     RateLimitExhausted { retries: u32 },
+
+    #[error(
+        "Fallback gate: {count} lid value(s) resolved with unmatched placeholder(s) and \
+         unconsumed remote value(s) both present (see Notice above) — `apply` requires \
+         --allow-fallback to proceed"
+    )]
+    FallbackGated { count: usize },
 }

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -195,11 +195,7 @@ fn resolve_lid_batch(
         return (Vec::new(), 0);
     }
     if !field.supports_html_anchor() && !field.supports_plaintext_anchor() {
-        // Positional FIFO can't structurally leave both an unmatched
-        // placeholder and an unconsumed remote value at once — whichever
-        // side is longer accounts for the entire imbalance — so there is
-        // nothing to feed into the gate here.
-        let out = resolve_lid_positional(
+        return resolve_lid_positional(
             placeholders,
             lid_indices,
             remote,
@@ -207,7 +203,6 @@ fn resolve_lid_batch(
             warnings,
             fallbacks,
         );
-        return (out, 0);
     }
 
     let remote_pairs: Vec<LidCorrelation> = if field.supports_html_anchor() {
@@ -322,7 +317,7 @@ fn resolve_lid_positional(
     field: FieldKind,
     warnings: &mut Vec<String>,
     fallbacks: &mut Vec<LidFallback>,
-) -> Vec<Option<String>> {
+) -> (Vec<Option<String>>, usize) {
     let remote_values = extract_lid_values_unanchored(remote);
     let field_label = match field {
         FieldKind::EmailSubject => "subject",
@@ -360,7 +355,14 @@ fn resolve_lid_positional(
             }
         }
     }
-    out
+    // Whatever `iter` did not yield during the loop above is the remote
+    // leftover: the loop calls `next()` exactly `lid_indices.len()` times,
+    // so if `remote_values` was longer, the remainder is still sitting in
+    // `iter`. Computed rather than asserted, so a future change to the
+    // matching logic above (e.g. skipping already-used values) can't
+    // silently desync this count from what was actually left unconsumed.
+    let unconsumed_remote_lid = iter.count();
+    (out, unconsumed_remote_lid)
 }
 
 /// Pair cb_id placeholders with remote `${NAME} | id: 'cbN'` matches by
@@ -772,11 +774,15 @@ mod tests {
     #[test]
     fn subject_with_more_remote_lids_than_template_does_not_gate() {
         // The mirror case: remote has more lid values than the template has
-        // placeholders. The extra remote value is simply dropped (with a
-        // warning), never recorded as a fallback, so the gate's other half
-        // (`!fallbacks.is_empty()`) is never satisfied either — pins the
-        // positional path's hardcoded 0-unconsumed-count for this direction
-        // too, not just the template-longer-than-remote one above.
+        // placeholders. `resolve_lid_positional` drops the extra value (with
+        // a warning) rather than recording a fallback, so `fallbacks` stays
+        // empty and the gate's `!fallbacks.is_empty()` half never fires here
+        // — independent of whatever `resolve_lid_positional` computes for
+        // its now-real (no longer hardcoded) unconsumed-remote count, which
+        // isn't observable through `prepare_field`'s public surface. This
+        // pins the *outward* behavior (no gate, a warning); it does not and
+        // cannot pin the internal count computation directly, since the two
+        // are structurally independent on this path.
         let template = "{{x | lid: '__BRAZESYNC__'}} A";
         let remote = "{{x | lid: 'firstval123'}} A {{y | lid: 'secondval2b'}}";
         let p = prepare_field(template, Some(remote), FieldKind::EmailSubject);
@@ -784,6 +790,11 @@ mod tests {
         assert!(p.body.contains("'firstval123'"));
         assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
         assert!(!p.fallback_gated);
+        assert!(
+            p.warnings.iter().any(|w| w.contains("will be dropped")),
+            "got: {:?}",
+            p.warnings
+        );
     }
 
     #[test]

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -770,6 +770,23 @@ mod tests {
     }
 
     #[test]
+    fn subject_with_more_remote_lids_than_template_does_not_gate() {
+        // The mirror case: remote has more lid values than the template has
+        // placeholders. The extra remote value is simply dropped (with a
+        // warning), never recorded as a fallback, so the gate's other half
+        // (`!fallbacks.is_empty()`) is never satisfied either — pins the
+        // positional path's hardcoded 0-unconsumed-count for this direction
+        // too, not just the template-longer-than-remote one above.
+        let template = "{{x | lid: '__BRAZESYNC__'}} A";
+        let remote = "{{x | lid: 'firstval123'}} A {{y | lid: 'secondval2b'}}";
+        let p = prepare_field(template, Some(remote), FieldKind::EmailSubject);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.body.contains("'firstval123'"));
+        assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
+        assert!(!p.fallback_gated);
+    }
+
+    #[test]
     fn retired_envelope_is_fatal() {
         let template = "stuff __BRAZESYNC.lid.foo__ stuff";
         let p = prepare_field(template, None, FieldKind::ContentBlock);

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -42,6 +42,13 @@ pub struct PreparedTemplate {
     /// the expected path and would be noise. Populated only when a
     /// remote body was provided but came up short.
     pub fallbacks: Vec<LidFallback>,
+    /// `true` when, after all exact matching for this field completed,
+    /// unmatched template placeholders (`fallbacks` non-empty) *and*
+    /// unconsumed remote lid values coexisted. This is the suspicious
+    /// case #79's "Gate the fallback" targets — an ordinary new link
+    /// also leaves `fallbacks` non-empty with nothing on the remote
+    /// side to consume, and must not gate. See `resolve_lid_batch`.
+    pub fallback_gated: bool,
 }
 
 /// A single drift-fallback assignment. `anchor` is the URL anchor when
@@ -72,6 +79,7 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
             errors,
             warnings: Vec::new(),
             fallbacks: Vec::new(),
+            fallback_gated: false,
         };
     }
 
@@ -95,7 +103,7 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
         .map(|(i, _)| i)
         .collect();
 
-    let lid_values: Vec<Option<String>> = match remote {
+    let (lid_values, unconsumed_remote_lid): (Vec<Option<String>>, usize) = match remote {
         Some(remote_body) => resolve_lid_batch(
             &body,
             &placeholders,
@@ -105,8 +113,12 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
             &mut warnings,
             &mut fallbacks,
         ),
-        None => fallback_lid_batch(&body, &placeholders, &lid_indices, field),
+        None => (
+            fallback_lid_batch(&body, &placeholders, &lid_indices, field),
+            0,
+        ),
     };
+    let fallback_gated = !fallbacks.is_empty() && unconsumed_remote_lid > 0;
 
     // cb_id resolution map (offset → value or None).
     let cb_id_resolved: BTreeMap<usize, Option<String>> = match remote {
@@ -161,11 +173,15 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
         errors,
         warnings,
         fallbacks,
+        fallback_gated,
     }
 }
 
 /// Resolve lid placeholders against `remote`. Returns one entry per
-/// lid placeholder in template-appearance order.
+/// lid placeholder in template-appearance order, plus the count of
+/// remote lid values left in the URL buckets after matching — the
+/// other half of the fallback gate's condition (see
+/// `PreparedTemplate::fallback_gated`).
 fn resolve_lid_batch(
     body: &str,
     placeholders: &[crate::values::placeholder::Placeholder],
@@ -174,12 +190,16 @@ fn resolve_lid_batch(
     field: FieldKind,
     warnings: &mut Vec<String>,
     fallbacks: &mut Vec<LidFallback>,
-) -> Vec<Option<String>> {
+) -> (Vec<Option<String>>, usize) {
     if lid_indices.is_empty() {
-        return Vec::new();
+        return (Vec::new(), 0);
     }
     if !field.supports_html_anchor() && !field.supports_plaintext_anchor() {
-        return resolve_lid_positional(
+        // Positional FIFO can't structurally leave both an unmatched
+        // placeholder and an unconsumed remote value at once — whichever
+        // side is longer accounts for the entire imbalance — so there is
+        // nothing to feed into the gate here.
+        let out = resolve_lid_positional(
             placeholders,
             lid_indices,
             remote,
@@ -187,6 +207,7 @@ fn resolve_lid_batch(
             warnings,
             fallbacks,
         );
+        return (out, 0);
     }
 
     let remote_pairs: Vec<LidCorrelation> = if field.supports_html_anchor() {
@@ -263,7 +284,8 @@ fn resolve_lid_batch(
             }
         }
     }
-    out
+    let unconsumed_remote_lid = by_url.values().map(|b| b.len()).sum();
+    (out, unconsumed_remote_lid)
 }
 
 /// Slug fallback for a single lid placeholder. `used` is shared across
@@ -670,6 +692,54 @@ mod tests {
             .warnings
             .iter()
             .any(|w| w.contains("not found in remote body")));
+        // The remote body carries no lid values at all, so there is
+        // nothing left unconsumed — an ordinary new link must not gate.
+        assert!(!p.fallback_gated);
+    }
+
+    #[test]
+    fn fallback_gates_when_placeholder_miss_and_remote_leftover_coexist() {
+        // The template's link no longer matches anything in the remote
+        // body (URL changed), *and* the remote carries an entirely
+        // different link the template no longer references. Both an
+        // unmatched placeholder and an unconsumed remote value survive
+        // past exact matching — the case #79's gate exists to flag.
+        let template = r#"<a href="https://x.com/new-page">{{x | lid: '__BRAZESYNC__'}}</a>"#;
+        let remote = r#"<a href="https://x.com/old-page">{{x | lid: 'liveeeeeeee1'}}</a>"#;
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert_eq!(p.fallbacks.len(), 1, "{:?}", p.fallbacks);
+        assert!(
+            p.fallback_gated,
+            "expected the gate to fire: unmatched placeholder + unconsumed remote value"
+        );
+    }
+
+    #[test]
+    fn extra_remote_link_alone_does_not_gate() {
+        // Every template placeholder resolves against its own link; the
+        // remote simply carries one extra link the template no longer
+        // references (e.g. a link was removed from the template). No
+        // placeholder is unmatched, so the gate must not fire even
+        // though a remote value is left unconsumed.
+        let template = r#"<a href="https://x.com/a">{{x | lid: '__BRAZESYNC__'}}</a>"#;
+        let remote = r#"<a href="https://x.com/a">{{x | lid: 'liveeeeeeee1'}}</a>
+<a href="https://x.com/b">{{x | lid: 'liveeeeeeee2'}}</a>"#;
+        let p = prepare_field(template, Some(remote), FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(p.fallbacks.is_empty(), "{:?}", p.fallbacks);
+        assert!(!p.fallback_gated);
+    }
+
+    #[test]
+    fn new_resource_never_gates() {
+        // `remote = None` is the new-resource path — every lid is a
+        // documented fallback, not a suspicious one, and there is no
+        // remote body to leave anything unconsumed in.
+        let template = r#"<a href="https://x.com/spring-sale">{{x | lid: '__BRAZESYNC__'}}</a>"#;
+        let p = prepare_field(template, None, FieldKind::ContentBlock);
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        assert!(!p.fallback_gated);
     }
 
     #[test]
@@ -693,6 +763,10 @@ mod tests {
         assert!(p.errors.is_empty(), "{:?}", p.errors);
         assert!(p.body.contains("'firstval123'"));
         assert!(p.body.contains("'lid_1'"), "got: {}", p.body);
+        // Positional FIFO can't leave both sides non-empty at once — the
+        // template has strictly more placeholders than the remote has
+        // values, so nothing remote is left unconsumed.
+        assert!(!p.fallback_gated);
     }
 
     #[test]

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -166,6 +166,18 @@ pub fn resolve_email_template_with_remote(
     Ok(reports)
 }
 
+/// Count of fallback values across `reports` whose report is gated (see
+/// [`FallbackReport::gated`]). Shared by `format_fallback_reports` and the
+/// `diff` / `apply` CLI gate checks so the "how many are gated" definition
+/// has one source.
+pub fn gated_fallback_count(reports: &[FallbackReport]) -> usize {
+    reports
+        .iter()
+        .filter(|r| r.gated)
+        .map(|r| r.fallbacks.len())
+        .sum()
+}
+
 /// Human-readable summary block for collected drift fallbacks.
 /// Empty input → empty string (so callers can append unconditionally).
 pub fn format_fallback_reports(reports: &[FallbackReport]) -> String {
@@ -173,11 +185,7 @@ pub fn format_fallback_reports(reports: &[FallbackReport]) -> String {
         return String::new();
     }
     let total: usize = reports.iter().map(|r| r.fallbacks.len()).sum();
-    let gated_total: usize = reports
-        .iter()
-        .filter(|r| r.gated)
-        .map(|r| r.fallbacks.len())
-        .sum();
+    let gated_total = gated_fallback_count(reports);
     let mut out = String::new();
     out.push_str(&format!(
         "\nNotice: {total} link(s) resolved with fallback lid values \
@@ -417,6 +425,22 @@ mod tests {
         );
         let reports = resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
         assert_eq!(reports.len(), 1);
+        assert!(reports[0].gated);
+    }
+
+    #[test]
+    fn email_template_placeholder_miss_and_remote_leftover_report_is_gated() {
+        // Same suspicious shape as the content_block case above, but through
+        // the per-field `resolve_field!` macro path — that path independently
+        // sets `gated: prep.fallback_gated` per field and had no coverage.
+        let mut t = et("welcome");
+        t.body_html = r#"<a href="https://x.com/new-page">{{x | lid: '__BRAZESYNC__'}}</a>"#.into();
+        let mut remote = et("welcome");
+        remote.body_html =
+            r#"<a href="https://x.com/old-page">{{x | lid: 'liveeeeeeee1'}}</a>"#.into();
+        let reports = resolve_email_template_with_remote(&mut t, Some(&remote)).unwrap();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].field, Some("body_html"));
         assert!(reports[0].gated);
     }
 

--- a/src/values/integration.rs
+++ b/src/values/integration.rs
@@ -16,6 +16,10 @@ pub struct FallbackReport {
     pub resource_name: String,
     pub field: Option<&'static str>,
     pub fallbacks: Vec<LidFallback>,
+    /// See [`crate::values::braze_managed::PreparedTemplate::fallback_gated`].
+    /// `diff` exits non-zero and `apply` requires `--allow-fallback` when
+    /// any report in a run has this set.
+    pub gated: bool,
 }
 
 /// One resource's worth of placeholder failures, ready to be folded
@@ -64,6 +68,7 @@ pub fn resolve_content_block_with_remote(
             resource_name: cb.name.clone(),
             field: None,
             fallbacks: prep.fallbacks,
+            gated: prep.fallback_gated,
         }]
     };
     Ok(reports)
@@ -103,6 +108,7 @@ pub fn resolve_email_template_with_remote(
                             resource_name: et.name.clone(),
                             field: Some($field_name),
                             fallbacks: prep.fallbacks,
+                            gated: prep.fallback_gated,
                         });
                     }
                     Some(prep.body)
@@ -167,6 +173,11 @@ pub fn format_fallback_reports(reports: &[FallbackReport]) -> String {
         return String::new();
     }
     let total: usize = reports.iter().map(|r| r.fallbacks.len()).sum();
+    let gated_total: usize = reports
+        .iter()
+        .filter(|r| r.gated)
+        .map(|r| r.fallbacks.len())
+        .sum();
     let mut out = String::new();
     out.push_str(&format!(
         "\nNotice: {total} link(s) resolved with fallback lid values \
@@ -178,6 +189,13 @@ pub fn format_fallback_reports(reports: &[FallbackReport]) -> String {
             None => format!("  {} '{}'", r.resource_kind, r.resource_name),
         };
         out.push_str(&scope);
+        if r.gated {
+            out.push_str(
+                " ⚠ GATED — unmatched placeholder(s) and unconsumed remote lid \
+                 value(s) both present; may indicate a link merge/reorder, not a \
+                 plain new link",
+            );
+        }
         out.push('\n');
         for fb in &r.fallbacks {
             match &fb.anchor {
@@ -188,6 +206,13 @@ pub fn format_fallback_reports(reports: &[FallbackReport]) -> String {
                 )),
             }
         }
+    }
+    if gated_total > 0 {
+        out.push_str(&format!(
+            "\n{gated_total} of the above are gated (see ⚠ above): `diff` exits \
+             non-zero; `apply` requires `--allow-fallback` in addition to \
+             `--confirm`.\n"
+        ));
     }
     out
 }
@@ -366,6 +391,70 @@ mod tests {
             Some("https://x.com/cta")
         );
         assert_eq!(reports[0].fallbacks[0].value, "cta");
+    }
+
+    #[test]
+    fn missing_remote_anchor_report_is_not_gated() {
+        let mut block = cb(
+            "promo",
+            r#"<a href="https://x.com/cta">{{x | lid: '__BRAZESYNC__'}}</a>"#,
+        );
+        let remote = cb("promo", "<p>no anchor here</p>");
+        let reports = resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
+        assert_eq!(reports.len(), 1);
+        assert!(!reports[0].gated);
+    }
+
+    #[test]
+    fn placeholder_miss_and_remote_leftover_report_is_gated() {
+        let mut block = cb(
+            "promo",
+            r#"<a href="https://x.com/new-page">{{x | lid: '__BRAZESYNC__'}}</a>"#,
+        );
+        let remote = cb(
+            "promo",
+            r#"<a href="https://x.com/old-page">{{x | lid: 'liveeeeeeee1'}}</a>"#,
+        );
+        let reports = resolve_content_block_with_remote(&mut block, Some(&remote)).unwrap();
+        assert_eq!(reports.len(), 1);
+        assert!(reports[0].gated);
+    }
+
+    #[test]
+    fn format_fallback_reports_marks_gated_entries() {
+        let reports = vec![FallbackReport {
+            resource_kind: "content_block",
+            resource_name: "promo".into(),
+            field: None,
+            fallbacks: vec![LidFallback {
+                anchor: Some("https://x.com/new-page".into()),
+                value: "new_page".into(),
+            }],
+            gated: true,
+        }];
+        let out = format_fallback_reports(&reports);
+        assert!(out.contains("GATED"), "got: {out}");
+        assert!(
+            out.contains("--allow-fallback"),
+            "expected the apply hint, got: {out}"
+        );
+    }
+
+    #[test]
+    fn format_fallback_reports_omits_gate_hint_when_nothing_gated() {
+        let reports = vec![FallbackReport {
+            resource_kind: "content_block",
+            resource_name: "promo".into(),
+            field: None,
+            fallbacks: vec![LidFallback {
+                anchor: Some("https://x.com/cta".into()),
+                value: "cta".into(),
+            }],
+            gated: false,
+        }];
+        let out = format_fallback_reports(&reports);
+        assert!(!out.contains("GATED"), "got: {out}");
+        assert!(!out.contains("--allow-fallback"), "got: {out}");
     }
 
     #[test]

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -17,8 +17,9 @@ pub use correlation::{
     slug_for_cb_id, slug_for_lid, Anchor, CbIdCorrelation, LidCorrelation,
 };
 pub use integration::{
-    format_failures, format_fallback_reports, resolve_content_block_with_remote,
-    resolve_email_template_with_remote, FallbackReport, ResolutionFailure,
+    format_failures, format_fallback_reports, gated_fallback_count,
+    resolve_content_block_with_remote, resolve_email_template_with_remote, FallbackReport,
+    ResolutionFailure,
 };
 pub use placeholder::{
     extract_placeholders, find_suspicious_placeholders, has_placeholders, Placeholder,

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -540,6 +540,159 @@ async fn content_block_confirm_update_posts_to_update_endpoint_with_id() {
     .unwrap();
 }
 
+// =====================================================================
+// Fallback gate (#79 Step3, #93)
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn confirm_with_fallback_gate_without_allow_fallback_exits_8() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-promo", "name": "promo"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .and(query_param("content_block_id", "id-promo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo",
+            "content": "<a href=\"https://example.com/old-page\">{{x | lid: 'liveeeeeeee1'}}</a>\n",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+    // Gate guard MUST fire before the update call.
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/update"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(
+        tmp.path(),
+        "promo",
+        "<a href=\"https://example.com/new-page\">{{x | lid: '__BRAZESYNC__'}}</a>\n",
+    );
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "content_block", "--confirm"])
+            .assert()
+            .failure()
+            .code(8);
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn confirm_with_allow_fallback_calls_update_and_exits_zero() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-promo", "name": "promo"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .and(query_param("content_block_id", "id-promo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo",
+            "content": "<a href=\"https://example.com/old-page\">{{x | lid: 'liveeeeeeee1'}}</a>\n",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/update"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(
+        tmp.path(),
+        "promo",
+        "<a href=\"https://example.com/new-page\">{{x | lid: '__BRAZESYNC__'}}</a>\n",
+    );
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "content_block",
+                "--confirm",
+                "--allow-fallback",
+            ])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dry_run_with_fallback_gate_does_not_require_allow_fallback() {
+    // The gate only blocks an actual apply — dry-run preview must still
+    // show the plan and exit 0 without needing --allow-fallback, same as
+    // the destructive guard's dry-run behavior.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-promo", "name": "promo"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .and(query_param("content_block_id", "id-promo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo",
+            "content": "<a href=\"https://example.com/old-page\">{{x | lid: 'liveeeeeeee1'}}</a>\n",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(
+        tmp.path(),
+        "promo",
+        "<a href=\"https://example.com/new-page\">{{x | lid: '__BRAZESYNC__'}}</a>\n",
+    );
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "content_block"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn content_block_orphan_makes_no_write_calls() {
     // Orphan policy is report-only: content block orphans never trigger

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -798,6 +798,112 @@ async fn content_block_diff_no_drift_when_placeholders_resolve_to_remote() {
     );
 }
 
+// =====================================================================
+// Fallback gate (#79 Step3, #93)
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_fallback_gate_exits_eight() {
+    // The template's link URL changed (no longer matches the remote
+    // anchor) while the remote still carries its own, now-unreferenced
+    // link. Both an unmatched template placeholder and an unconsumed
+    // remote lid value survive exact matching — the gate must fire and
+    // `diff` must exit non-zero without needing `--fail-on-drift`.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-promo", "name": "promo"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .and(query_param("content_block_id", "id-promo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo",
+            "content": "<a href=\"https://example.com/old-page\">{{x | lid: 'liveeeeeeee1'}}</a>\n",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(
+        tmp.path(),
+        "promo",
+        "<a href=\"https://example.com/new-page\">{{x | lid: '__BRAZESYNC__'}}</a>\n",
+    );
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "content_block"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(8),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("GATED"), "stderr: {stderr}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_ordinary_new_link_fallback_does_not_gate() {
+    // A genuinely new link (remote has no lid values at all) must not
+    // trip the gate — this is the expected fallback path, not the
+    // suspicious one.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-promo", "name": "promo"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .and(query_param("content_block_id", "id-promo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo",
+            "content": "<p>no anchor</p>\n",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(
+        tmp.path(),
+        "promo",
+        "<a href=\"https://example.com/new-page\">{{x | lid: '__BRAZESYNC__'}}</a>\n",
+    );
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "content_block"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn email_template_diff_no_drift_when_placeholders_resolve_to_remote() {
     // Parity with the content_block no-drift test: confirm the


### PR DESCRIPTION
## Summary

Closes #93 (Step3 of the #79 alternative hardening plan; Step1 = #86, Step2 = #90/#91).

`diff`/`apply` previously surfaced a drift-fallback `lid` (template placeholder resolved with a generated slug instead of a correlated remote value) as a Notice only — exit code and control flow were unaffected. This makes it loud:

- `diff` exits `8` unconditionally when the gate fires (no flag needed — this is not `--fail-on-drift`'s opt-in drift gate).
- `apply` requires `--allow-fallback` in addition to `--confirm`, mirroring the existing `--allow-destructive` pattern. Dry-run preview is unaffected.

**Gate condition** (per field, judged once after all exact matching completes): an unmatched template placeholder *and* an unconsumed remote lid value must both be present. Per-miss judgment is explicitly wrong — it would flag an ordinary new link (unmatched placeholder, no remote counterpart) as a false positive.

**Structural prerequisite found during scoping** (see the [issue #79 scope-decision comment](https://github.com/uny/braze-sync/issues/79#issuecomment-5309477220)): `resolve_lid_batch` discarded the unconsumed remainder of each FIFO bucket after matching — only the miss list survived into `PreparedTemplate`. `resolve_lid_batch` now also returns the leftover count, and `PreparedTemplate.fallback_gated` combines both sides.

The positional/FIFO path (subject, preheader) can't structurally produce both conditions at once, so in practice the gate only fires on the anchored `lid` path (body fields) — covered by a unit test.

**Out of scope** (tracked as a follow-up once this lands): detecting the two-anchors-merge-into-one-bucket case, which needs a second, un-normalized key compared in parallel and risks reopening #77's false positives if done naively.

## Test plan

- [x] New unit tests in `braze_managed.rs`: gate fires on placeholder-miss + remote-leftover; does not fire on an ordinary new link, an extra unreferenced remote link alone, the new-resource path, or the positional path
- [x] New unit tests in `integration.rs`: `FallbackReport.gated` propagation, `format_fallback_reports` gated/ungated formatting
- [x] New CLI integration tests in `tests/cli_diff.rs` / `tests/cli_apply.rs`: gate exits 8 on both `diff` and `apply --confirm`, `--allow-fallback` unblocks apply, dry-run is unaffected, ordinary new links don't gate
- [x] `cargo test` (449 unit + 34 cli_diff + 24 cli_apply, all green)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] README exit-codes table updated with code `8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fallback protection for unmatched placeholders and unconsumed remote values.
  * `diff` now exits with code 8 when gated fallback results are detected.
  * `apply` blocks gated fallback updates unless `--allow-fallback` is provided.
  * Dry-run mode continues to preview these changes without requiring approval.

* **Bug Fixes**
  * Prevented potentially unintended updates when fallback resolution is suspicious.

* **Documentation**
  * Documented exit code 8 and the required override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->