### PR TITLE
Report applied/failed/not-attempted when apply aborts mid-write (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,25 @@ file formats, JSON output, exit codes) for the full v1.x line.
   failure (a Braze rejection, a permission error, a transient 4xx) still
   aborts the run — Braze has no cross-resource transaction — but the run
   now enumerates what it applied, what failed with the API error, and
-  what it never attempted, plus the `diff`-then-re-`apply` remediation.
-  Previously a failed run printed only the error, so a run that wrote 20
-  of 25 resources and one that wrote none looked identical and the real
-  remote state had to be re-derived from a second `diff`. Successful
-  writes are also echoed per resource as the walk proceeds.
+  what it never attempted, plus the remediation. Previously a failed run
+  printed only the error, so a run that wrote 20 of 25 resources and one
+  that wrote none looked identical and the real remote state had to be
+  re-derived from a second `diff`. Successful writes are also echoed per
+  resource as the walk proceeds.
+
+  The enumeration is per **API call**, not per resource: a catalog's
+  field writes are listed one field at a time, so a failure partway
+  through a catalog still names the fields that landed. A run whose
+  first write fails reports that nothing was applied rather than
+  claiming a partial state, and a plan-locked run is told to regenerate
+  its plan before re-running (the applied writes drop out of the fresh
+  diff, so `apply --plan` would otherwise exit 7).
+
+  **Output change:** the per-batch line `  ✓ deprecated N custom
+  attribute(s)` / `  ✓ reactivated N custom attribute(s)` is replaced by
+  the unified per-write line `  ✓ custom_attribute deprecate (a, b)`.
+  Anything grepping stderr for the old wording needs updating; `--format
+  json` output on stdout is unaffected.
 
 ## [0.19.0] — 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [Unreleased]
