### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
-## [Unreleased]
+## [0.20.0] — 2026-08-20
 
 ### Changed
 
@@ -40,6 +40,11 @@ file formats, JSON output, exit codes) for the full v1.x line.
   API call: a catalog with three field additions emits three
   `  ✓ catalog_schema 'x' field '…' (add)` lines rather than one per
   resource.
+
+### Security
+
+- **`h2` bumped to 0.4.17** for RUSTSEC-2026-0258. Transitive dependency
+  via `reqwest`; no braze-sync API surface is affected.
 
 ## [0.19.0] — 2026-08-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
Release prep for **v0.20.0**. Version bump + CHANGELOG only — no code changes.

## Contents since v0.19.0

- **#96 / #97** — `apply` reports applied / failed / not-attempted writes when it aborts mid-plan.
- **h2 0.4.17** for RUSTSEC-2026-0258 (transitive via `reqwest`).

## Why minor, not patch

The #96 work replaces the per-batch `✓ deprecated N custom attribute(s)` stderr lines with the unified per-write line, and adds per-write success echoes. `--format json` on stdout is unchanged, but stderr wording is part of what people script against, so this is a minor bump under the v0.x policy.

## After merge

Push the tag to fire the release workflow (build → GitHub release → `cargo publish` → Homebrew tap):

```bash
git tag v0.20.0 && git push origin v0.20.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 0.20.0 on August 20, 2026.

* **Documentation**
  * Added guidance for partial-state reporting when apply operations are aborted.
  * Documented per-call success output and plan-lock remediation steps.
  * Clarified the unified format for writing custom attributes.
  * Added a security upgrade note addressing a transitive dependency vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->