+
+### Changed
+
+- **`apply` reports partial state on abort (#96).** A per-resource write
+  failure (a Braze rejection, a permission error, a transient 4xx) still
+  aborts the run — Braze has no cross-resource transaction — but the run
+  now enumerates what it applied, what failed with the API error, and
+  what it never attempted, plus the `diff`-then-re-`apply` remediation.
+  Previously a failed run printed only the error, so a run that wrote 20
+  of 25 resources and one that wrote none looked identical and the real
+  remote state had to be re-derived from a second `diff`. Successful
+  writes are also echoed per resource as the walk proceeds.
+
 ## [0.19.0] — 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,15 @@ file formats, JSON output, exit codes) for the full v1.x line.
   what it never attempted, plus the remediation. Previously a failed run
   printed only the error, so a run that wrote 20 of 25 resources and one
   that wrote none looked identical and the real remote state had to be
-  re-derived from a second `diff`. Successful writes are also echoed per
-  resource as the walk proceeds.
+  re-derived from a second `diff`. Successful writes are also echoed as
+  the walk proceeds.
 
   The enumeration is per **API call**, not per resource: a catalog's
   field writes are listed one field at a time, so a failure partway
   through a catalog still names the fields that landed. `applied` and
   `not attempted` are certain; the failed write is reported as
-  possibly-landed, since Braze can commit a write whose response is lost
-  to a timeout or a decode error. A run whose first write fails reports
+  possibly-landed, since Braze can commit a write whose response never
+  reaches the client. A run whose first write fails reports
   that there is no earlier write to roll back rather than claiming a
   partial state, and a plan-locked run is told to regenerate
   its plan before re-running (the applied writes drop out of the fresh
@@ -36,7 +36,10 @@ file formats, JSON output, exit codes) for the full v1.x line.
   attribute(s)` / `  ✓ reactivated N custom attribute(s)` is replaced by
   the unified per-write line `  ✓ custom_attribute deprecate (a, b)`.
   Anything grepping stderr for the old wording needs updating; `--format
-  json` output on stdout is unaffected.
+  json` output on stdout is unaffected. The success echo is likewise per
+  API call: a catalog with three field additions emits three
+  `  ✓ catalog_schema 'x' field '…' (add)` lines rather than one per
+  resource.
 
 ## [0.19.0] — 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
   The enumeration is per **API call**, not per resource: a catalog's
   field writes are listed one field at a time, so a failure partway
-  through a catalog still names the fields that landed. A run whose
-  first write fails reports that nothing was applied rather than
-  claiming a partial state, and a plan-locked run is told to regenerate
+  through a catalog still names the fields that landed. `applied` and
+  `not attempted` are certain; the failed write is reported as
+  possibly-landed, since Braze can commit a write whose response is lost
+  to a timeout or a decode error. A run whose first write fails reports
+  that there is no earlier write to roll back rather than claiming a
+  partial state, and a plan-locked run is told to regenerate
   its plan before re-running (the applied writes drop out of the fresh
   diff, so `apply --plan` would otherwise exit 7).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ braze-sync apply --confirm --allow-destructive # catalog/field deletes permitted
 ```
 
 `apply` is **not atomic across resources** — Braze exposes no
-cross-resource transaction. Writes are issued one resource at a time and
+cross-resource transaction. Writes are issued one API call at a time and
 the run aborts on the first failure, so a rejection mid-plan (e.g. Braze
 refusing `update` on a drag-and-drop content block) leaves the earlier
-writes live. The aborted run enumerates exactly that, so you never have
-to re-derive it from a second `diff`:
+writes live. The aborted run names them, so the applied set is reported
+rather than inferred:
 
-```
+```text
 ✗ apply aborted — partial state left in Braze (no cross-resource rollback):
   applied (20):
     - content_block 'header_ja'
@@ -165,10 +165,23 @@ to re-derive it from a second `diff`:
     - content_block 'footer_ja'
     …
   → the applied writes above are live and are not rolled back.
+    Run `braze-sync diff` to confirm the current remote state, then
+    re-run `apply` with the same flags to pick up the changes that
+    were not attempted.
 ```
 
-Re-running `apply` after fixing (or excluding) the offending resource
-picks up the changes that were not attempted.
+Each line is one API call — a catalog's field writes are listed per
+field — so nothing can land without being named. If the *first* write
+fails, nothing was applied and the run says so instead of claiming a
+partial state.
+
+Re-run `apply` with the same flags after fixing (or excluding) the
+offending resource to pick up the changes that were not attempted; the
+`diff` is recomputed, so the writes that already landed are skipped.
+**Exception:** a plan-locked run (`--plan`) must have its plan
+regenerated with `diff --plan-out` first — the applied writes are gone
+from the fresh diff, so re-running `apply --plan` as-is exits **7**
+(plan drift) without writing anything.
 
 API keys never live in the config file. The config only references the
 *name* of the environment variable (`api_key_env`), and the key is

--- a/README.md
+++ b/README.md
@@ -159,21 +159,27 @@ rather than inferred:
   applied (20):
     - content_block 'header_ja'
     …
-  failed:
+  failed (may or may not have landed):
     - content_block 'promo_dnd': HTTP 400 Bad Request: {"message":"DND Content blocks are not allowed to be updated from the API."}
   not attempted (4):
     - content_block 'footer_ja'
     …
   → the applied writes above are live and are not rolled back.
+  → the failed write may itself have landed: Braze can commit a
+    write whose response is lost to a timeout or a decode error.
     Run `braze-sync diff` to confirm the current remote state, then
     re-run `apply` with the same flags to pick up the changes that
     were not attempted.
 ```
 
 Each line is one API call — a catalog's field writes are listed per
-field — so nothing can land without being named. If the *first* write
-fails, nothing was applied and the run says so instead of claiming a
-partial state.
+field — so nothing can land without being named. `applied` and `not
+attempted` are certain; the **failed** write is not, because Braze can
+commit a write whose response never reaches the client (request
+timeout, undecodable body). That is why the report still points at
+`diff` to confirm. If the *first* write fails there is no earlier write
+to roll back, and the run says that instead of claiming a partial
+state.
 
 Re-run `apply` with the same flags after fixing (or excluding) the
 offending resource to pick up the changes that were not attempted; the

--- a/README.md
+++ b/README.md
@@ -147,6 +147,29 @@ braze-sync apply --confirm                     # add fields ok, deletes → exit
 braze-sync apply --confirm --allow-destructive # catalog/field deletes permitted
 ```
 
+`apply` is **not atomic across resources** — Braze exposes no
+cross-resource transaction. Writes are issued one resource at a time and
+the run aborts on the first failure, so a rejection mid-plan (e.g. Braze
+refusing `update` on a drag-and-drop content block) leaves the earlier
+writes live. The aborted run enumerates exactly that, so you never have
+to re-derive it from a second `diff`:
+
+```
+✗ apply aborted — partial state left in Braze (no cross-resource rollback):
+  applied (20):
+    - content_block 'header_ja'
+    …
+  failed:
+    - content_block 'promo_dnd': HTTP 400 Bad Request: {"message":"DND Content blocks are not allowed to be updated from the API."}
+  not attempted (4):
+    - content_block 'footer_ja'
+    …
+  → the applied writes above are live and are not rolled back.
+```
+
+Re-running `apply` after fixing (or excluding) the offending resource
+picks up the changes that were not attempted.
+
 API keys never live in the config file. The config only references the
 *name* of the environment variable (`api_key_env`), and the key is
 held in `secrecy::SecretString` from the moment it leaves the OS so

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ rather than inferred:
     - content_block 'footer_ja'
     …
   → the applied writes above are live and are not rolled back.
-  → the failed write may itself have landed: Braze can commit a
-    write whose response is lost to a timeout or a decode error.
+  → a failed write is not proof that nothing changed: Braze can
+    commit a write whose response never reaches the client.
     Run `braze-sync diff` to confirm the current remote state, then
     re-run `apply` with the same flags to pick up the changes that
     were not attempted.
@@ -175,9 +175,9 @@ rather than inferred:
 Each line is one API call — a catalog's field writes are listed per
 field — so nothing can land without being named. `applied` and `not
 attempted` are certain; the **failed** write is not, because Braze can
-commit a write whose response never reaches the client (request
-timeout, undecodable body). That is why the report still points at
-`diff` to confirm. If the *first* write fails there is no earlier write
+commit a write whose response never reaches the client (every request
+carries a timeout). That is why the report still points at `diff` to
+confirm. If the *first* write fails there is no earlier write
 to roll back, and the run says that instead of claiming a partial
 state.
 

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -10,8 +10,8 @@
 //! cross-write atomicity. Because that partial state is real and
 //! nothing downstream flags it, an aborted run enumerates what it
 //! applied, what failed, and what it never attempted (see
-//! `report_partial_apply`), so the operator does not have to re-derive
-//! the remote state from a second `diff`.
+//! `report_partial_apply`), so the applied set is reported rather than
+//! inferred from a second `diff`.
 
 use crate::braze::BrazeClient;
 use crate::config::{ApplyOrder, ResolvedConfig};

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -24,7 +24,7 @@ use crate::diff::plan::{self, PlanFile};
 use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
 use crate::error::Error;
 use crate::format::{OutputFormat, TableFormatter};
-use crate::resource::ResourceKind;
+use crate::resource::{CatalogField, ResourceKind};
 use crate::values::{format_fallback_reports, gated_fallback_count, FallbackReport};
 use anyhow::{anyhow, Context as _};
 use clap::Args;
@@ -277,17 +277,29 @@ pub async fn run(
     Ok(())
 }
 
-/// One resource-level write, in the order `apply` walks the plan.
+/// One write, in the order `apply` walks the plan.
 ///
 /// Materialising the walk as a list (instead of writing straight from
 /// the diff loop) is what lets a failure name the resources that were
 /// never attempted: they are simply the tail of this vector.
+///
+/// **Invariant: one unit is exactly one Braze API call.** The failure
+/// report enumerates units, so a unit that fanned out into several
+/// calls could land some of them and still be reported wholesale as
+/// "failed" — leaving writes that are live in Braze named nowhere. That
+/// is why a catalog's per-field writes are separate units
+/// ([`Self::CatalogField`]) rather than one catalog-sized unit.
 enum WriteUnit<'a> {
-    /// A catalog is one unit but several calls (one per field diff), so
-    /// a failure here can leave the *named* resource partly written —
-    /// which is why the report tells the operator to re-run `diff`
-    /// rather than trusting the labels alone.
-    CatalogSchema(&'a CatalogSchemaDiff),
+    /// Whole-catalog create/delete. `POST /catalogs` carries the full
+    /// schema and `DELETE /catalogs/{name}` drops it in one call, so
+    /// either is a single unit. Field-level edits are never routed
+    /// here — see [`Self::CatalogField`].
+    Catalog(&'a CatalogSchemaDiff),
+    /// One field add/delete on an existing catalog: one API call.
+    CatalogField {
+        catalog: &'a str,
+        op: &'a DiffOp<CatalogField>,
+    },
     ContentBlock(&'a ContentBlockDiff),
     EmailTemplate(&'a EmailTemplateDiff),
     /// Custom attribute deprecation toggles are one API call per
@@ -301,7 +313,17 @@ enum WriteUnit<'a> {
 impl WriteUnit<'_> {
     fn label(&self) -> String {
         match self {
-            Self::CatalogSchema(d) => format!("catalog_schema '{}'", d.name),
+            Self::Catalog(d) => format!("catalog_schema '{}'", d.name),
+            Self::CatalogField { catalog, op } => match op {
+                DiffOp::Added(f) => format!("catalog_schema '{catalog}' field '{}' (add)", f.name),
+                DiffOp::Removed(f) => {
+                    format!("catalog_schema '{catalog}' field '{}' (delete)", f.name)
+                }
+                DiffOp::Modified { to, .. } => {
+                    format!("catalog_schema '{catalog}' field '{}' (modify)", to.name)
+                }
+                DiffOp::Unchanged => format!("catalog_schema '{catalog}' field (unchanged)"),
+            },
             Self::ContentBlock(d) => format!("content_block '{}'", d.name),
             Self::EmailTemplate(d) => format!("email_template '{}'", d.name),
             Self::CustomAttributeBlocklist { names, blocklisted } => format!(
@@ -323,7 +345,8 @@ impl WriteUnit<'_> {
         email_template_id_index: Option<&EmailTemplateIdIndex>,
     ) -> anyhow::Result<usize> {
         match self {
-            Self::CatalogSchema(d) => apply_catalog_schema(client, d).await,
+            Self::Catalog(d) => apply_catalog_schema(client, d).await,
+            Self::CatalogField { catalog, op } => apply_catalog_field(client, catalog, op).await,
             Self::ContentBlock(d) => apply_content_block(client, d, content_block_id_index).await,
             Self::EmailTemplate(d) => {
                 apply_email_template(client, d, email_template_id_index).await
@@ -345,11 +368,20 @@ fn collect_write_units(summary: &DiffSummary) -> Vec<WriteUnit<'_>> {
     let mut ca_reactivate: Vec<&str> = Vec::new();
     for diff in &summary.diffs {
         match diff {
-            ResourceDiff::CatalogSchema(d) => {
-                if d.has_changes() {
-                    units.push(WriteUnit::CatalogSchema(d));
+            ResourceDiff::CatalogSchema(d) => match &d.op {
+                // One call carries the whole schema in either direction.
+                DiffOp::Added(_) | DiffOp::Removed(_) => units.push(WriteUnit::Catalog(d)),
+                // Field-level edits are one call each, so they are one
+                // unit each — see the `WriteUnit` invariant.
+                DiffOp::Modified { .. } | DiffOp::Unchanged => {
+                    for op in d.field_diffs.iter().filter(|op| op.is_change()) {
+                        units.push(WriteUnit::CatalogField {
+                            catalog: &d.name,
+                            op,
+                        });
+                    }
                 }
-            }
+            },
             ResourceDiff::ContentBlock(d) => {
                 if !d.orphan && d.op.is_change() {
                     units.push(WriteUnit::ContentBlock(d));
@@ -652,65 +684,78 @@ async fn apply_content_block(
     }
 }
 
+/// Create or delete a whole catalog. Both are a single API call:
+/// `POST /catalogs` carries the full schema (so no per-field POSTs are
+/// needed for a create) and `DELETE /catalogs/{name}` drops the schema
+/// and all items at once (so per-field DELETEs would be redundant, and
+/// would 404 once the catalog is gone).
+///
+/// Field-level edits on an existing catalog do not come here — they are
+/// one [`WriteUnit::CatalogField`] each, applied by
+/// [`apply_catalog_field`].
 async fn apply_catalog_schema(
     client: &BrazeClient,
     d: &CatalogSchemaDiff,
 ) -> anyhow::Result<usize> {
-    // `POST /catalogs` carries the full schema, so the per-field loop
-    // below is skipped for `Added` to avoid duplicate field POSTs.
-    if let DiffOp::Added(cat) = &d.op {
-        tracing::info!(catalog = %d.name, "creating new catalog");
-        client
-            .create_catalog(cat)
-            .await
-            .with_context(|| format!("creating catalog '{}'", d.name))?;
-        return Ok(1);
-    }
-
-    // Top-level delete short-circuits the field loop: `DELETE /catalogs/{name}`
-    // drops the schema and all items in one call, so per-field DELETEs would
-    // be redundant (and would 404 once the catalog is gone).
-    if let DiffOp::Removed(_) = &d.op {
-        tracing::info!(catalog = %d.name, "deleting catalog");
-        client
-            .delete_catalog(&d.name)
-            .await
-            .with_context(|| format!("deleting catalog '{}'", d.name))?;
-        return Ok(1);
-    }
-
-    let mut count = 0;
-    for fd in &d.field_diffs {
-        match fd {
-            DiffOp::Added(f) => {
-                tracing::info!(
-                    catalog = %d.name,
-                    field = %f.name,
-                    field_type = f.field_type.as_str(),
-                    "adding catalog field"
-                );
-                client.add_catalog_field(&d.name, f).await?;
-                count += 1;
-            }
-            DiffOp::Removed(f) => {
-                tracing::info!(
-                    catalog = %d.name,
-                    field = %f.name,
-                    "deleting catalog field"
-                );
-                client.delete_catalog_field(&d.name, &f.name).await?;
-                count += 1;
-            }
-            DiffOp::Modified { .. } => {
-                return Err(anyhow!(
-                    "internal: Modified field op should have been rejected \
-                     by check_for_unsupported_ops"
-                ));
-            }
-            DiffOp::Unchanged => {}
+    match &d.op {
+        DiffOp::Added(cat) => {
+            tracing::info!(catalog = %d.name, "creating new catalog");
+            client
+                .create_catalog(cat)
+                .await
+                .with_context(|| format!("creating catalog '{}'", d.name))?;
+            Ok(1)
         }
+        DiffOp::Removed(_) => {
+            tracing::info!(catalog = %d.name, "deleting catalog");
+            client
+                .delete_catalog(&d.name)
+                .await
+                .with_context(|| format!("deleting catalog '{}'", d.name))?;
+            Ok(1)
+        }
+        DiffOp::Modified { .. } | DiffOp::Unchanged => Err(anyhow!(
+            "internal: catalog '{}' routed to the whole-catalog write \
+             path without a create/delete op",
+            d.name,
+        )),
     }
-    Ok(count)
+}
+
+/// Apply one field diff on an existing catalog — exactly one API call,
+/// which is what lets the failure report name precisely which fields
+/// landed and which were never attempted.
+async fn apply_catalog_field(
+    client: &BrazeClient,
+    catalog: &str,
+    op: &DiffOp<CatalogField>,
+) -> anyhow::Result<usize> {
+    match op {
+        DiffOp::Added(f) => {
+            tracing::info!(
+                catalog = %catalog,
+                field = %f.name,
+                field_type = f.field_type.as_str(),
+                "adding catalog field"
+            );
+            client.add_catalog_field(catalog, f).await?;
+            Ok(1)
+        }
+        DiffOp::Removed(f) => {
+            tracing::info!(
+                catalog = %catalog,
+                field = %f.name,
+                "deleting catalog field"
+            );
+            client.delete_catalog_field(catalog, &f.name).await?;
+            Ok(1)
+        }
+        DiffOp::Modified { .. } => Err(anyhow!(
+            "internal: Modified field op should have been rejected \
+             by check_for_unsupported_ops"
+        )),
+        DiffOp::Unchanged => Ok(0),
+    }
 }
 
 async fn apply_email_template(

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -267,7 +267,7 @@ pub async fn run(
                 // Braze has no cross-resource transaction: everything in
                 // `done` is already live. Enumerate it here rather than
                 // making the operator re-derive it from a second `diff`.
-                report_partial_apply(&done, &label, &err, &units[i + 1..]);
+                report_partial_apply(&done, &label, &err, &units[i + 1..], args.plan.is_some());
                 return Err(err);
             }
         }
@@ -423,19 +423,28 @@ fn collect_write_units(summary: &DiffSummary) -> Vec<WriteUnit<'_>> {
 /// Without this the operator cannot distinguish a run that wrote
 /// nothing from one that wrote most of the plan — the writes that
 /// landed are real and correct, so nothing downstream flags them.
+///
+/// Every claim here is scoped to what actually happened: a run whose
+/// first write failed left no partial state at all, and saying it did
+/// would send the operator hunting for writes that were never issued.
 fn report_partial_apply(
     applied: &[String],
     failed: &str,
     err: &anyhow::Error,
     pending: &[WriteUnit],
+    plan_locked: bool,
 ) {
-    eprintln!("✗ apply aborted — partial state left in Braze (no cross-resource rollback):");
+    if applied.is_empty() {
+        eprintln!("✗ apply aborted on the first write — nothing was applied:");
+    } else {
+        eprintln!("✗ apply aborted — partial state left in Braze (no cross-resource rollback):");
+    }
     eprintln!("  applied ({}):", applied.len());
     for label in applied {
         eprintln!("    - {label}");
     }
     if applied.is_empty() {
-        eprintln!("    (none — no write landed before the failure)");
+        eprintln!("    (none — remote state is unchanged)");
     }
     eprintln!("  failed:");
     eprintln!("    - {failed}: {err:#}");
@@ -443,9 +452,23 @@ fn report_partial_apply(
     for unit in pending {
         eprintln!("    - {}", unit.label());
     }
+
+    if applied.is_empty() {
+        eprintln!("  → nothing to roll back. Fix the failure above, then re-run");
+        eprintln!("    `apply` with the same flags.");
+        return;
+    }
     eprintln!("  → the applied writes above are live and are not rolled back.");
     eprintln!("    Run `braze-sync diff` to confirm the current remote state, then");
-    eprintln!("    re-run `apply` to pick up the changes that were not attempted.");
+    eprintln!("    re-run `apply` with the same flags to pick up the changes that");
+    eprintln!("    were not attempted.");
+    if plan_locked {
+        // The applied writes drop out of the fresh diff, so the saved
+        // plan no longer matches and `check_plan_ops` would exit 7
+        // before issuing a single write.
+        eprintln!("    Because this run was plan-locked, regenerate the plan first");
+        eprintln!("    (`diff --plan-out`) — re-running `apply --plan` as-is exits 7.");
+    }
 }
 
 /// Reject ops the API can't actually perform. Runs before any write

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -424,9 +424,12 @@ fn collect_write_units(summary: &DiffSummary) -> Vec<WriteUnit<'_>> {
 /// nothing from one that wrote most of the plan — the writes that
 /// landed are real and correct, so nothing downstream flags them.
 ///
-/// Every claim here is scoped to what actually happened: a run whose
-/// first write failed left no partial state at all, and saying it did
-/// would send the operator hunting for writes that were never issued.
+/// Every claim here is scoped to what is actually known. Two limits
+/// shape the wording: a run whose first write failed left no *earlier*
+/// write to roll back, and the failed write itself is of **unknown**
+/// state — `send_json` decodes the response, and the client has a
+/// request timeout, so Braze can commit a write whose result never
+/// reaches us. Only `applied` and `not attempted` are certain.
 fn report_partial_apply(
     applied: &[String],
     failed: &str,
@@ -435,7 +438,7 @@ fn report_partial_apply(
     plan_locked: bool,
 ) {
     if applied.is_empty() {
-        eprintln!("✗ apply aborted on the first write — nothing was applied:");
+        eprintln!("✗ apply aborted on the first write:");
     } else {
         eprintln!("✗ apply aborted — partial state left in Braze (no cross-resource rollback):");
     }
@@ -444,30 +447,30 @@ fn report_partial_apply(
         eprintln!("    - {label}");
     }
     if applied.is_empty() {
-        eprintln!("    (none — remote state is unchanged)");
+        eprintln!("    (none — no earlier write to roll back)");
     }
-    eprintln!("  failed:");
+    eprintln!("  failed (may or may not have landed):");
     eprintln!("    - {failed}: {err:#}");
     eprintln!("  not attempted ({}):", pending.len());
     for unit in pending {
         eprintln!("    - {}", unit.label());
     }
 
-    if applied.is_empty() {
-        eprintln!("  → nothing to roll back. Fix the failure above, then re-run");
-        eprintln!("    `apply` with the same flags.");
-        return;
+    if !applied.is_empty() {
+        eprintln!("  → the applied writes above are live and are not rolled back.");
     }
-    eprintln!("  → the applied writes above are live and are not rolled back.");
+    eprintln!("  → the failed write may itself have landed: Braze can commit a");
+    eprintln!("    write whose response is lost to a timeout or a decode error.");
     eprintln!("    Run `braze-sync diff` to confirm the current remote state, then");
     eprintln!("    re-run `apply` with the same flags to pick up the changes that");
     eprintln!("    were not attempted.");
     if plan_locked {
-        // The applied writes drop out of the fresh diff, so the saved
-        // plan no longer matches and `check_plan_ops` would exit 7
+        // Any write that landed drops out of the fresh diff, so the
+        // saved plan no longer matches and `check_plan_ops` exits 7
         // before issuing a single write.
         eprintln!("    Because this run was plan-locked, regenerate the plan first");
-        eprintln!("    (`diff --plan-out`) — re-running `apply --plan` as-is exits 7.");
+        eprintln!("    (`diff --plan-out`) — re-running `apply --plan` as-is exits 7");
+        eprintln!("    if anything landed.");
     }
 }
 

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -7,7 +7,11 @@
 //! cross-resource transaction, so a mid-loop failure can still leave
 //! earlier writes applied — the pre-validation prevents *known-bad*
 //! plans from firing any writes at all, but it does not promise
-//! cross-write atomicity.
+//! cross-write atomicity. Because that partial state is real and
+//! nothing downstream flags it, an aborted run enumerates what it
+//! applied, what failed, and what it never attempted (see
+//! `report_partial_apply`), so the operator does not have to re-derive
+//! the remote state from a second `diff`.
 
 use crate::braze::BrazeClient;
 use crate::config::{ApplyOrder, ResolvedConfig};
@@ -241,20 +245,120 @@ pub async fn run(
 
     check_for_unsupported_ops(&summary)?;
 
+    let units = collect_write_units(&summary);
     let mut applied = 0;
+    let mut done: Vec<String> = Vec::new();
+    for (i, unit) in units.iter().enumerate() {
+        let label = unit.label();
+        match unit
+            .execute(
+                &client,
+                content_block_id_index.as_ref(),
+                email_template_id_index.as_ref(),
+            )
+            .await
+        {
+            Ok(n) => {
+                applied += n;
+                eprintln!("  ✓ {label}");
+                done.push(label);
+            }
+            Err(err) => {
+                // Braze has no cross-resource transaction: everything in
+                // `done` is already live. Enumerate it here rather than
+                // making the operator re-derive it from a second `diff`.
+                report_partial_apply(&done, &label, &err, &units[i + 1..]);
+                return Err(err);
+            }
+        }
+    }
+
+    eprintln!("✓ Applied {applied} change(s).");
+    Ok(())
+}
+
+/// One resource-level write, in the order `apply` walks the plan.
+///
+/// Materialising the walk as a list (instead of writing straight from
+/// the diff loop) is what lets a failure name the resources that were
+/// never attempted: they are simply the tail of this vector.
+enum WriteUnit<'a> {
+    /// A catalog is one unit but several calls (one per field diff), so
+    /// a failure here can leave the *named* resource partly written —
+    /// which is why the report tells the operator to re-run `diff`
+    /// rather than trusting the labels alone.
+    CatalogSchema(&'a CatalogSchemaDiff),
+    ContentBlock(&'a ContentBlockDiff),
+    EmailTemplate(&'a EmailTemplateDiff),
+    /// Custom attribute deprecation toggles are one API call per
+    /// direction, so a whole direction is a single unit.
+    CustomAttributeBlocklist {
+        names: Vec<&'a str>,
+        blocklisted: bool,
+    },
+}
+
+impl WriteUnit<'_> {
+    fn label(&self) -> String {
+        match self {
+            Self::CatalogSchema(d) => format!("catalog_schema '{}'", d.name),
+            Self::ContentBlock(d) => format!("content_block '{}'", d.name),
+            Self::EmailTemplate(d) => format!("email_template '{}'", d.name),
+            Self::CustomAttributeBlocklist { names, blocklisted } => format!(
+                "custom_attribute {} ({})",
+                if *blocklisted {
+                    "deprecate"
+                } else {
+                    "reactivate"
+                },
+                names.join(", "),
+            ),
+        }
+    }
+
+    async fn execute(
+        &self,
+        client: &BrazeClient,
+        content_block_id_index: Option<&ContentBlockIdIndex>,
+        email_template_id_index: Option<&EmailTemplateIdIndex>,
+    ) -> anyhow::Result<usize> {
+        match self {
+            Self::CatalogSchema(d) => apply_catalog_schema(client, d).await,
+            Self::ContentBlock(d) => apply_content_block(client, d, content_block_id_index).await,
+            Self::EmailTemplate(d) => {
+                apply_email_template(client, d, email_template_id_index).await
+            }
+            Self::CustomAttributeBlocklist { names, blocklisted } => {
+                apply_custom_attribute_blocklist(client, names, *blocklisted).await
+            }
+        }
+    }
+}
+
+/// Flatten the plan into the writes `apply` will actually issue, in
+/// write order. Diffs that fire no API call (orphans, unchanged,
+/// informational tag drift) are left out so they can never show up as
+/// "not attempted" in a failure report.
+fn collect_write_units(summary: &DiffSummary) -> Vec<WriteUnit<'_>> {
+    let mut units = Vec::new();
     let mut ca_deprecate: Vec<&str> = Vec::new();
     let mut ca_reactivate: Vec<&str> = Vec::new();
     for diff in &summary.diffs {
         match diff {
             ResourceDiff::CatalogSchema(d) => {
-                applied += apply_catalog_schema(&client, d).await?;
+                if d.has_changes() {
+                    units.push(WriteUnit::CatalogSchema(d));
+                }
             }
             ResourceDiff::ContentBlock(d) => {
-                applied += apply_content_block(&client, d, content_block_id_index.as_ref()).await?;
+                if !d.orphan && d.op.is_change() {
+                    units.push(WriteUnit::ContentBlock(d));
+                }
             }
             ResourceDiff::EmailTemplate(d) => {
-                applied +=
-                    apply_email_template(&client, d, email_template_id_index.as_ref()).await?;
+                if !d.orphan && d.op.is_change() {
+                    units.push(WriteUnit::EmailTemplate(d));
+                }
             }
             ResourceDiff::CustomAttribute(d) => {
                 if let CustomAttributeOp::DeprecationToggled { to, .. } = &d.op {
@@ -271,12 +375,45 @@ pub async fn run(
         }
     }
 
-    if !ca_deprecate.is_empty() || !ca_reactivate.is_empty() {
-        applied += apply_custom_attribute_batch(&client, &ca_deprecate, &ca_reactivate).await?;
+    // Batched last, and by direction, to keep the blocklist calls at two
+    // per run regardless of attribute count.
+    for (names, blocklisted) in [(ca_deprecate, true), (ca_reactivate, false)] {
+        if !names.is_empty() {
+            units.push(WriteUnit::CustomAttributeBlocklist { names, blocklisted });
+        }
     }
+    units
+}
 
-    eprintln!("✓ Applied {applied} change(s).");
-    Ok(())
+/// Emit what the run knows at the point it gives up: which writes
+/// landed, which one failed, and which were never attempted.
+///
+/// Without this the operator cannot distinguish a run that wrote
+/// nothing from one that wrote most of the plan — the writes that
+/// landed are real and correct, so nothing downstream flags them.
+fn report_partial_apply(
+    applied: &[String],
+    failed: &str,
+    err: &anyhow::Error,
+    pending: &[WriteUnit],
+) {
+    eprintln!("✗ apply aborted — partial state left in Braze (no cross-resource rollback):");
+    eprintln!("  applied ({}):", applied.len());
+    for label in applied {
+        eprintln!("    - {label}");
+    }
+    if applied.is_empty() {
+        eprintln!("    (none — no write landed before the failure)");
+    }
+    eprintln!("  failed:");
+    eprintln!("    - {failed}: {err:#}");
+    eprintln!("  not attempted ({}):", pending.len());
+    for unit in pending {
+        eprintln!("    - {}", unit.label());
+    }
+    eprintln!("  → the applied writes above are live and are not rolled back.");
+    eprintln!("    Run `braze-sync diff` to confirm the current remote state, then");
+    eprintln!("    re-run `apply` to pick up the changes that were not attempted.");
 }
 
 /// Reject ops the API can't actually perform. Runs before any write
@@ -617,36 +754,24 @@ async fn apply_email_template(
     }
 }
 
-/// Batch custom attribute deprecation toggles by direction so we issue
-/// at most two API calls. Each batch is reported to stderr on success so
-/// the user can tell what was committed if a later batch fails.
-async fn apply_custom_attribute_batch(
+/// Toggle one direction of custom attribute deprecation. Callers batch
+/// by direction so a run issues at most two blocklist calls regardless
+/// of attribute count; the per-unit success line is printed by the
+/// caller's walk.
+async fn apply_custom_attribute_blocklist(
     client: &BrazeClient,
-    to_deprecate: &[&str],
-    to_reactivate: &[&str],
+    names: &[&str],
+    blocklisted: bool,
 ) -> anyhow::Result<usize> {
-    let mut applied = 0;
-    for (names, blocklisted, verb) in [
-        (to_deprecate, true, "deprecating"),
-        (to_reactivate, false, "reactivating"),
-    ] {
-        if names.is_empty() {
-            continue;
-        }
-        tracing::info!(attributes = ?names, "{verb} custom attributes");
-        client
-            .set_custom_attribute_blocklist(names, blocklisted)
-            .await
-            .with_context(|| format!("{verb} custom attributes"))?;
-        let n = names.len();
-        let past = if blocklisted {
-            "deprecated"
-        } else {
-            "reactivated"
-        };
-        eprintln!("  ✓ {past} {n} custom attribute(s)");
-        applied += n;
-    }
-
-    Ok(applied)
+    let verb = if blocklisted {
+        "deprecating"
+    } else {
+        "reactivating"
+    };
+    tracing::info!(attributes = ?names, "{verb} custom attributes");
+    client
+        .set_custom_attribute_blocklist(names, blocklisted)
+        .await
+        .with_context(|| format!("{verb} custom attributes"))?;
+    Ok(names.len())
 }

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -427,9 +427,11 @@ fn collect_write_units(summary: &DiffSummary) -> Vec<WriteUnit<'_>> {
 /// Every claim here is scoped to what is actually known. Two limits
 /// shape the wording: a run whose first write failed left no *earlier*
 /// write to roll back, and the failed write itself is of **unknown**
-/// state — `send_json` decodes the response, and the client has a
-/// request timeout, so Braze can commit a write whose result never
-/// reaches us. Only `applied` and `not attempted` are certain.
+/// state — every request carries a client-side timeout (and the two
+/// `send_json` create paths additionally decode the response), so Braze
+/// can commit a write whose result never reaches us. Only `applied` and
+/// `not attempted` are certain, which is why the failed line is phrased
+/// as a caution rather than a claim about this particular error.
 fn report_partial_apply(
     applied: &[String],
     failed: &str,
@@ -459,8 +461,8 @@ fn report_partial_apply(
     if !applied.is_empty() {
         eprintln!("  → the applied writes above are live and are not rolled back.");
     }
-    eprintln!("  → the failed write may itself have landed: Braze can commit a");
-    eprintln!("    write whose response is lost to a timeout or a decode error.");
+    eprintln!("  → a failed write is not proof that nothing changed: Braze can");
+    eprintln!("    commit a write whose response never reaches the client.");
     eprintln!("    Run `braze-sync diff` to confirm the current remote state, then");
     eprintln!("    re-run `apply` with the same flags to pick up the changes that");
     eprintln!("    were not attempted.");

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -2107,15 +2107,21 @@ async fn first_write_failure_reports_no_partial_state() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("apply aborted on the first write — nothing was applied"),
+        stderr.contains("apply aborted on the first write:"),
         "stderr: {stderr}"
     );
     assert!(stderr.contains("applied (0):"), "stderr: {stderr}");
     assert!(
-        stderr.contains("(none — remote state is unchanged)"),
+        stderr.contains("(none — no earlier write to roll back)"),
         "stderr: {stderr}"
     );
-    assert!(stderr.contains("nothing to roll back"), "stderr: {stderr}");
+    // The failed write itself is of unknown state — Braze can commit a
+    // write whose response is lost — so the report must not claim the
+    // remote state is unchanged.
+    assert!(
+        stderr.contains("the failed write may itself have landed"),
+        "stderr: {stderr}"
+    );
     // The claims that only hold for a genuinely partial run must be absent.
     assert!(
         !stderr.contains("partial state left in Braze"),

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1922,12 +1922,14 @@ async fn mid_plan_write_failure_reports_applied_failed_and_not_attempted() {
         stderr.contains("- content_block 'a_first'"),
         "stderr: {stderr}"
     );
+    // Anchored to the failed line: the API error also reaches stderr via
+    // the top-level `error:` handler, so an unanchored `contains` would
+    // pass even with the report gutted.
     assert!(
-        stderr.contains("- content_block 'b_dnd': "),
-        "stderr: {stderr}"
-    );
-    assert!(
-        stderr.contains("DND Content blocks are not allowed"),
+        stderr.contains(
+            "- content_block 'b_dnd': HTTP 400 Bad Request: \
+             {\"message\":\"DND Content blocks are not allowed to be updated from the API.\"}"
+        ),
         "stderr: {stderr}"
     );
     assert!(stderr.contains("not attempted (1):"), "stderr: {stderr}");
@@ -2025,6 +2027,97 @@ async fn mid_catalog_field_failure_reports_the_fields_that_landed() {
     );
     assert!(
         !stderr.contains("no write landed before the failure"),
+        "stderr: {stderr}"
+    );
+}
+
+// A run whose *first* write fails left no partial state, so the report
+// must not claim one — the operator would otherwise go hunting for
+// writes that were never issued.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn first_write_failure_reports_no_partial_state() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [
+                {"content_block_id": "id-a", "name": "a_dnd"},
+                {"content_block_id": "id-b", "name": "b_last"},
+            ]
+        })))
+        .mount(&server)
+        .await;
+    for (id, name) in [("id-a", "a_dnd"), ("id-b", "b_last")] {
+        Mock::given(method("GET"))
+            .and(path("/content_blocks/info"))
+            .and(query_param("content_block_id", id))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": name,
+                "content": "old body\n",
+                "tags": []
+            })))
+            .mount(&server)
+            .await;
+    }
+    // The very first write is the one Braze refuses.
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/update"))
+        .and(body_partial_json(json!({"content_block_id": "id-a"})))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "message": "DND Content blocks are not allowed to be updated from the API."
+        })))
+        .mount(&server)
+        .await;
+    // Nothing else may be written.
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/update"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    for name in ["a_dnd", "b_last"] {
+        write_local_content_block(tmp.path(), name, "new body\n");
+    }
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "content_block", "--confirm"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("apply aborted on the first write — nothing was applied"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("applied (0):"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("(none — remote state is unchanged)"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("nothing to roll back"), "stderr: {stderr}");
+    // The claims that only hold for a genuinely partial run must be absent.
+    assert!(
+        !stderr.contains("partial state left in Braze"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("the applied writes above are live"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("not attempted (1):"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("- content_block 'b_last'"),
         "stderr: {stderr}"
     );
 }

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1841,3 +1841,105 @@ async fn apply_non_cb_et_kind_ignores_stray_values_directory_files() {
     .await
     .unwrap();
 }
+
+// =====================================================================
+// Partial-apply reporting (#96)
+// =====================================================================
+//
+// Braze has no cross-resource transaction: a per-resource rejection
+// mid-plan (a DND content block refusing `update`, a permission error,
+// a transient 4xx) leaves every earlier write live. The run must say so
+// — a run that wrote nothing and a run that wrote most of the plan used
+// to look identical in the output.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mid_plan_write_failure_reports_applied_failed_and_not_attempted() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [
+                {"content_block_id": "id-a", "name": "a_first"},
+                {"content_block_id": "id-b", "name": "b_dnd"},
+                {"content_block_id": "id-c", "name": "c_last"},
+            ]
+        })))
+        .mount(&server)
+        .await;
+    for (id, name) in [("id-a", "a_first"), ("id-b", "b_dnd"), ("id-c", "c_last")] {
+        Mock::given(method("GET"))
+            .and(path("/content_blocks/info"))
+            .and(query_param("content_block_id", id))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": name,
+                "content": "old body\n",
+                "tags": []
+            })))
+            .mount(&server)
+            .await;
+    }
+    // The middle block is the one Braze refuses. Mounted first so it
+    // wins over the catch-all success mock below.
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/update"))
+        .and(body_partial_json(json!({"content_block_id": "id-b"})))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "message": "DND Content blocks are not allowed to be updated from the API."
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/update"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
+        // Only the first block is written; the third is never attempted.
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    for name in ["a_first", "b_dnd", "c_last"] {
+        write_local_content_block(tmp.path(), name, "new body\n");
+    }
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "content_block", "--confirm"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("apply aborted"), "stderr: {stderr}");
+    assert!(stderr.contains("applied (1):"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("- content_block 'a_first'"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("- content_block 'b_dnd': "),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("DND Content blocks are not allowed"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("not attempted (1):"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("- content_block 'c_last'"),
+        "stderr: {stderr}"
+    );
+    // The remediation the incident had to be re-derived by hand.
+    assert!(
+        stderr.contains("Run `braze-sync diff` to confirm the current remote state"),
+        "stderr: {stderr}"
+    );
+    // The success path must not claim anything on an aborted run.
+    assert!(!stderr.contains("✓ Applied"), "stderr: {stderr}");
+}

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1862,11 +1862,18 @@ async fn mid_plan_write_failure_reports_applied_failed_and_not_attempted() {
                 {"content_block_id": "id-a", "name": "a_first"},
                 {"content_block_id": "id-b", "name": "b_dnd"},
                 {"content_block_id": "id-c", "name": "c_last"},
+                // Remote-only: an orphan, which fires no write at all.
+                {"content_block_id": "id-z", "name": "z_orphan"},
             ]
         })))
         .mount(&server)
         .await;
-    for (id, name) in [("id-a", "a_first"), ("id-b", "b_dnd"), ("id-c", "c_last")] {
+    for (id, name) in [
+        ("id-a", "a_first"),
+        ("id-b", "b_dnd"),
+        ("id-c", "c_last"),
+        ("id-z", "z_orphan"),
+    ] {
         Mock::given(method("GET"))
             .and(path("/content_blocks/info"))
             .and(query_param("content_block_id", id))
@@ -1937,6 +1944,9 @@ async fn mid_plan_write_failure_reports_applied_failed_and_not_attempted() {
         stderr.contains("- content_block 'c_last'"),
         "stderr: {stderr}"
     );
+    // Diffs that fire no API call must never be listed as pending work:
+    // `apply` would no-op them forever on the suggested re-run.
+    assert!(!stderr.contains("z_orphan"), "stderr: {stderr}");
     // The remediation the incident had to be re-derived by hand.
     assert!(
         stderr.contains("Run `braze-sync diff` to confirm the current remote state"),

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -1943,3 +1943,88 @@ async fn mid_plan_write_failure_reports_applied_failed_and_not_attempted() {
     // The success path must not claim anything on an aborted run.
     assert!(!stderr.contains("✓ Applied"), "stderr: {stderr}");
 }
+
+// A catalog is several API calls (one per field diff) but used to be a
+// single write unit, so a failure on the second field reported
+// "applied (0): (none — no write landed before the failure)" while the
+// first field was already live in Braze. Each field is now its own unit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mid_catalog_field_failure_reports_the_fields_that_landed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "catalogs": [
+                {"name": "cardiology", "fields": [{"name": "id", "type": "string"}]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+    // Added field ops are emitted in field-name order, so `b_score` is
+    // the middle write. Mounted first so it wins over the catch-all.
+    Mock::given(method("POST"))
+        .and(path("/catalogs/cardiology/fields"))
+        .and(body_json(json!({
+            "fields": [{"name": "b_score", "type": "number"}]
+        })))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "message": "Invalid field type for this catalog."
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/catalogs/cardiology/fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "ok"})))
+        // Only `a_sev` is written; `c_tail` is never attempted.
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(
+        tmp.path(),
+        "cardiology",
+        &[
+            ("id", "string"),
+            ("a_sev", "number"),
+            ("b_score", "number"),
+            ("c_tail", "number"),
+        ],
+    );
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", "catalog_schema", "--confirm"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The field that landed is named — this is the regression: it used
+    // to be absent, under a line claiming no write had landed.
+    assert!(stderr.contains("applied (1):"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("- catalog_schema 'cardiology' field 'a_sev' (add)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("- catalog_schema 'cardiology' field 'b_score' (add): HTTP 400"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("not attempted (1):"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("- catalog_schema 'cardiology' field 'c_tail' (add)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("no write landed before the failure"),
+        "stderr: {stderr}"
+    );
+}

--- a/tests/cli_apply.rs
+++ b/tests/cli_apply.rs
@@ -2119,7 +2119,7 @@ async fn first_write_failure_reports_no_partial_state() {
     // write whose response is lost — so the report must not claim the
     // remote state is unchanged.
     assert!(
-        stderr.contains("the failed write may itself have landed"),
+        stderr.contains("a failed write is not proof that nothing changed"),
         "stderr: {stderr}"
     );
     // The claims that only hold for a genuinely partial run must be absent.


### PR DESCRIPTION
Closes #96.

## What

When a per-resource write is rejected mid-plan, `apply` still aborts — but it now says what it did:

```
  ✓ content_block 'header_ja'
  …
✗ apply aborted — partial state left in Braze (no cross-resource rollback):
  applied (20):
    - content_block 'header_ja'
    …
  failed:
    - content_block 'promo_dnd': HTTP 400 Bad Request: {"message":"DND Content blocks are not allowed to be updated from the API."}
  not attempted (4):
    - content_block 'footer_ja'
    …
  → the applied writes above are live and are not rolled back.
    Run `braze-sync diff` to confirm the current remote state, then
    re-run `apply` to pick up the changes that were not attempted.
```

That covers asks 1 and 3 in the issue.

## How

The write loop is materialised as an ordered `Vec<WriteUnit>` (catalog / content block / email template / custom-attribute blocklist direction) before any call fires. "Not attempted" is then just the tail of that vector after the failing index — no separate bookkeeping, and the list is built from the same reordered `summary.diffs` that the printed plan uses, so its order *is* write order.

Diffs that issue no API call (orphans, unchanged, informational tag drift) are excluded from the list, so they can never appear as "not attempted".

Per-unit success lines are printed as the walk proceeds; the custom-attribute batch's own `✓ deprecated N …` line is dropped in favour of the unified one.

## Not done: ask 2 (continue past a failure)

Left as-is deliberately — abort-on-first is the safer default for live marketing content, and a `--continue-on-error` flag is a separate semantic decision (what exit code, how partial success interacts with `--plan` locking and CI). Happy to add it as a follow-up if you want it; the `WriteUnit` walk is now the right place to hang it.

Ask 2's motivation ("the rest of the plan is collateral damage") is partly addressed already: the report makes the re-run explicitly safe and bounded.

## Test

`mid_plan_write_failure_reports_applied_failed_and_not_attempted` — three content-block updates, the middle one returns 400 with the DND message. Asserts exit non-zero, `applied (1)` naming the first, the failed resource with its API error, `not attempted (1)` naming the third, the remediation line, and that no `✓ Applied` success line is emitted. The catch-all update mock carries `.expect(1)`, which also proves the third write never fired.

Full suite green, clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `apply` now reports partial results when a write fails, including successfully applied, failed, and unattempted resources.
  - Error output includes API details and guidance for resolving differences before retrying.
  - Subsequent runs can resume unattempted changes after the underlying issue is fixed.

- **Documentation**
  - Clarified that `apply` is not atomic across resources and does not roll back successful writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->