### PR TITLE
Check remote preconditions in the plan lock, not just op shape (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [Unreleased]
+
+### Changed
+
+- **`apply --plan` now checks the remote, not just the op shape (#100).**
+  The plan file's own doc comment promised a Terraform-style plan/apply
+  lock — apply refuses to run when the live Braze state has drifted —
+  but the check compared only the multiset of `{kind, name, op}`. Remote
+  drift that did not change an operation's *classification* was
+  invisible: a content block already classified `modify`, edited in the
+  web console, still recomputed to `modify`, so the multisets matched,
+  the run printed `✓ Plan matches saved plan`, and the console edit was
+  overwritten with no warning.
+
+  `diff --plan-out` now records, for every op that writes to Braze, a
+  digest of the **remote** side as `diff` observed it (`add` records
+  absence instead). `apply --plan` compares those preconditions against
+  its own fresh fetch and exits `7` when one no longer holds, naming the
+  drift as a remote change rather than a local edit. The plan carries
+  digests, not payloads, so it stays safe to publish as a CI artifact,
+  and local edits between plan and apply are still applied — the plan
+  binds the remote preconditions, not the change set.
+
+  Each digest covers exactly the surface the corresponding `syncable_eq`
+  compares; the equivalence is pinned by tests so the digest and the
+  diff cannot drift apart. Read-only fields `apply` can never overwrite
+  (`ContentBlock::state`, `EmailTemplate::description`,
+  `Catalog::description`) stay outside the projection.
+
+  This makes true a claim `apply` was already printing: after a partial
+  apply, re-running the same plan now really does exit `7`. For a
+  catalog whose fields are written one API call at a time, the surviving
+  ops previously kept the same shape and the replay was allowed through.
+
+  **Not claimed, and stated in the docs rather than papered over:** this
+  is not concurrency control (Braze offers no `If-Match`, so the window
+  between check and write remains), it does not freeze the reviewed
+  change set, it does not detect a remote object replaced by identical
+  content under a different Braze ID, the catalog digest says nothing
+  about catalog items, and `scope.environment` is a config name rather
+  than a workspace identity.
+
+- **Catalog field removals are planned as `destructive_delete`.**
+  Dropping a field is a destructive write, but the plan classified it as
+  `modify` — the destructive check sat in a `classify` branch that
+  `diff_schema` cannot actually produce. That dead branch is removed and
+  the check moved to the reachable one. The `--allow-destructive` gate
+  itself was already correct; this aligns the plan's vocabulary with it.
+
+### Breaking
+
+- **Plan file version 2; version 1 files are rejected.** A v1 plan
+  carries no evidence about the remote, so it cannot be checked rather
+  than migrated. Regenerate with `diff --plan-out` — and review the new
+  plan, since regenerating immediately before `apply` would discard the
+  correspondence to what was reviewed. A v2 plan whose `modify` or
+  `destructive_delete` op is missing its digest is rejected as
+  malformed; a missing precondition is never treated as "skip the check
+  for this op".
+
 ## [0.20.0] — 2026-08-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,20 @@ file formats, JSON output, exit codes) for the full v1.x line.
   the run printed `✓ Plan matches saved plan`, and the console edit was
   overwritten with no warning.
 
-  `diff --plan-out` now records, for every op that writes to Braze, a
-  digest of the **remote** side as `diff` observed it (`add` records
-  absence instead). `apply --plan` compares those preconditions against
-  its own fresh fetch and exits `7` when one no longer holds, naming the
-  drift as a remote change rather than a local edit. The plan carries
-  digests, not payloads, so it stays safe to publish as a CI artifact,
-  and local edits between plan and apply are still applied — the plan
-  binds the remote preconditions, not the change set.
+  `diff --plan-out` now records, for every op that would overwrite a
+  remote body, a digest of the **remote** side as `diff` observed it; an
+  `add` records absence instead, and `deprecate` / `reactivate` record
+  nothing (their expected prior value is the op direction itself, so a
+  remote toggle drops the op from the fresh diff and is caught as op
+  drift). `apply --plan` compares those preconditions against its own
+  fresh fetch and exits `7` when one no longer holds, naming the drift as
+  a remote change rather than a local edit. Local edits between plan and
+  apply are still applied as long as they leave the op shapes unchanged —
+  the plan binds the remote preconditions, not the change set. The plan
+  carries digests, not payloads, so publishing it discloses no content
+  directly; the digest is unkeyed and its encoding is public, so it
+  remains a confirmation oracle for guessable content rather than a
+  secret (see README).
 
   Each digest covers exactly the surface the corresponding `syncable_eq`
   compares; the equivalence is pinned by tests so the digest and the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ dotenvy = "0.15"
 # CSV for catalog items error types (Phase B)
 csv = "1"
 
-# Hashing for catalog items diff
+# Remote-state digests in the plan file
 blake3 = "1"
 
 # Text diff (Content Block body comparison, future Email Template parts)

--- a/README.md
+++ b/README.md
@@ -185,9 +185,26 @@ Re-run `apply` with the same flags after fixing (or excluding) the
 offending resource to pick up the changes that were not attempted; the
 `diff` is recomputed, so the writes that already landed are skipped.
 **Exception:** a plan-locked run (`--plan`) must have its plan
-regenerated with `diff --plan-out` first — the applied writes are gone
-from the fresh diff, so re-running `apply --plan` as-is exits **7**
-(plan drift) without writing anything.
+regenerated with `diff --plan-out` first — the writes that landed moved
+the remote away from what the plan recorded, so re-running
+`apply --plan` as-is exits **7** (plan drift) without writing anything.
+
+### What a plan file guarantees
+
+`diff --plan-out` records, for every op it can apply, a digest of the
+**remote** side as `diff` observed it. `apply --plan` re-fetches, and
+refuses to run if the op set changed *or* if any of those remote objects
+moved. So a plan authorizes exactly this:
+
+> Apply the *current* local intent, provided the remote preconditions
+> the plan recorded still hold.
+
+It deliberately does **not** freeze the change set: editing a local file
+between plan and apply still applies, as long as the op shapes match.
+Nor is it concurrency control — Braze's REST API offers no `If-Match`,
+so the check happens against apply's own fetch and a lost update remains
+possible in the window before the write. The plan carries digests rather
+than payloads, which keeps it safe to publish as a CI artifact.
 
 API keys never live in the config file. The config only references the
 *name* of the environment variable (`api_key_env`), and the key is
@@ -244,7 +261,7 @@ across all v1.x releases.
 | `4` | Authentication failed (invalid API key) |
 | `5` | Rate limit retries exhausted |
 | `6` | Destructive change blocked (pass `--allow-destructive`) |
-| `7` | Plan/apply mismatch (`apply --plan` ops drift) |
+| `7` | Plan/apply mismatch (`apply --plan`: op set differs, or the remote moved since the plan) |
 | `8` | Fallback gate (unmatched placeholder + unconsumed remote lid). Unlike `2`, `diff` has no opt-in flag for this — it always exits `8` when the gate fires; `apply` requires `--allow-fallback` |
 
 ## Output formats

--- a/README.md
+++ b/README.md
@@ -191,10 +191,15 @@ the remote away from what the plan recorded, so re-running
 
 ### What a plan file guarantees
 
-`diff --plan-out` records, for every op it can apply, a digest of the
-**remote** side as `diff` observed it. `apply --plan` re-fetches, and
-refuses to run if the op set changed *or* if any of those remote objects
-moved. So a plan authorizes exactly this:
+`diff --plan-out` records, for every op that would overwrite a remote
+body (`modify`, `destructive_delete`), a digest of the **remote** side as
+`diff` observed it; an `add` records the remote's *absence* instead.
+`deprecate` / `reactivate` record nothing — they write a boolean whose
+expected prior value the op direction already states, so a remote toggle
+removes the op from the fresh diff and is caught as op drift. `apply
+--plan` re-fetches, and refuses to run if the op set changed *or* if any
+of those remote preconditions no longer holds. So a plan authorizes
+exactly this:
 
 > Apply the *current* local intent, provided the remote preconditions
 > the plan recorded still hold.
@@ -203,8 +208,16 @@ It deliberately does **not** freeze the change set: editing a local file
 between plan and apply still applies, as long as the op shapes match.
 Nor is it concurrency control — Braze's REST API offers no `If-Match`,
 so the check happens against apply's own fetch and a lost update remains
-possible in the window before the write. The plan carries digests rather
-than payloads, which keeps it safe to publish as a CI artifact.
+possible in the window before the write.
+
+The plan carries digests rather than payloads, so publishing it as a CI
+artifact does not disclose content directly — but a digest is not
+confidentiality. The projection is an unkeyed, deterministic hash whose
+encoding is public in this repo, so anyone holding the artifact can
+recompute a guess and confirm it. Resource *names* are in the plan in
+cleartext regardless. Treat a plan file as you would any other build
+artifact describing your Braze workspace, and do not publish plans that
+touch sensitive resources to readers you would not otherwise trust.
 
 API keys never live in the config file. The config only references the
 *name* of the environment variable (`api_key_env`), and the key is

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -591,7 +591,7 @@ fn check_plan_scope(plan: &PlanFile, environment: &str, args: &ApplyArgs) -> any
         ));
     }
     if let Err(problems) = plan.validate() {
-        eprintln!("✗ malformed plan file: ops are missing required remote preconditions");
+        eprintln!("✗ malformed plan file: ops carry the wrong remote preconditions");
         for problem in &problems {
             eprintln!("    - {problem}");
         }

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -214,7 +214,17 @@ pub async fn run(
     // Print the fresh plan first so the operator sees it even on mismatch.
     if let Some(saved) = &saved_plan {
         check_plan_ops(saved, &summary)?;
-        eprintln!("✓ Plan matches saved plan ({} op(s)).", saved.ops.len());
+        let checked = saved
+            .ops
+            .iter()
+            .filter(|op| op.precondition.is_some())
+            .count();
+        eprintln!(
+            "✓ Plan verified: scope, {} op(s), and the remote state of {} of them \
+             are unchanged since the plan was generated.",
+            saved.ops.len(),
+            checked,
+        );
     }
 
     if summary.actionable_count() == 0 {
@@ -467,9 +477,11 @@ fn report_partial_apply(
     eprintln!("    re-run `apply` with the same flags to pick up the changes that");
     eprintln!("    were not attempted.");
     if plan_locked {
-        // Any write that landed drops out of the fresh diff, so the
-        // saved plan no longer matches and `check_plan_ops` exits 7
-        // before issuing a single write.
+        // A write that landed moves the remote away from the digest the
+        // plan recorded, so `check_plan_ops` exits 7 before issuing a
+        // single write. Op shape alone would not be enough here: a
+        // catalog that got one of its two field writes still recomputes
+        // to the same `modify` op.
         eprintln!("    Because this run was plan-locked, regenerate the plan first");
         eprintln!("    (`diff --plan-out`) — re-running `apply --plan` as-is exits 7");
         eprintln!("    if anything landed.");
@@ -571,9 +583,20 @@ fn check_plan_scope(plan: &PlanFile, environment: &str, args: &ApplyArgs) -> any
     if plan.version != plan::CURRENT_PLAN_VERSION {
         return Err(anyhow!(
             "plan file version {} is not supported by this binary \
-             (expected {}). Regenerate with `diff --plan-out`.",
+             (expected {}). Regenerate with `diff --plan-out` and review \
+             the new plan — an older plan carries no evidence this binary \
+             can check.",
             plan.version,
             plan::CURRENT_PLAN_VERSION,
+        ));
+    }
+    if let Err(problems) = plan.validate() {
+        eprintln!("✗ malformed plan file: ops are missing required remote preconditions");
+        for problem in &problems {
+            eprintln!("    - {problem}");
+        }
+        return Err(anyhow!(
+            "plan file cannot be checked; regenerate with `diff --plan-out`"
         ));
     }
     if plan.scope.environment != environment {
@@ -621,8 +644,9 @@ fn warn_on_plan_metadata(plan: &PlanFile) {
     }
 }
 
-/// Compare the saved plan's ops against the freshly-computed summary.
-/// Returns `Error::PlanDrift` on any (kind, name, op_type) mismatch.
+/// Compare the saved plan against the freshly-computed summary: first the
+/// op shapes, then the remote preconditions of the ops that matched.
+/// Returns `Error::PlanDrift` on either.
 fn check_plan_ops(saved: &PlanFile, fresh: &DiffSummary) -> anyhow::Result<()> {
     let fresh_ops = plan::collect_ops(fresh);
     let diff = saved.diff_ops(&fresh_ops);
@@ -633,13 +657,41 @@ fn check_plan_ops(saved: &PlanFile, fresh: &DiffSummary) -> anyhow::Result<()> {
     if !diff.missing.is_empty() {
         eprintln!("  ops in saved plan but not in fresh plan (resolved or absorbed remotely):");
         for op in &diff.missing {
-            eprintln!("    - {} '{}' [{:?}]", op.kind.as_str(), op.name, op.op);
+            eprintln!(
+                "    - {} '{}' [{}]",
+                op.kind.as_str(),
+                op.name,
+                op.op.as_str()
+            );
         }
     }
     if !diff.extra.is_empty() {
         eprintln!("  ops in fresh plan but not in saved plan (new drift since plan):");
         for op in &diff.extra {
-            eprintln!("    - {} '{}' [{:?}]", op.kind.as_str(), op.name, op.op);
+            eprintln!(
+                "    - {} '{}' [{}]",
+                op.kind.as_str(),
+                op.name,
+                op.op.as_str()
+            );
+        }
+    }
+    if !diff.precondition_drift.is_empty() {
+        // Attribution matters: the op shape is unchanged, so this is the
+        // remote moving, not a local edit.
+        eprintln!(
+            "  ops whose remote state changed since the plan was generated \
+             (applying would overwrite that change):"
+        );
+        for drift in &diff.precondition_drift {
+            eprintln!(
+                "    - {} '{}' [{}]: remote state moved (planned {}, found {})",
+                drift.op.kind.as_str(),
+                drift.op.name,
+                drift.op.op.as_str(),
+                drift.expected.describe(),
+                drift.found.describe(),
+            );
         }
     }
     eprintln!("  → regenerate with `diff --plan-out` and review before re-applying");

--- a/src/diff/catalog.rs
+++ b/src/diff/catalog.rs
@@ -329,6 +329,21 @@ mod tests {
             assert_agree(&base(), &b);
         }
 
+        #[test]
+        fn duplicate_field_names_collapse_in_both() {
+            // Braze's schema cannot produce this, but the equivalence
+            // must not rest on that: `diff_fields` keys by name and the
+            // last entry wins, so the projection has to do the same or
+            // it distinguishes two catalogs the diff cannot.
+            let dup = cat(vec![
+                field("id", CatalogFieldType::String),
+                field("id", CatalogFieldType::Number),
+            ]);
+            let collapsed = cat(vec![field("id", CatalogFieldType::Number)]);
+            assert!(diff_fields(&dup.fields, &collapsed.fields).is_empty());
+            assert_agree(&dup, &collapsed);
+        }
+
         /// Compile-time guard: adding a field to `Catalog` or
         /// `CatalogField` breaks this destructure, which is the prompt to
         /// decide whether it belongs in `diff_fields` *and* in the

--- a/src/diff/catalog.rs
+++ b/src/diff/catalog.rs
@@ -263,4 +263,95 @@ mod tests {
         assert!(d.field_diffs.is_empty());
         assert!(!d.has_changes());
     }
+
+    // -----------------------------------------------------------
+    // digest <=> "diff_fields is empty". Catalog has no syncable_eq;
+    // the diff's notion of "unchanged" is an empty field diff, and the
+    // plan's remote precondition must agree with exactly that.
+    // See src/diff/digest.rs.
+    // -----------------------------------------------------------
+
+    mod digest_equivalence {
+        use super::*;
+        use crate::diff::digest;
+        use crate::resource::Catalog;
+
+        fn cat(fields: Vec<CatalogField>) -> Catalog {
+            Catalog {
+                name: "products".into(),
+                description: None,
+                fields,
+            }
+        }
+
+        fn field(name: &str, field_type: CatalogFieldType) -> CatalogField {
+            CatalogField {
+                name: name.into(),
+                field_type,
+            }
+        }
+
+        fn base() -> Catalog {
+            cat(vec![
+                field("id", CatalogFieldType::String),
+                field("price", CatalogFieldType::Number),
+            ])
+        }
+
+        #[track_caller]
+        fn assert_agree(a: &Catalog, b: &Catalog) {
+            assert_eq!(
+                diff_fields(&a.fields, &b.fields).is_empty(),
+                digest::catalog(a) == digest::catalog(b),
+                "digest and diff_fields disagree on {a:?} vs {b:?}",
+            );
+        }
+
+        #[test]
+        fn identical_agree() {
+            assert_agree(&base(), &base());
+        }
+
+        #[test]
+        fn field_order_agrees() {
+            let mut b = base();
+            b.fields.reverse();
+            assert!(diff_fields(&base().fields, &b.fields).is_empty());
+            assert_agree(&base(), &b);
+        }
+
+        #[test]
+        fn description_is_ignored_by_both() {
+            let mut b = base();
+            b.description = Some("edited remotely".into());
+            assert_agree(&base(), &b);
+        }
+
+        #[test]
+        fn field_changes_disagree_in_both() {
+            let variants = vec![
+                cat(vec![field("id", CatalogFieldType::String)]),
+                cat(vec![
+                    field("id", CatalogFieldType::String),
+                    field("price", CatalogFieldType::String),
+                ]),
+                cat(vec![
+                    field("id", CatalogFieldType::String),
+                    field("price", CatalogFieldType::Number),
+                    field("sku", CatalogFieldType::String),
+                ]),
+                cat(vec![
+                    field("id", CatalogFieldType::String),
+                    field("cost", CatalogFieldType::Number),
+                ]),
+            ];
+            for b in variants {
+                assert!(
+                    !diff_fields(&base().fields, &b.fields).is_empty(),
+                    "expected a real change: {b:?}",
+                );
+                assert_agree(&base(), &b);
+            }
+        }
+    }
 }

--- a/src/diff/catalog.rs
+++ b/src/diff/catalog.rs
@@ -265,10 +265,12 @@ mod tests {
     }
 
     // -----------------------------------------------------------
-    // digest <=> "diff_fields is empty". Catalog has no syncable_eq;
-    // the diff's notion of "unchanged" is an empty field diff, and the
-    // plan's remote precondition must agree with exactly that.
-    // See src/diff/digest.rs.
+    // digest <=> "diff_fields is empty", for two catalogs of the SAME
+    // name — the digest also covers `name`, which `diff_fields` never
+    // sees, and `diff_ops` pairs ops by name before comparing digests.
+    // Catalog has no syncable_eq; the diff's notion of "unchanged" is an
+    // empty field diff, and the plan's remote precondition must agree
+    // with exactly that. See src/diff/digest.rs.
     // -----------------------------------------------------------
 
     mod digest_equivalence {
@@ -325,6 +327,24 @@ mod tests {
             let mut b = base();
             b.description = Some("edited remotely".into());
             assert_agree(&base(), &b);
+        }
+
+        /// Compile-time guard: adding a field to `Catalog` or
+        /// `CatalogField` breaks this destructure, which is the prompt to
+        /// decide whether it belongs in `diff_fields` *and* in the
+        /// projection. The variant list below is hand-written and cannot
+        /// notice a field neither side looks at.
+        #[test]
+        fn variant_list_covers_every_field() {
+            let Catalog {
+                name: _,
+                description: _,
+                fields: _,
+            } = base();
+            let CatalogField {
+                name: _,
+                field_type: _,
+            } = field("id", CatalogFieldType::String);
         }
 
         #[test]

--- a/src/diff/content_block.rs
+++ b/src/diff/content_block.rs
@@ -346,6 +346,23 @@ mod tests {
             assert_agree(&base(), &b);
         }
 
+        /// Compile-time guard on the list below. Adding a field to
+        /// `ContentBlock` breaks this destructure, which is the prompt to
+        /// decide whether it belongs in `syncable_eq` *and* in the
+        /// projection — a field added to one but not the other silently
+        /// falsifies the biconditional, and no runtime test here would
+        /// notice because the mutation list is hand-written.
+        #[test]
+        fn mutation_list_covers_every_field() {
+            let ContentBlock {
+                name: _,
+                description: _,
+                content: _,
+                tags: _,
+                state: _,
+            } = base();
+        }
+
         #[test]
         fn every_syncable_field_change_disagrees_in_both() {
             let mutations: Vec<fn(&mut ContentBlock)> = vec![

--- a/src/diff/content_block.rs
+++ b/src/diff/content_block.rs
@@ -286,4 +286,81 @@ mod tests {
         let modified = diff(Some(&l2), Some(&r2)).unwrap();
         assert!(!modified.op.is_destructive());
     }
+
+    // -----------------------------------------------------------
+    // digest <=> syncable_eq. The plan file's remote precondition is
+    // only sound while these two agree; see src/diff/digest.rs.
+    // -----------------------------------------------------------
+
+    mod digest_equivalence {
+        use super::*;
+        use crate::diff::digest;
+
+        fn base() -> ContentBlock {
+            ContentBlock {
+                name: "hero".into(),
+                description: Some("d".into()),
+                content: "body".into(),
+                tags: vec!["a".into(), "b".into()],
+                state: ContentBlockState::Active,
+            }
+        }
+
+        #[track_caller]
+        fn assert_agree(a: &ContentBlock, b: &ContentBlock) {
+            assert_eq!(
+                syncable_eq(a, b),
+                digest::content_block(a) == digest::content_block(b),
+                "digest and syncable_eq disagree on {a:?} vs {b:?}",
+            );
+        }
+
+        #[test]
+        fn identical_agree() {
+            assert_agree(&base(), &base());
+        }
+
+        #[test]
+        fn none_and_empty_description_agree() {
+            let mut a = base();
+            a.description = None;
+            let mut b = base();
+            b.description = Some(String::new());
+            assert!(syncable_eq(&a, &b));
+            assert_agree(&a, &b);
+        }
+
+        #[test]
+        fn tag_order_agrees() {
+            let mut b = base();
+            b.tags.reverse();
+            assert!(syncable_eq(&base(), &b));
+            assert_agree(&base(), &b);
+        }
+
+        #[test]
+        fn state_is_ignored_by_both() {
+            let mut b = base();
+            b.state = ContentBlockState::Draft;
+            assert!(syncable_eq(&base(), &b));
+            assert_agree(&base(), &b);
+        }
+
+        #[test]
+        fn every_syncable_field_change_disagrees_in_both() {
+            let mutations: Vec<fn(&mut ContentBlock)> = vec![
+                |c| c.name = "other".into(),
+                |c| c.description = Some("changed".into()),
+                |c| c.content = "changed".into(),
+                |c| c.tags.push("extra".into()),
+                |c| c.tags.clear(),
+            ];
+            for mutate in mutations {
+                let mut b = base();
+                mutate(&mut b);
+                assert!(!syncable_eq(&base(), &b), "expected a real change: {b:?}");
+                assert_agree(&base(), &b);
+            }
+        }
+    }
 }

--- a/src/diff/digest.rs
+++ b/src/diff/digest.rs
@@ -1,0 +1,269 @@
+//! Canonical projections of the *remote* side of a resource, hashed for
+//! the apply-time precondition check (`apply --plan`).
+//!
+//! A projection answers one question: *"is the remote object still the one
+//! `diff` observed when the plan was written?"* It therefore covers exactly
+//! the surface [`syncable_eq`](crate::diff) compares — no more, no less:
+//!
+//! ```text
+//! digest(a) == digest(b)  <=>  syncable_eq(a, b)
+//! ```
+//!
+//! That equivalence is the load-bearing invariant, pinned by tests in this
+//! module and in each `diff::*` module. It is what makes the digest and the
+//! diff unable to disagree: a remote edit the diff would treat as a real
+//! change is a remote edit the digest catches, and a remote representation
+//! wobble the diff deliberately absorbs (`None` vs `""`, tag order) is one
+//! the digest absorbs too.
+//!
+//! # What a projection deliberately excludes
+//!
+//! Read-only fields that braze-sync never writes: `ContentBlock::state`
+//! (absent from `/content_blocks/info`), `EmailTemplate::description` and
+//! `Catalog::description` (returned by Braze but not settable by
+//! create/update). A remote edit to one of those cannot be clobbered by
+//! `apply`, so it is not a precondition.
+//!
+//! # Stability
+//!
+//! The byte encoding below is part of the plan file format. Changing it
+//! invalidates every saved plan, so any change here must bump
+//! [`CURRENT_PLAN_VERSION`](crate::diff::plan::CURRENT_PLAN_VERSION). The
+//! insta snapshots in this module exist to make that impossible to forget.
+//!
+//! # Limitation
+//!
+//! Projections run over domain objects, not the wire bytes. Catalog field
+//! types Braze adds after this binary was built collapse to
+//! [`CatalogFieldType::Unknown`](crate::resource::CatalogFieldType) at the
+//! resource layer, so a remote change between two such types is invisible
+//! to the digest. See the type's doc comment.
+
+use blake3::Hasher;
+
+use crate::resource::{Catalog, ContentBlock, EmailTemplate};
+
+/// Length-prefixed, domain-separated field accumulator.
+///
+/// Every value is written as its byte length (u64 LE) followed by its
+/// bytes, so no two distinct field sequences can collide by concatenation
+/// (`["ab", "c"]` and `["a", "bc"]` hash differently).
+struct Projection(Hasher);
+
+impl Projection {
+    /// `tag` names the projected type and separates the hash domains, so
+    /// a content block and an email template with identical field values
+    /// never share a digest.
+    fn new(tag: &str) -> Self {
+        let mut p = Self(Hasher::new());
+        p.str_field(tag);
+        p
+    }
+
+    fn str_field(&mut self, value: &str) -> &mut Self {
+        self.0.update(&(value.len() as u64).to_le_bytes());
+        self.0.update(value.as_bytes());
+        self
+    }
+
+    /// `None` and `Some("")` project identically — mirrors
+    /// [`opt_str_eq`](crate::diff::opt_str_eq).
+    fn opt_str_field(&mut self, value: &Option<String>) -> &mut Self {
+        self.str_field(value.as_deref().unwrap_or(""))
+    }
+
+    /// Three-valued: `None` is distinct from `Some(false)`, matching the
+    /// plain `==` that `syncable_eq` uses on `should_inline_css`.
+    fn opt_bool_field(&mut self, value: Option<bool>) -> &mut Self {
+        self.str_field(match value {
+            None => "unset",
+            Some(true) => "true",
+            Some(false) => "false",
+        })
+    }
+
+    /// Sorted, so tag order does not affect the digest — mirrors
+    /// [`tags_eq_unordered`](crate::diff::tags_eq_unordered).
+    fn tags_field(&mut self, tags: &[String]) -> &mut Self {
+        let mut sorted: Vec<&str> = tags.iter().map(String::as_str).collect();
+        sorted.sort_unstable();
+        self.str_field(&sorted.len().to_string());
+        for tag in sorted {
+            self.str_field(tag);
+        }
+        self
+    }
+
+    fn finish(&self) -> String {
+        self.0.finalize().to_hex().to_string()
+    }
+}
+
+/// Digest the surface `diff::content_block::syncable_eq` compares.
+/// Excludes `state` (read-only: Braze `/info` does not return it).
+pub fn content_block(cb: &ContentBlock) -> String {
+    let mut p = Projection::new("content_block/v2");
+    p.str_field(&cb.name)
+        .opt_str_field(&cb.description)
+        .str_field(&cb.content)
+        .tags_field(&cb.tags)
+        .finish()
+}
+
+/// Digest the surface `diff::email_template::syncable_eq` compares.
+/// Excludes `description` (read-only: create/update cannot set it).
+pub fn email_template(tpl: &EmailTemplate) -> String {
+    let mut p = Projection::new("email_template/v2");
+    p.str_field(&tpl.name)
+        .str_field(&tpl.subject)
+        .str_field(&tpl.body_html)
+        .str_field(&tpl.body_plaintext)
+        .opt_str_field(&tpl.preheader)
+        .opt_bool_field(tpl.should_inline_css)
+        .tags_field(&tpl.tags)
+        .finish()
+}
+
+/// Digest the surface `diff::catalog::diff_fields` compares: the field set
+/// keyed by name, each with its type. Field order does not matter (the
+/// diff keys by name via `BTreeMap`), so fields are sorted here.
+///
+/// Excludes `description`: Braze has no endpoint to update it, so
+/// `diff_schema` treats description-only differences as `Unchanged` and
+/// `apply` can never overwrite one.
+pub fn catalog(cat: &Catalog) -> String {
+    let mut fields: Vec<(&str, &'static str)> = cat
+        .fields
+        .iter()
+        .map(|f| (f.name.as_str(), f.field_type.as_str()))
+        .collect();
+    fields.sort_unstable();
+
+    let mut p = Projection::new("catalog_schema/v2");
+    p.str_field(&cat.name);
+    p.str_field(&fields.len().to_string());
+    for (name, field_type) in fields {
+        p.str_field(name).str_field(field_type);
+    }
+    p.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::{CatalogField, CatalogFieldType, ContentBlockState};
+
+    fn cb() -> ContentBlock {
+        ContentBlock {
+            name: "hero".into(),
+            description: Some("banner".into()),
+            content: "{{ x }}".into(),
+            tags: vec!["b".into(), "a".into()],
+            state: ContentBlockState::Active,
+        }
+    }
+
+    fn tpl() -> EmailTemplate {
+        EmailTemplate {
+            name: "welcome".into(),
+            subject: "Hi".into(),
+            body_html: "<p>hi</p>".into(),
+            body_plaintext: "hi".into(),
+            description: Some("read-only".into()),
+            preheader: Some("peek".into()),
+            should_inline_css: Some(true),
+            tags: vec!["z".into(), "a".into()],
+        }
+    }
+
+    fn cat() -> Catalog {
+        Catalog {
+            name: "products".into(),
+            description: Some("read-only".into()),
+            fields: vec![
+                CatalogField {
+                    name: "id".into(),
+                    field_type: CatalogFieldType::String,
+                },
+                CatalogField {
+                    name: "price".into(),
+                    field_type: CatalogFieldType::Number,
+                },
+            ],
+        }
+    }
+
+    // -------------------------------------------------------------
+    // Snapshots. A failure here means the plan file format changed:
+    // bump CURRENT_PLAN_VERSION before accepting the new snapshot.
+    // -------------------------------------------------------------
+
+    #[test]
+    fn content_block_projection_is_stable() {
+        insta::assert_snapshot!(content_block(&cb()));
+    }
+
+    #[test]
+    fn email_template_projection_is_stable() {
+        insta::assert_snapshot!(email_template(&tpl()));
+    }
+
+    #[test]
+    fn catalog_projection_is_stable() {
+        insta::assert_snapshot!(catalog(&cat()));
+    }
+
+    // -------------------------------------------------------------
+    // Domain separation and encoding unambiguity.
+    // -------------------------------------------------------------
+
+    #[test]
+    fn digests_are_domain_separated() {
+        // Same leading field value, three different projected types.
+        let mut a = cb();
+        a.name = "same".into();
+        a.description = None;
+        a.content = String::new();
+        a.tags = vec![];
+
+        let mut b = tpl();
+        b.name = "same".into();
+        b.subject = String::new();
+        b.body_html = String::new();
+        b.body_plaintext = String::new();
+        b.preheader = None;
+        b.should_inline_css = None;
+        b.tags = vec![];
+
+        let c = Catalog {
+            name: "same".into(),
+            description: None,
+            fields: vec![],
+        };
+
+        let (x, y, z) = (content_block(&a), email_template(&b), catalog(&c));
+        assert_ne!(x, y);
+        assert_ne!(y, z);
+        assert_ne!(x, z);
+    }
+
+    #[test]
+    fn field_boundaries_are_unambiguous() {
+        let mut a = cb();
+        a.name = "ab".into();
+        a.description = Some("c".into());
+        let mut b = cb();
+        b.name = "a".into();
+        b.description = Some("bc".into());
+        assert_ne!(content_block(&a), content_block(&b));
+    }
+
+    #[test]
+    fn tag_count_prefix_prevents_boundary_collision() {
+        let mut a = cb();
+        a.tags = vec!["x".into(), "y".into()];
+        let mut b = cb();
+        b.tags = vec!["xy".into()];
+        assert_ne!(content_block(&a), content_block(&b));
+    }
+}

--- a/src/diff/digest.rs
+++ b/src/diff/digest.rs
@@ -28,8 +28,12 @@
 //!
 //! The byte encoding below is part of the plan file format. Changing it
 //! invalidates every saved plan, so any change here must bump
-//! [`CURRENT_PLAN_VERSION`](crate::diff::plan::CURRENT_PLAN_VERSION). The
-//! insta snapshots in this module exist to make that impossible to forget.
+//! [`CURRENT_PLAN_VERSION`](crate::diff::plan::CURRENT_PLAN_VERSION).
+//! The insta snapshots in this module make an encoding change impossible
+//! to make *silently* — they fail, and accepting a new one is the prompt
+//! to bump. Nothing enforces the bump itself: accept the snapshot without
+//! it and every already-saved v2 plan starts reporting drift its remote
+//! never had.
 //!
 //! # Limitation
 //!
@@ -40,6 +44,7 @@
 //! to the digest. See the type's doc comment.
 
 use blake3::Hasher;
+use std::collections::BTreeMap;
 
 use crate::resource::{Catalog, ContentBlock, EmailTemplate};
 
@@ -126,18 +131,30 @@ pub fn email_template(tpl: &EmailTemplate) -> String {
 
 /// Digest the surface `diff::catalog::diff_fields` compares: the field set
 /// keyed by name, each with its type. Field order does not matter (the
-/// diff keys by name via `BTreeMap`), so fields are sorted here.
+/// diff keys by name via `BTreeMap`), so fields are keyed the same way here.
+///
+/// Also covers `name`, which `diff_fields` does not look at — the diff is
+/// handed two field lists that the caller already paired by catalog name.
+/// So the equivalence holds *per catalog name*, which is the only way it
+/// is ever used: `diff_ops` pairs ops by `(kind, name, op_type)` before
+/// any digest is compared.
 ///
 /// Excludes `description`: Braze has no endpoint to update it, so
 /// `diff_schema` treats description-only differences as `Unchanged` and
 /// `apply` can never overwrite one.
 pub fn catalog(cat: &Catalog) -> String {
-    let mut fields: Vec<(&str, &'static str)> = cat
+    // Keyed by name, exactly as `diff_fields` keys its own `BTreeMap`:
+    // that gives the sort for free, and it collapses a repeated field
+    // name last-wins the same way the diff does. A sorted `Vec` of pairs
+    // would instead distinguish two catalogs the diff cannot tell apart,
+    // breaking the equivalence in the direction that matters (digest
+    // silent while the diff sees a change) — unreachable through Braze's
+    // schema, but the invariant is what everything downstream rests on.
+    let fields: BTreeMap<&str, &'static str> = cat
         .fields
         .iter()
         .map(|f| (f.name.as_str(), f.field_type.as_str()))
         .collect();
-    fields.sort_unstable();
 
     let mut p = Projection::new("catalog_schema/v2");
     p.str_field(&cat.name);

--- a/src/diff/digest.rs
+++ b/src/diff/digest.rs
@@ -29,11 +29,16 @@
 //! The byte encoding below is part of the plan file format. Changing it
 //! invalidates every saved plan, so any change here must bump
 //! [`CURRENT_PLAN_VERSION`](crate::diff::plan::CURRENT_PLAN_VERSION).
-//! The insta snapshots in this module make an encoding change impossible
-//! to make *silently* — they fail, and accepting a new one is the prompt
-//! to bump. Nothing enforces the bump itself: accept the snapshot without
-//! it and every already-saved v2 plan starts reporting drift its remote
-//! never had.
+//! The insta snapshots in this module catch an encoding change *for the
+//! three fixtures they pin*, and a failure there is the prompt to bump.
+//! Two gaps to keep in mind, because neither is enforced:
+//!
+//! - Nothing ties the bump to the snapshot. Accept a new one and leave
+//!   the version alone, and every already-saved v2 plan starts reporting
+//!   drift its remote never had.
+//! - An input class the fixtures do not exercise can change encoding
+//!   with all three still green — a catalog with a repeated field name
+//!   did exactly that when this projection moved to a `BTreeMap`.
 //!
 //! # Limitation
 //!

--- a/src/diff/email_template.rs
+++ b/src/diff/email_template.rs
@@ -294,4 +294,97 @@ mod tests {
         let modified = diff(Some(&l2), Some(&r2)).unwrap();
         assert!(!modified.op.is_destructive());
     }
+
+    // -----------------------------------------------------------
+    // digest <=> syncable_eq. See src/diff/digest.rs.
+    // -----------------------------------------------------------
+
+    mod digest_equivalence {
+        use super::*;
+        use crate::diff::digest;
+
+        fn base() -> EmailTemplate {
+            EmailTemplate {
+                name: "welcome".into(),
+                subject: "Hi".into(),
+                body_html: "<p>hi</p>".into(),
+                body_plaintext: "hi".into(),
+                description: Some("read-only".into()),
+                preheader: Some("peek".into()),
+                should_inline_css: Some(true),
+                tags: vec!["a".into(), "b".into()],
+            }
+        }
+
+        #[track_caller]
+        fn assert_agree(a: &EmailTemplate, b: &EmailTemplate) {
+            assert_eq!(
+                syncable_eq(a, b),
+                digest::email_template(a) == digest::email_template(b),
+                "digest and syncable_eq disagree on {a:?} vs {b:?}",
+            );
+        }
+
+        #[test]
+        fn identical_agree() {
+            assert_agree(&base(), &base());
+        }
+
+        #[test]
+        fn none_and_empty_preheader_agree() {
+            let mut a = base();
+            a.preheader = None;
+            let mut b = base();
+            b.preheader = Some(String::new());
+            assert!(syncable_eq(&a, &b));
+            assert_agree(&a, &b);
+        }
+
+        #[test]
+        fn unset_inline_css_differs_from_false_in_both() {
+            let mut a = base();
+            a.should_inline_css = None;
+            let mut b = base();
+            b.should_inline_css = Some(false);
+            assert!(!syncable_eq(&a, &b));
+            assert_agree(&a, &b);
+        }
+
+        #[test]
+        fn tag_order_agrees() {
+            let mut b = base();
+            b.tags.reverse();
+            assert!(syncable_eq(&base(), &b));
+            assert_agree(&base(), &b);
+        }
+
+        #[test]
+        fn description_is_ignored_by_both() {
+            let mut b = base();
+            b.description = Some("edited remotely".into());
+            assert!(syncable_eq(&base(), &b));
+            assert_agree(&base(), &b);
+        }
+
+        #[test]
+        fn every_syncable_field_change_disagrees_in_both() {
+            let mutations: Vec<fn(&mut EmailTemplate)> = vec![
+                |t| t.name = "other".into(),
+                |t| t.subject = "changed".into(),
+                |t| t.body_html = "changed".into(),
+                |t| t.body_plaintext = "changed".into(),
+                |t| t.preheader = Some("changed".into()),
+                |t| t.should_inline_css = Some(false),
+                |t| t.should_inline_css = None,
+                |t| t.tags.push("extra".into()),
+                |t| t.tags.clear(),
+            ];
+            for mutate in mutations {
+                let mut b = base();
+                mutate(&mut b);
+                assert!(!syncable_eq(&base(), &b), "expected a real change: {b:?}");
+                assert_agree(&base(), &b);
+            }
+        }
+    }
 }

--- a/src/diff/email_template.rs
+++ b/src/diff/email_template.rs
@@ -366,6 +366,23 @@ mod tests {
             assert_agree(&base(), &b);
         }
 
+        /// Compile-time guard on the list below — see the same test in
+        /// `diff::content_block` for why the hand-written mutation list
+        /// cannot be trusted to stay exhaustive on its own.
+        #[test]
+        fn mutation_list_covers_every_field() {
+            let EmailTemplate {
+                name: _,
+                subject: _,
+                body_html: _,
+                body_plaintext: _,
+                description: _,
+                preheader: _,
+                should_inline_css: _,
+                tags: _,
+            } = base();
+        }
+
         #[test]
         fn every_syncable_field_change_disagrees_in_both() {
             let mutations: Vec<fn(&mut EmailTemplate)> = vec![

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -11,6 +11,7 @@ pub mod catalog;
 pub mod content_block;
 pub mod content_block_order;
 pub mod custom_attribute;
+pub mod digest;
 pub mod email_template;
 pub mod plan;
 pub mod tag;

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -6,12 +6,18 @@
 //!
 //! > Apply the *current* local intent, provided that (a) the set of
 //! > operations still has the shape the plan recorded, and (b) the
-//! > remote side of every op that writes to Braze is still what `diff`
-//! > observed when the plan was generated.
+//! > remote side of every op that would overwrite a remote body is still
+//! > what `diff` observed when the plan was generated.
 //!
 //! Both halves are enforced: (a) by the op multiset comparison in
 //! [`PlanFile::diff_ops`], (b) by the [`RemotePrecondition`] carried on
 //! each op and checked against a freshly-fetched remote at apply time.
+//!
+//! `Deprecate` / `Reactivate` are covered by (a) alone — they write a
+//! boolean whose expected prior value the op direction already states, so
+//! a remote toggle removes the op from the fresh diff rather than
+//! surviving it with a stale precondition. See
+//! [`PlanOpType::requires_precondition`].
 //!
 //! # What this does not promise
 //!
@@ -87,12 +93,28 @@ pub enum RemotePrecondition {
     Digest(String),
 }
 
+/// Length of the hex form of a blake3 digest, which is what
+/// [`crate::diff::digest`] emits.
+const DIGEST_HEX_LEN: usize = 64;
+
+/// Whether a plan-supplied string is shaped like one of our digests.
+/// The plan file is operator-supplied input, so the *shape* is checked
+/// rather than assumed — see [`PlanFile::validate`].
+fn is_digest_hex(s: &str) -> bool {
+    s.len() == DIGEST_HEX_LEN && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 impl RemotePrecondition {
     /// Short human-readable form for drift reporting.
+    ///
+    /// Truncates by *character*, not by byte: `validate` rejects a
+    /// malformed digest before this can be reached, but this is a public
+    /// method on operator-supplied data and must not be one edit away
+    /// from panicking on a split codepoint.
     pub fn describe(&self) -> String {
         match self {
             Self::Absent => "absent".to_string(),
-            Self::Digest(d) => format!("digest {}…", &d[..d.len().min(12)]),
+            Self::Digest(d) => format!("digest {}…", d.chars().take(12).collect::<String>()),
         }
     }
 }
@@ -262,6 +284,10 @@ impl PlanFile {
     /// treated as a malformed plan, never as "skip the comparison for
     /// this op" — silently degrading to the pre-v2 shape-only check is
     /// exactly the failure mode v2 exists to remove.
+    ///
+    /// A digest that is not one of ours is rejected here for the same
+    /// reason, and because everything downstream — the comparison, the
+    /// drift report — is entitled to assume the shape this checks.
     pub fn validate(&self) -> Result<(), Vec<String>> {
         let mut problems = Vec::new();
         for op in &self.ops {
@@ -273,7 +299,14 @@ impl PlanFile {
             match (expected, &op.precondition) {
                 (None, None) => {}
                 (Some("absent"), Some(RemotePrecondition::Absent)) => {}
-                (Some("a digest"), Some(RemotePrecondition::Digest(_))) => {}
+                (Some("a digest"), Some(RemotePrecondition::Digest(d))) if is_digest_hex(d) => {}
+                (Some("a digest"), Some(RemotePrecondition::Digest(_))) => problems.push(format!(
+                    "{} {}: op `{}` carries a malformed digest \
+                     (expected {DIGEST_HEX_LEN} lowercase hex characters)",
+                    op.kind.as_str(),
+                    op.name,
+                    op.op.as_str(),
+                )),
                 (None, Some(_)) => problems.push(format!(
                     "{} {}: op `{}` must not carry a remote precondition",
                     op.kind.as_str(),
@@ -429,11 +462,18 @@ mod tests {
         Catalog, CatalogField, CatalogFieldType, ContentBlock, ContentBlockState,
     };
 
+    /// A distinct, *well-formed* digest per name. `validate` checks the
+    /// hex shape, so a readable placeholder like `digest-of-hero` would
+    /// make every fixture below a malformed plan.
+    fn digest_like(name: &str) -> String {
+        blake3::hash(name.as_bytes()).to_hex().to_string()
+    }
+
     fn op(kind: ResourceKind, name: &str, op: PlanOpType) -> PlanOp {
         let precondition = match op {
             PlanOpType::Add => Some(RemotePrecondition::Absent),
             PlanOpType::Modify | PlanOpType::DestructiveDelete => {
-                Some(RemotePrecondition::Digest(format!("digest-of-{name}")))
+                Some(RemotePrecondition::Digest(digest_like(name)))
             }
             _ => None,
         };
@@ -592,6 +632,33 @@ mod tests {
         assert_eq!(problems.len(), 2);
         assert!(problems[0].contains("requires absent"), "{problems:?}");
         assert!(problems[1].contains("must not carry"), "{problems:?}");
+    }
+
+    #[test]
+    fn validate_rejects_a_malformed_digest() {
+        // Not hex — and byte 12 lands inside the '€', which is what
+        // `describe` used to slice straight through.
+        let plan = plan_with(vec![PlanOp {
+            kind: ResourceKind::ContentBlock,
+            name: "hero".into(),
+            op: PlanOpType::Modify,
+            precondition: Some(RemotePrecondition::Digest("aaaaaaaaaaa€zz".into())),
+        }]);
+        let problems = plan.validate().unwrap_err();
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("malformed digest"), "{problems:?}");
+    }
+
+    #[test]
+    fn describe_truncates_by_character_not_byte() {
+        // `validate` rejects this shape before `describe` can see it;
+        // `describe` is public, so it must not panic on it regardless.
+        let p = RemotePrecondition::Digest("aaaaaaaaaaa€zz".into());
+        assert_eq!(p.describe(), "digest aaaaaaaaaaa€…");
+        assert_eq!(
+            RemotePrecondition::Digest(digest_like("hero")).describe(),
+            format!("digest {}…", &digest_like("hero")[..12]),
+        );
     }
 
     #[test]

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -1,18 +1,53 @@
 //! Plan file schema and matching for `diff --plan-out` / `apply --plan`.
 //!
-//! The plan file freezes the set of actionable ops produced by `diff` so
-//! that `apply` can refuse to run when the live Braze state has drifted
-//! since the plan was generated (Terraform-style plan/apply lock).
+//! # Contract
+//!
+//! A saved plan authorizes exactly this:
+//!
+//! > Apply the *current* local intent, provided that (a) the set of
+//! > operations still has the shape the plan recorded, and (b) the
+//! > remote side of every op that writes to Braze is still what `diff`
+//! > observed when the plan was generated.
+//!
+//! Both halves are enforced: (a) by the op multiset comparison in
+//! [`PlanFile::diff_ops`], (b) by the [`RemotePrecondition`] carried on
+//! each op and checked against a freshly-fetched remote at apply time.
+//!
+//! # What this does not promise
+//!
+//! - **It is not concurrency control.** The precondition is checked
+//!   against apply's own fetch, then the write happens. As of 2026-09
+//!   Braze's REST API offers no `If-Match` or expected-state token on
+//!   any endpoint braze-sync writes to, so a lost update remains
+//!   possible inside that window.
+//! - **It does not freeze the change set.** Local edits between plan and
+//!   apply are still applied as long as the op shapes match; the plan
+//!   binds the remote preconditions, not the bytes that get written.
+//! - **It does not detect identity replacement.** A remote object
+//!   replaced by identical content under a different Braze ID projects to
+//!   the same digest.
+//! - **It does not cover catalog items.** Deleting a catalog deletes its
+//!   items, which braze-sync never fetches; the schema digest says
+//!   nothing about rows added since the plan.
+//! - **`scope.environment` is a config name, not a workspace identity.**
+//!   Repointing an environment at a different Braze workspace is not
+//!   visible here.
+//! - **A digest is not confidentiality.** Predictable content can be
+//!   guessed and confirmed. It is small enough to publish as a CI
+//!   artifact, which is why the plan carries digests rather than payloads.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::diff::custom_attribute::CustomAttributeOp;
-use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
+use crate::diff::{digest, DiffOp, DiffSummary, ResourceDiff};
 use crate::resource::ResourceKind;
 
-pub const CURRENT_PLAN_VERSION: u32 = 1;
+/// Bumped whenever the op vocabulary or a digest projection changes.
+/// Older plans are rejected rather than migrated: a plan whose meaning
+/// this binary cannot reproduce is not evidence of anything.
+pub const CURRENT_PLAN_VERSION: u32 = 2;
 
 /// Warn at apply time when the saved plan is older than this.
 pub const STALE_PLAN_WARN_THRESHOLD: chrono::TimeDelta = chrono::TimeDelta::hours(24);
@@ -35,17 +70,62 @@ pub struct PlanScope {
     pub name: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// The state the remote side of an op must still be in for the plan to
+/// authorize it.
+///
+/// Digests cover the surface `apply` would overwrite — see
+/// [`crate::diff::digest`]. Read-only fields are deliberately outside the
+/// projection: a remote edit to one cannot be clobbered, so it is not a
+/// precondition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "state", content = "digest")]
+pub enum RemotePrecondition {
+    /// The resource must still not exist remotely. Carried by `Add`.
+    Absent,
+    /// The remote object must still project to this blake3 hex digest.
+    /// Carried by `Modify` and `DestructiveDelete`.
+    Digest(String),
+}
+
+impl RemotePrecondition {
+    /// Short human-readable form for drift reporting.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Absent => "absent".to_string(),
+            Self::Digest(d) => format!("digest {}…", &d[..d.len().min(12)]),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanOp {
     pub kind: ResourceKind,
     pub name: String,
     pub op: PlanOpType,
+    /// `None` only for ops that write nothing to the resource's remote
+    /// body — see [`PlanOpType::requires_precondition`]. Never "we could
+    /// not compute one": a v2 plan missing a required precondition is
+    /// rejected as malformed by [`PlanFile::validate`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub precondition: Option<RemotePrecondition>,
+}
+
+impl PlanOp {
+    /// The pairing key for [`PlanFile::diff_ops`]. Deliberately excludes
+    /// `precondition`: ops are matched by shape first, then their
+    /// preconditions are compared, so a drifted remote reads as "this op
+    /// changed underneath you" rather than as an unrelated op appearing
+    /// and another disappearing.
+    fn shape(&self) -> (ResourceKind, &str, PlanOpType) {
+        (self.kind, self.name.as_str(), self.op)
+    }
 }
 
 /// The coarse op classification used for plan locking. Field-level
 /// payloads are deliberately excluded so the plan file stays safe to
 /// publish as a CI artifact and so the apply-time comparison tolerates
-/// benign content edits made between plan and apply.
+/// benign *local* edits made between plan and apply. Remote drift is
+/// caught by [`RemotePrecondition`] instead, which needs only a digest.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanOpType {
@@ -55,6 +135,32 @@ pub enum PlanOpType {
     Orphan,
     Deprecate,
     Reactivate,
+}
+
+impl PlanOpType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Add => "add",
+            Self::Modify => "modify",
+            Self::DestructiveDelete => "destructive_delete",
+            Self::Orphan => "orphan",
+            Self::Deprecate => "deprecate",
+            Self::Reactivate => "reactivate",
+        }
+    }
+
+    /// Whether a v2 plan op of this type must carry a precondition.
+    ///
+    /// `Orphan` is report-only and its remote body is never even fetched
+    /// (`cli::diff` issues `/info` only for names present on both sides).
+    /// `Deprecate` / `Reactivate` write a boolean whose expected prior
+    /// value is implied by the op direction itself.
+    pub fn requires_precondition(self) -> bool {
+        match self {
+            Self::Add | Self::Modify | Self::DestructiveDelete => true,
+            Self::Orphan | Self::Deprecate | Self::Reactivate => false,
+        }
+    }
 }
 
 impl PlanFile {
@@ -89,21 +195,24 @@ impl PlanFile {
         std::fs::write(path, json)
     }
 
-    /// Compare saved ops against `fresh` as a multiset over `(kind, name,
-    /// op_type)`, order-independent. `collect_ops` is invariant-by-design
-    /// unique per `(kind, name)` today, but we use a merge walk rather
-    /// than a set so duplicates would surface as drift instead of being
-    /// silently collapsed.
+    /// Compare saved ops against `fresh` as a multiset over
+    /// `(kind, name, op_type)`, order-independent, then compare the
+    /// preconditions of the pairs that matched.
+    ///
+    /// `collect_ops` is invariant-by-design unique per `(kind, name)`
+    /// today, but we use a merge walk rather than a set so duplicates
+    /// would surface as drift instead of being silently collapsed.
     pub fn diff_ops(&self, fresh: &[PlanOp]) -> PlanOpsDiff {
         let mut saved: Vec<&PlanOp> = self.ops.iter().collect();
         let mut fresh_sorted: Vec<&PlanOp> = fresh.iter().collect();
-        saved.sort();
-        fresh_sorted.sort();
+        saved.sort_by(|a, b| a.shape().cmp(&b.shape()));
+        fresh_sorted.sort_by(|a, b| a.shape().cmp(&b.shape()));
         let (mut i, mut j) = (0, 0);
         let mut missing = Vec::new();
         let mut extra = Vec::new();
+        let mut precondition_drift = Vec::new();
         while i < saved.len() && j < fresh_sorted.len() {
-            match saved[i].cmp(fresh_sorted[j]) {
+            match saved[i].shape().cmp(&fresh_sorted[j].shape()) {
                 std::cmp::Ordering::Less => {
                     missing.push(saved[i].clone());
                     i += 1;
@@ -113,6 +222,26 @@ impl PlanFile {
                     j += 1;
                 }
                 std::cmp::Ordering::Equal => {
+                    // Equal shapes imply equal op types, and both
+                    // `validate` (saved) and `classify` (fresh) pin the
+                    // precondition kind to the op type — so either both
+                    // sides carry one or neither does.
+                    debug_assert_eq!(
+                        saved[i].precondition.is_some(),
+                        fresh_sorted[j].precondition.is_some(),
+                        "precondition presence must follow the op type",
+                    );
+                    if let (Some(expected), Some(found)) =
+                        (&saved[i].precondition, &fresh_sorted[j].precondition)
+                    {
+                        if expected != found {
+                            precondition_drift.push(PreconditionDrift {
+                                op: saved[i].clone(),
+                                expected: expected.clone(),
+                                found: found.clone(),
+                            });
+                        }
+                    }
                     i += 1;
                     j += 1;
                 }
@@ -120,8 +249,66 @@ impl PlanFile {
         }
         missing.extend(saved[i..].iter().map(|&op| op.clone()));
         extra.extend(fresh_sorted[j..].iter().map(|&op| op.clone()));
-        PlanOpsDiff { missing, extra }
+        PlanOpsDiff {
+            missing,
+            extra,
+            precondition_drift,
+        }
     }
+
+    /// Reject a plan this binary cannot check.
+    ///
+    /// A missing precondition on an op that writes to a remote body is
+    /// treated as a malformed plan, never as "skip the comparison for
+    /// this op" — silently degrading to the pre-v2 shape-only check is
+    /// exactly the failure mode v2 exists to remove.
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let mut problems = Vec::new();
+        for op in &self.ops {
+            let expected = match (op.op.requires_precondition(), op.op) {
+                (false, _) => None,
+                (true, PlanOpType::Add) => Some("absent"),
+                (true, _) => Some("a digest"),
+            };
+            match (expected, &op.precondition) {
+                (None, None) => {}
+                (Some("absent"), Some(RemotePrecondition::Absent)) => {}
+                (Some("a digest"), Some(RemotePrecondition::Digest(_))) => {}
+                (None, Some(_)) => problems.push(format!(
+                    "{} {}: op `{}` must not carry a remote precondition",
+                    op.kind.as_str(),
+                    op.name,
+                    op.op.as_str(),
+                )),
+                (Some(want), found) => problems.push(format!(
+                    "{} {}: op `{}` requires {} precondition, found {}",
+                    op.kind.as_str(),
+                    op.name,
+                    op.op.as_str(),
+                    want,
+                    match found {
+                        None => "none".to_string(),
+                        Some(RemotePrecondition::Absent) => "absent".to_string(),
+                        Some(RemotePrecondition::Digest(_)) => "a digest".to_string(),
+                    },
+                )),
+            }
+        }
+        if problems.is_empty() {
+            Ok(())
+        } else {
+            Err(problems)
+        }
+    }
+}
+
+/// A shape-matched op pair whose remote precondition no longer holds:
+/// the live Braze state moved between plan and apply.
+#[derive(Debug, Clone)]
+pub struct PreconditionDrift {
+    pub op: PlanOp,
+    pub expected: RemotePrecondition,
+    pub found: RemotePrecondition,
 }
 
 /// Result of comparing a saved plan's ops against a freshly-computed list.
@@ -131,67 +318,104 @@ pub struct PlanOpsDiff {
     pub missing: Vec<PlanOp>,
     /// In fresh but not in saved plan (new drift since plan).
     pub extra: Vec<PlanOp>,
+    /// Same op shape, but the remote is no longer what the plan observed.
+    pub precondition_drift: Vec<PreconditionDrift>,
 }
 
 impl PlanOpsDiff {
     pub fn is_match(&self) -> bool {
-        self.missing.is_empty() && self.extra.is_empty()
+        self.missing.is_empty() && self.extra.is_empty() && self.precondition_drift.is_empty()
     }
 }
 
-/// Convert a `DiffSummary` into the coarse plan-op list. Skips non-actionable
+/// Convert a `DiffSummary` into the plan-op list. Skips non-actionable
 /// diffs (Tag drift, Custom Attribute metadata-only, Unchanged) so the
 /// plan-lock vocabulary matches the set of operations apply can actually
 /// perform.
 pub fn collect_ops(summary: &DiffSummary) -> Vec<PlanOp> {
     let mut out = Vec::new();
     for diff in &summary.diffs {
-        let Some(op) = classify(diff) else { continue };
+        let Some((op, precondition)) = classify(diff) else {
+            continue;
+        };
         out.push(PlanOp {
             kind: diff.kind(),
             name: diff.name().to_string(),
             op,
+            precondition,
         });
     }
-    out.sort();
+    out.sort_by(|a, b| a.shape().cmp(&b.shape()));
     out
 }
 
-fn classify(diff: &ResourceDiff) -> Option<PlanOpType> {
+/// Classify one diff into its plan op and the remote state that op
+/// presupposes.
+///
+/// The precondition always comes from the `from` (remote) side. The `to`
+/// side is local intent, which the plan deliberately does not bind — see
+/// the module contract.
+fn classify(diff: &ResourceDiff) -> Option<(PlanOpType, Option<RemotePrecondition>)> {
     match diff {
         ResourceDiff::CatalogSchema(d) => match &d.op {
-            DiffOp::Added(_) => Some(PlanOpType::Add),
-            DiffOp::Removed(_) => Some(PlanOpType::DestructiveDelete),
-            DiffOp::Modified { .. } => Some(PlanOpType::Modify),
-            DiffOp::Unchanged => {
-                // Field-level edits with the catalog itself "unchanged".
-                if d.field_diffs.iter().any(|f| f.is_destructive()) {
-                    Some(PlanOpType::DestructiveDelete)
-                } else if d.field_diffs.iter().any(|f| f.is_change()) {
-                    Some(PlanOpType::Modify)
-                } else {
-                    None
-                }
+            DiffOp::Added(_) => Some((PlanOpType::Add, Some(RemotePrecondition::Absent))),
+            DiffOp::Removed(r) => {
+                Some((PlanOpType::DestructiveDelete, digest_of(r, digest::catalog)))
             }
+            // A field removal rewrites the schema destructively even
+            // though the catalog itself is `Modified`. Classify on what
+            // apply will actually do, so the plan's vocabulary and the
+            // `--allow-destructive` gate agree.
+            DiffOp::Modified { from, .. } => {
+                let op = if d.field_diffs.iter().any(|f| f.is_destructive()) {
+                    PlanOpType::DestructiveDelete
+                } else {
+                    PlanOpType::Modify
+                };
+                Some((op, digest_of(from, digest::catalog)))
+            }
+            // `diff_schema` bases the top-level op solely on field-level
+            // changes, so `Unchanged` here means there are none.
+            DiffOp::Unchanged => None,
         },
-        ResourceDiff::ContentBlock(d) => classify_orphanable(d.orphan, &d.op),
-        ResourceDiff::EmailTemplate(d) => classify_orphanable(d.orphan, &d.op),
+        ResourceDiff::ContentBlock(d) => {
+            classify_orphanable(d.orphan, &d.op, digest::content_block)
+        }
+        ResourceDiff::EmailTemplate(d) => {
+            classify_orphanable(d.orphan, &d.op, digest::email_template)
+        }
         ResourceDiff::CustomAttribute(d) => match &d.op {
-            CustomAttributeOp::DeprecationToggled { to: true, .. } => Some(PlanOpType::Deprecate),
-            CustomAttributeOp::DeprecationToggled { to: false, .. } => Some(PlanOpType::Reactivate),
+            // The baseline these presuppose is a boolean the op
+            // direction already states; a digest would add nothing.
+            CustomAttributeOp::DeprecationToggled { to: true, .. } => {
+                Some((PlanOpType::Deprecate, None))
+            }
+            CustomAttributeOp::DeprecationToggled { to: false, .. } => {
+                Some((PlanOpType::Reactivate, None))
+            }
             _ => None,
         },
         ResourceDiff::Tag(_) => None,
     }
 }
 
-fn classify_orphanable<T>(orphan: bool, op: &DiffOp<T>) -> Option<PlanOpType> {
+fn digest_of<T>(remote: &T, project: fn(&T) -> String) -> Option<RemotePrecondition> {
+    Some(RemotePrecondition::Digest(project(remote)))
+}
+
+fn classify_orphanable<T>(
+    orphan: bool,
+    op: &DiffOp<T>,
+    project: fn(&T) -> String,
+) -> Option<(PlanOpType, Option<RemotePrecondition>)> {
     if orphan {
-        return Some(PlanOpType::Orphan);
+        // Report-only, and the remote body is never fetched for an
+        // orphan — there is nothing to take a precondition on.
+        return Some((PlanOpType::Orphan, None));
     }
     match op {
-        DiffOp::Added(_) => Some(PlanOpType::Add),
-        DiffOp::Modified { .. } => Some(PlanOpType::Modify),
+        DiffOp::Added(_) => Some((PlanOpType::Add, Some(RemotePrecondition::Absent))),
+        DiffOp::Modified { from, .. } => Some((PlanOpType::Modify, digest_of(from, project))),
         DiffOp::Removed(_) | DiffOp::Unchanged => None,
     }
 }
@@ -199,19 +423,31 @@ fn classify_orphanable<T>(orphan: bool, op: &DiffOp<T>) -> Option<PlanOpType> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::diff::catalog::CatalogSchemaDiff;
+    use crate::diff::content_block::ContentBlockDiff;
+    use crate::resource::{
+        Catalog, CatalogField, CatalogFieldType, ContentBlock, ContentBlockState,
+    };
 
     fn op(kind: ResourceKind, name: &str, op: PlanOpType) -> PlanOp {
+        let precondition = match op {
+            PlanOpType::Add => Some(RemotePrecondition::Absent),
+            PlanOpType::Modify | PlanOpType::DestructiveDelete => {
+                Some(RemotePrecondition::Digest(format!("digest-of-{name}")))
+            }
+            _ => None,
+        };
         PlanOp {
             kind,
             name: name.to_string(),
             op,
+            precondition,
         }
     }
 
-    #[test]
-    fn ops_match_is_order_independent() {
-        let plan = PlanFile {
-            version: 1,
+    fn plan_with(ops: Vec<PlanOp>) -> PlanFile {
+        PlanFile {
+            version: CURRENT_PLAN_VERSION,
             generated_at: Utc::now(),
             braze_sync_version: "test".into(),
             scope: PlanScope {
@@ -219,11 +455,16 @@ mod tests {
                 resource: None,
                 name: None,
             },
-            ops: vec![
-                op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
-                op(ResourceKind::CatalogSchema, "x", PlanOpType::Add),
-            ],
-        };
+            ops,
+        }
+    }
+
+    #[test]
+    fn ops_match_is_order_independent() {
+        let plan = plan_with(vec![
+            op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
+            op(ResourceKind::CatalogSchema, "x", PlanOpType::Add),
+        ]);
         let fresh = vec![
             op(ResourceKind::CatalogSchema, "x", PlanOpType::Add),
             op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
@@ -233,22 +474,17 @@ mod tests {
 
     #[test]
     fn ops_mismatch_when_op_kind_changes() {
-        let plan = PlanFile {
-            version: 1,
-            generated_at: Utc::now(),
-            braze_sync_version: "test".into(),
-            scope: PlanScope {
-                environment: "dev".into(),
-                resource: None,
-                name: None,
-            },
-            ops: vec![op(ResourceKind::ContentBlock, "a", PlanOpType::Modify)],
-        };
+        let plan = plan_with(vec![op(
+            ResourceKind::ContentBlock,
+            "a",
+            PlanOpType::Modify,
+        )]);
         let fresh = vec![op(ResourceKind::ContentBlock, "a", PlanOpType::Orphan)];
         let diff = plan.diff_ops(&fresh);
         assert!(!diff.is_match());
         assert_eq!(diff.missing.len(), 1);
         assert_eq!(diff.extra.len(), 1);
+        assert!(diff.precondition_drift.is_empty());
     }
 
     #[test]
@@ -256,20 +492,10 @@ mod tests {
         // Hand-crafted: two identical ops on either side should match,
         // but `n` on one side and `n+1` on the other should surface as
         // a single extra (set semantics would collapse to a match).
-        let plan = PlanFile {
-            version: 1,
-            generated_at: Utc::now(),
-            braze_sync_version: "test".into(),
-            scope: PlanScope {
-                environment: "dev".into(),
-                resource: None,
-                name: None,
-            },
-            ops: vec![
-                op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
-                op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
-            ],
-        };
+        let plan = plan_with(vec![
+            op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
+            op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
+        ]);
         let fresh_dup = vec![
             op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
             op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
@@ -286,7 +512,7 @@ mod tests {
     #[test]
     fn round_trip_json() {
         let plan = PlanFile {
-            version: 1,
+            version: CURRENT_PLAN_VERSION,
             generated_at: "2026-05-18T12:34:56Z".parse().unwrap(),
             braze_sync_version: "0.12.0".into(),
             scope: PlanScope {
@@ -294,11 +520,205 @@ mod tests {
                 resource: Some(ResourceKind::ContentBlock),
                 name: None,
             },
-            ops: vec![op(ResourceKind::ContentBlock, "hero", PlanOpType::Add)],
+            ops: vec![
+                op(ResourceKind::ContentBlock, "hero", PlanOpType::Add),
+                op(ResourceKind::ContentBlock, "promo", PlanOpType::Modify),
+                op(ResourceKind::ContentBlock, "stale", PlanOpType::Orphan),
+            ],
         };
         let json = serde_json::to_string(&plan).unwrap();
         let round: PlanFile = serde_json::from_str(&json).unwrap();
         assert!(plan.diff_ops(&round.ops).is_match());
         assert_eq!(round.scope, plan.scope);
+        assert_eq!(round.ops, plan.ops);
+    }
+
+    // -------------------------------------------------------------
+    // Remote preconditions
+    // -------------------------------------------------------------
+
+    #[test]
+    fn same_op_shape_with_changed_remote_is_drift() {
+        // The #100 scenario in miniature: shape unchanged, remote moved.
+        let plan = plan_with(vec![PlanOp {
+            kind: ResourceKind::ContentBlock,
+            name: "hero".into(),
+            op: PlanOpType::Modify,
+            precondition: Some(RemotePrecondition::Digest("aaa".into())),
+        }]);
+        let fresh = vec![PlanOp {
+            kind: ResourceKind::ContentBlock,
+            name: "hero".into(),
+            op: PlanOpType::Modify,
+            precondition: Some(RemotePrecondition::Digest("bbb".into())),
+        }];
+        let diff = plan.diff_ops(&fresh);
+        assert!(!diff.is_match());
+        assert!(diff.missing.is_empty(), "shape is unchanged");
+        assert!(diff.extra.is_empty(), "shape is unchanged");
+        assert_eq!(diff.precondition_drift.len(), 1);
+    }
+
+    #[test]
+    fn validate_rejects_missing_digest() {
+        let plan = plan_with(vec![PlanOp {
+            kind: ResourceKind::ContentBlock,
+            name: "hero".into(),
+            op: PlanOpType::Modify,
+            precondition: None,
+        }]);
+        let problems = plan.validate().unwrap_err();
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("requires a digest"), "{problems:?}");
+    }
+
+    #[test]
+    fn validate_rejects_wrong_precondition_kind() {
+        let plan = plan_with(vec![
+            PlanOp {
+                kind: ResourceKind::CatalogSchema,
+                name: "c".into(),
+                op: PlanOpType::Add,
+                precondition: Some(RemotePrecondition::Digest("x".into())),
+            },
+            PlanOp {
+                kind: ResourceKind::ContentBlock,
+                name: "orphaned".into(),
+                op: PlanOpType::Orphan,
+                precondition: Some(RemotePrecondition::Absent),
+            },
+        ]);
+        let problems = plan.validate().unwrap_err();
+        assert_eq!(problems.len(), 2);
+        assert!(problems[0].contains("requires absent"), "{problems:?}");
+        assert!(problems[1].contains("must not carry"), "{problems:?}");
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_plan() {
+        let plan = plan_with(vec![
+            op(ResourceKind::CatalogSchema, "c", PlanOpType::Add),
+            op(ResourceKind::ContentBlock, "a", PlanOpType::Modify),
+            op(ResourceKind::ContentBlock, "b", PlanOpType::Orphan),
+            op(ResourceKind::CustomAttribute, "d", PlanOpType::Deprecate),
+            op(
+                ResourceKind::CatalogSchema,
+                "e",
+                PlanOpType::DestructiveDelete,
+            ),
+        ]);
+        assert!(plan.validate().is_ok());
+    }
+
+    // -------------------------------------------------------------
+    // classify
+    // -------------------------------------------------------------
+
+    fn field(name: &str, field_type: CatalogFieldType) -> CatalogField {
+        CatalogField {
+            name: name.into(),
+            field_type,
+        }
+    }
+
+    fn catalog(name: &str, fields: Vec<CatalogField>) -> Catalog {
+        Catalog {
+            name: name.into(),
+            description: None,
+            fields,
+        }
+    }
+
+    #[test]
+    fn catalog_field_removal_classifies_as_destructive() {
+        let remote = catalog(
+            "c",
+            vec![
+                field("id", CatalogFieldType::String),
+                field("old", CatalogFieldType::Number),
+            ],
+        );
+        let local = catalog("c", vec![field("id", CatalogFieldType::String)]);
+        let d = crate::diff::catalog::diff_schema(Some(&local), Some(&remote)).unwrap();
+        let (op, precondition) = classify(&ResourceDiff::CatalogSchema(d)).unwrap();
+        assert_eq!(op, PlanOpType::DestructiveDelete);
+        assert_eq!(
+            precondition,
+            Some(RemotePrecondition::Digest(digest::catalog(&remote))),
+        );
+    }
+
+    #[test]
+    fn catalog_field_addition_classifies_as_modify_with_remote_digest() {
+        let remote = catalog("c", vec![field("id", CatalogFieldType::String)]);
+        let local = catalog(
+            "c",
+            vec![
+                field("id", CatalogFieldType::String),
+                field("new", CatalogFieldType::Number),
+            ],
+        );
+        let d = crate::diff::catalog::diff_schema(Some(&local), Some(&remote)).unwrap();
+        let (op, precondition) = classify(&ResourceDiff::CatalogSchema(d)).unwrap();
+        assert_eq!(op, PlanOpType::Modify);
+        assert_eq!(
+            precondition,
+            Some(RemotePrecondition::Digest(digest::catalog(&remote))),
+            "precondition must digest the remote, not the local, side",
+        );
+    }
+
+    #[test]
+    fn catalog_with_no_field_diffs_is_not_a_plan_op() {
+        let c = catalog("c", vec![field("id", CatalogFieldType::String)]);
+        let mut local = c.clone();
+        local.description = Some("description-only edit".into());
+        let d = crate::diff::catalog::diff_schema(Some(&local), Some(&c)).unwrap();
+        assert!(matches!(d.op, DiffOp::Unchanged));
+        assert!(classify(&ResourceDiff::CatalogSchema(d)).is_none());
+    }
+
+    #[test]
+    fn content_block_modify_digests_the_remote_side() {
+        let remote = ContentBlock {
+            name: "hero".into(),
+            description: None,
+            content: "remote".into(),
+            tags: vec![],
+            state: ContentBlockState::Active,
+        };
+        let mut local = remote.clone();
+        local.content = "local".into();
+        let d = crate::diff::content_block::diff(Some(&local), Some(&remote)).unwrap();
+        let (op, precondition) = classify(&ResourceDiff::ContentBlock(d)).unwrap();
+        assert_eq!(op, PlanOpType::Modify);
+        assert_eq!(
+            precondition,
+            Some(RemotePrecondition::Digest(digest::content_block(&remote))),
+        );
+        assert_ne!(
+            precondition,
+            Some(RemotePrecondition::Digest(digest::content_block(&local))),
+        );
+    }
+
+    #[test]
+    fn orphan_carries_no_precondition() {
+        let d = ContentBlockDiff::orphan("gone");
+        let (op, precondition) = classify(&ResourceDiff::ContentBlock(d)).unwrap();
+        assert_eq!(op, PlanOpType::Orphan);
+        assert_eq!(precondition, None);
+    }
+
+    #[test]
+    fn removed_catalog_digests_the_remote_resource() {
+        let remote = catalog("gone", vec![field("id", CatalogFieldType::String)]);
+        let d: CatalogSchemaDiff = crate::diff::catalog::diff_schema(None, Some(&remote)).unwrap();
+        let (op, precondition) = classify(&ResourceDiff::CatalogSchema(d)).unwrap();
+        assert_eq!(op, PlanOpType::DestructiveDelete);
+        assert_eq!(
+            precondition,
+            Some(RemotePrecondition::Digest(digest::catalog(&remote))),
+        );
     }
 }

--- a/src/diff/snapshots/braze_sync__diff__digest__tests__catalog_projection_is_stable.snap
+++ b/src/diff/snapshots/braze_sync__diff__digest__tests__catalog_projection_is_stable.snap
@@ -1,0 +1,6 @@
+---
+source: src/diff/digest.rs
+assertion_line: 213
+expression: catalog(&cat())
+---
+3b355ea34977f226a1e801dde61b7cffca1bff58798d88c2384f08b7b65ba80c

--- a/src/diff/snapshots/braze_sync__diff__digest__tests__content_block_projection_is_stable.snap
+++ b/src/diff/snapshots/braze_sync__diff__digest__tests__content_block_projection_is_stable.snap
@@ -1,0 +1,6 @@
+---
+source: src/diff/digest.rs
+assertion_line: 203
+expression: content_block(&cb())
+---
+63c1d9f7d4ff1c2c453160885a696910a58c73a705189baf8d2041c6f33d9dbb

--- a/src/diff/snapshots/braze_sync__diff__digest__tests__email_template_projection_is_stable.snap
+++ b/src/diff/snapshots/braze_sync__diff__digest__tests__email_template_projection_is_stable.snap
@@ -1,0 +1,6 @@
+---
+source: src/diff/digest.rs
+assertion_line: 208
+expression: email_template(&tpl())
+---
+f2ee4828697cc58b4dd5d8b9e08f24b7473a1dd1452c036f19b72f25c1bb3f84

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -20,7 +20,7 @@ use common::{
 };
 use predicates::prelude::PredicateBooleanExt;
 use serde_json::json;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{body_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -468,8 +468,17 @@ async fn local_only_edit_between_plan_and_apply_still_applies() {
         })))
         .mount(&server)
         .await;
+    // Match the body, not just the call: "a write fired" would also pass
+    // if apply had pushed the plan-time content, which is precisely the
+    // reading this test exists to rule out.
     Mock::given(method("POST"))
         .and(path("/content_blocks/update"))
+        .and(body_json(json!({
+            "content_block_id": "id-promo",
+            "name": "promo",
+            "content": "edited after planning\n",
+            "tags": []
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
         .expect(1)
         .mount(&server)

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -6,13 +6,21 @@
 //! - `diff --plan-out=<path>` writes a JSON plan file.
 //! - `apply --plan=<path>` succeeds when fresh plan matches saved plan.
 //! - mismatched ops, environment, or scope exit 7 and fire no writes.
+//!
+//! Plus the v2 remote-precondition contract (issue #100): an op whose
+//! *shape* is unchanged but whose *remote* moved between plan and apply
+//! must exit 7 and fire no writes, while a purely local edit must still
+//! be allowed through — the plan binds the remote, not the change set.
 
 mod common;
 
 use assert_cmd::Command;
-use common::{write_config, write_local_schema};
+use common::{
+    write_config, write_local_content_block, write_local_email_template, write_local_schema,
+};
+use predicates::prelude::PredicateBooleanExt;
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -44,7 +52,7 @@ async fn diff_plan_out_writes_plan_file() {
 
     let bytes = std::fs::read(&plan_path).expect("plan file written");
     let plan: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-    assert_eq!(plan["version"], 1);
+    assert_eq!(plan["version"], 2);
     assert_eq!(plan["scope"]["environment"], "test");
     assert_eq!(plan["scope"]["resource"], "catalog_schema");
     let ops = plan["ops"].as_array().unwrap();
@@ -52,6 +60,9 @@ async fn diff_plan_out_writes_plan_file() {
     assert_eq!(ops[0]["kind"], "catalog_schema");
     assert_eq!(ops[0]["name"], "newcat");
     assert_eq!(ops[0]["op"], "add");
+    // An `add` presupposes absence, not a digest.
+    assert_eq!(ops[0]["precondition"]["state"], "absent");
+    assert!(ops[0]["precondition"]["digest"].is_null());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -206,7 +217,7 @@ async fn apply_plan_environment_mismatch_exits_7_before_api_call() {
 
     // Hand-craft a plan file with a foreign environment.
     let plan_json = serde_json::json!({
-        "version": 1,
+        "version": 2,
         "generated_at": "2026-05-18T00:00:00Z",
         "braze_sync_version": env!("CARGO_PKG_VERSION"),
         "scope": {"environment": "prod"},
@@ -224,6 +235,604 @@ async fn apply_plan_environment_mismatch_exits_7_before_api_call() {
             .assert()
             .failure()
             .code(7);
+    })
+    .await
+    .unwrap();
+}
+
+// =====================================================================
+// Issue #100: op-shape equality is not evidence about the remote.
+// Each test below keeps the op classification identical between plan
+// and apply and moves only the remote, so a shape-only lock would let
+// the write through.
+// =====================================================================
+
+/// Runs `diff --plan-out` then `apply --plan` against the same config,
+/// returning the apply assertion for the caller to check.
+async fn plan_then_apply(
+    config_path: std::path::PathBuf,
+    plan_path: std::path::PathBuf,
+    resource: &'static str,
+) -> assert_cmd::assert::Assert {
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_for_diff = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_for_diff.to_str().unwrap()])
+            .args(["diff", "--resource", resource, &plan_out])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--resource", resource, "--confirm", &plan_in])
+            .assert()
+    })
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn content_block_remote_edit_that_keeps_modify_classification_exits_7() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-promo", "name": "promo"}]
+        })))
+        .mount(&server)
+        .await;
+    // Plan time: remote says "old body". Apply time: someone edited it in
+    // the web console to "console edit". Local still says "new body", so
+    // the op stays `modify` on both runs — the exact #100 precondition.
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .and(query_param("content_block_id", "id-promo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo", "content": "old body\n", "tags": []
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .and(query_param("content_block_id", "id-promo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo", "content": "console edit\n", "tags": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(tmp.path(), "promo", "new body\n");
+    let plan_path = tmp.path().join("plan.json");
+
+    plan_then_apply(config_path, plan_path, "content_block")
+        .await
+        .failure()
+        .code(7)
+        // Must fail on the precondition, not on op shape: prove the op
+        // set itself still matched.
+        .stderr(predicates::str::contains("remote state changed"))
+        .stderr(predicates::str::contains("remote state moved"))
+        .stderr(predicates::str::contains("not in fresh plan").not())
+        .stderr(predicates::str::contains("not in saved plan").not());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn email_template_remote_edit_that_keeps_modify_classification_exits_7() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "templates": [{"email_template_id": "id-welcome", "template_name": "welcome"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/info"))
+        .and(query_param("email_template_id", "id-welcome"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "template_name": "welcome",
+            "subject": "Old subject",
+            "body": "<p>old</p>",
+            "plaintext_body": "old",
+            "tags": []
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/templates/email/info"))
+        .and(query_param("email_template_id", "id-welcome"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "template_name": "welcome",
+            "subject": "Edited in console",
+            "body": "<p>old</p>",
+            "plaintext_body": "old",
+            "tags": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_email_template(tmp.path(), "welcome", "New subject", "<p>new</p>", "new");
+    let plan_path = tmp.path().join("plan.json");
+
+    plan_then_apply(config_path, plan_path, "email_template")
+        .await
+        .failure()
+        .code(7)
+        .stderr(predicates::str::contains("remote state changed"))
+        .stderr(predicates::str::contains("not in fresh plan").not())
+        .stderr(predicates::str::contains("not in saved plan").not());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn catalog_remote_field_type_change_that_keeps_modify_classification_exits_7() {
+    let server = MockServer::start().await;
+    // Plan time: remote `price` is a number. Apply time: it is a string.
+    // Local wants an extra `sku` field either way, so the op stays
+    // `modify` across both runs.
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"catalogs": [{
+                "name": "products",
+                "fields": [{"name": "id", "type": "string"}, {"name": "price", "type": "number"}]
+            }]})),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"catalogs": [{
+                "name": "products",
+                "fields": [{"name": "id", "type": "string"}, {"name": "price", "type": "string"}]
+            }]})),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(
+        tmp.path(),
+        "products",
+        &[("id", "string"), ("price", "number"), ("sku", "string")],
+    );
+    let plan_path = tmp.path().join("plan.json");
+
+    plan_then_apply(config_path, plan_path, "catalog_schema")
+        .await
+        .failure()
+        .code(7)
+        .stderr(predicates::str::contains("remote state changed"))
+        .stderr(predicates::str::contains("not in fresh plan").not())
+        .stderr(predicates::str::contains("not in saved plan").not());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_only_edit_between_plan_and_apply_still_applies() {
+    // The deliberate boundary of the v2 contract: the plan binds the
+    // *remote* preconditions, not the change set. A local edit that
+    // keeps the op shape is still applied. Guarantee B — binding the
+    // reviewed bytes to the written bytes — is a separate mechanism and
+    // is explicitly not claimed here.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content_blocks": [{"content_block_id": "id-promo", "name": "promo"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/info"))
+        .and(query_param("content_block_id", "id-promo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "promo", "content": "old body\n", "tags": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/content_blocks/update"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"message": "success"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_content_block(tmp.path(), "promo", "planned body\n");
+    let plan_path = tmp.path().join("plan.json");
+
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_for_diff = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_for_diff.to_str().unwrap()])
+            .args(["diff", "--resource", "content_block", &plan_out])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    // Edit locally after the plan was written; the remote is untouched.
+    write_local_content_block(tmp.path(), "promo", "edited after planning\n");
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "content_block",
+                "--confirm",
+                &plan_in,
+            ])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn v1_plan_file_is_rejected() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    let plan_path = tmp.path().join("plan.json");
+    // A v1 plan: correct scope, but its ops carry no evidence about the
+    // remote, so this binary cannot check it.
+    std::fs::write(
+        &plan_path,
+        serde_json::to_vec_pretty(&json!({
+            "version": 1,
+            "generated_at": "2026-05-18T00:00:00Z",
+            "braze_sync_version": "0.20.0",
+            "scope": {"environment": "test"},
+            "ops": [{"kind": "content_block", "name": "promo", "op": "modify"}]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--confirm", &plan_in])
+            .assert()
+            .failure()
+            // Version skew is a usage error, not plan drift: exit 1,
+            // deliberately distinct from the 7 that means "the world
+            // moved".
+            .code(1)
+            .stderr(predicates::str::contains("diff --plan-out"));
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn v2_plan_missing_a_required_digest_is_rejected_before_any_api_call() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    let plan_path = tmp.path().join("plan.json");
+    // A `modify` with no precondition must be rejected as malformed —
+    // never silently degraded to the pre-v2 shape-only comparison.
+    std::fs::write(
+        &plan_path,
+        serde_json::to_vec_pretty(&json!({
+            "version": 2,
+            "generated_at": "2026-05-18T00:00:00Z",
+            "braze_sync_version": env!("CARGO_PKG_VERSION"),
+            "scope": {"environment": "test"},
+            "ops": [{"kind": "content_block", "name": "promo", "op": "modify"}]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--confirm", &plan_in])
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(predicates::str::contains("malformed plan file"));
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn destructive_delete_with_changed_remote_exits_7() {
+    // A catalog slated for deletion whose remote schema gained a field
+    // between plan and apply. The op stays `destructive_delete`, so only
+    // the precondition can catch it.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"catalogs": [{
+                "name": "doomed",
+                "fields": [{"name": "id", "type": "string"}]
+            }]})),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"catalogs": [{
+            "name": "doomed",
+            "fields": [{"name": "id", "type": "string"}, {"name": "added_later", "type": "number"}]
+        }]})))
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    // No local schema at all → the remote catalog is a removal.
+    std::fs::create_dir_all(tmp.path().join("catalogs")).unwrap();
+    let plan_path = tmp.path().join("plan.json");
+
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_for_diff = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_for_diff.to_str().unwrap()])
+            .args(["diff", "--resource", "catalog_schema", &plan_out])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let saved: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&plan_path).unwrap()).unwrap();
+    assert_eq!(saved["ops"][0]["op"], "destructive_delete");
+    assert!(saved["ops"][0]["precondition"]["digest"].is_string());
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "catalog_schema",
+                "--confirm",
+                "--allow-destructive",
+                &plan_in,
+            ])
+            .assert()
+            .failure()
+            .code(7)
+            .stderr(predicates::str::contains("remote state changed"));
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn catalog_field_removal_is_planned_as_destructive_delete() {
+    // The op classification must describe what apply will actually do:
+    // dropping a field is a destructive write, even though the catalog
+    // itself is a `Modified` diff.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"catalogs": [{
+                "name": "products",
+                "fields": [{"name": "id", "type": "string"}, {"name": "legacy", "type": "number"}]
+            }]})),
+        )
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(tmp.path(), "products", &[("id", "string")]);
+    let plan_path = tmp.path().join("plan.json");
+
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "catalog_schema", &plan_out])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let saved: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&plan_path).unwrap()).unwrap();
+    assert_eq!(saved["ops"].as_array().unwrap().len(), 1);
+    assert_eq!(saved["ops"][0]["op"], "destructive_delete");
+    assert!(saved["ops"][0]["precondition"]["digest"].is_string());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replaying_a_plan_after_a_partial_catalog_apply_exits_7() {
+    // `report_partial_apply` tells the operator that re-running a
+    // plan-locked apply exits 7 if anything landed. For a catalog whose
+    // fields are written one call at a time that claim was previously
+    // false: the surviving ops kept the same shape. The remote
+    // precondition is what makes it true.
+    let server = MockServer::start().await;
+    // Plan + first apply see the bare catalog; after the first field
+    // lands, the remote carries it.
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"catalogs": [{
+                "name": "products",
+                "fields": [{"name": "id", "type": "string"}]
+            }]})),
+        )
+        .up_to_n_times(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"catalogs": [{
+                "name": "products",
+                "fields": [{"name": "id", "type": "string"}, {"name": "alpha", "type": "string"}]
+            }]})),
+        )
+        .mount(&server)
+        .await;
+    // First field add succeeds, every later one fails: a partial apply.
+    Mock::given(method("POST"))
+        .and(path("/catalogs/products/fields"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({"message": "success"})))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/catalogs/products/fields"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(
+        tmp.path(),
+        "products",
+        &[("id", "string"), ("alpha", "string"), ("beta", "string")],
+    );
+    let plan_path = tmp.path().join("plan.json");
+
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_for_diff = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_for_diff.to_str().unwrap()])
+            .args(["diff", "--resource", "catalog_schema", &plan_out])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    let config_for_first = config_path.clone();
+    let plan_for_first = plan_in.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_for_first.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "catalog_schema",
+                "--confirm",
+                &plan_for_first,
+            ])
+            .assert()
+            .failure();
+    })
+    .await
+    .unwrap();
+
+    // Replay the same plan. `alpha` landed, so the remote no longer
+    // matches the precondition even though `products` is still `modify`.
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "catalog_schema",
+                "--confirm",
+                &plan_in,
+            ])
+            .assert()
+            .failure()
+            .code(7)
+            .stderr(predicates::str::contains("remote state changed"));
     })
     .await
     .unwrap();


### PR DESCRIPTION
Fixes #100.

## 問題

`src/diff/plan.rs` の module doc は plan ファイルを「Terraform 式 plan/apply lock」——plan 生成後に live Braze state が drift していたら apply が拒否する——と宣言していた。しかし `check_plan_ops` が比較していたのは `{kind, name, op}` のマルチセットだけで、これはリモートについての証拠ではない。

op の**分類を変えない**リモート変更は不可視だった。既に `modify` 分類の content block が web console で編集されても、再計算でまた `modify` になるのでマルチセットは一致し、`✓ Plan matches saved plan` と表示したまま console の編集を無警告で上書きしていた。

## 対応方針

Fable 5.1 と Codex GPT-6 Astra の両方に諮り、当初案（保証 A と B を同一機構で取る）は**撤回**した。Astra が実コードから反例を示し、検証で裏付けられたため:

- content block の create は `state` を、catalog の create は `description` を送るが、diff は両方除外する。`None` vs `""`、tag 順序、対象 ID も wire では別物。**diff の同値比較用の projection で書き込みバイト列は束縛できない。**
- 一方、**A（リモート前提条件の検証）は独立して成立する契約**であり、B とは別機構を要する。

よって本 PR は A のみを実装し、B は別 issue に切り出している。

## 契約

> 保存 plan と操作形状が一致し、対象リソースの定義済みリモート観測値が plan 生成時と一致する場合に、現在のローカル意図を適用する。取得後の競合、未観測状態、レビュー内容の固定は保証しない。

## 変更点

- **`src/diff/digest.rs`（新規）** — 長さ prefix 付き・ドメイン分離した canonical projection を blake3 で digest 化。`Cargo.toml` に宣言済みで未使用だった `blake3` を使用。
- **不変条件 `digest(a) == digest(b) ⟺ syncable_eq(a, b)`** を各 diff モジュールのテストで固定。digest と diff が構造的に食い違えない。projection は insta snapshot で pin してあり、encoding を変えると CI が落ちる（bump 自体を強制はしない — snapshot を accept して version を据え置くことは可能なので、doc にそう明記した）。
- **`RemotePrecondition{Absent, Digest}`** を各 op に付与。`add`→absent（digest ではない）、`modify`/`destructive_delete`→リモート側の digest、`orphan`/`deprecate`/`reactivate`→なし（設計上該当なし）。
- **必須の precondition が欠けた plan は malformed として拒否**する。「digest が無ければ比較をスキップ」は実装しない — v2 が排除しようとしている失敗モードそのものだから。
- **ペアリングキーは `{kind, name, op}` のまま**（digest を key に入れない）。入れるとリモート drift が「別の op が増えた／消えた」と表示され原因が読めなくなる。不一致は第3のリストで「リモートが plan 生成後に変更された」と帰属を明示する（「ローカル編集」とは呼ばない）。
- **plan version 2、v1 は拒否**（migration なし）。メッセージは再生成だけでなく**再レビュー**が必要であることを言う — apply 直前の自動再生成はレビュー時点との対応を失うため。
- **catalog の field 削除を `destructive_delete` に修正。** field 削除は破壊的な書き込みだが `modify` と分類されていた。破壊判定が `diff_schema` の生成し得ない到達不能な `Unchanged` 枝にあったため。その死んだ枝を削除し、判定を到達可能な枝へ移した。`--allow-destructive` ゲート自体は元々正しく動いており、これは plan 上の語彙を揃える変更。
- `report_partial_apply` が既に印字していた「何か適用されたなら同じ plan の再実行は exit 7」は、catalog の複数 field write では**偽**だった（1つ成功しても残りが `modify` のままで形状が一致する）。from digest によって真になり、それを証明するテストを追加した。

## 保証しないこと

ドキュメントに明記した。取り繕わない:

- **並行制御ではない** — Braze REST API に `If-Match` / expected-state token が無く、check と write は非アトミック。
- **レビュー済み変更セットの凍結ではない** — リモートが不変なら、ローカル側の任意の変更は op 形状が同じ限り通る。
- **ID 差し替えは検出できない** — 同一内容・別リモート ID への置換は同じ digest に射影される。
- **catalog items は保護しない** — catalog 削除は items も消すが braze-sync は items を fetch しない。
- **`scope.environment` は workspace identity ではない** — 同名 environment の接続先変更は見えない。
- **digest は機密性ではない** — 予測可能な内容は推測・確認できる。
- `CatalogFieldType::Unknown` の collapse により、wire レベルの型名変更は検出できない。

## テスト

619 件すべて green、`clippy -D warnings` / `cargo fmt --check` クリーン。plan-lock の統合テストは 4 → 13 件:

- #100 の中核シナリオ（content block / email template / catalog、いずれも**分類不変でリモートのみ編集**）→ exit 7、write ゼロ。**stderr で「op 形状の drift ではなく precondition で落ちた」ことまで検証**している。
- `local_only_edit_between_plan_and_apply_still_applies` — 契約の境界（B ではない）を固定するネガティブテスト。
- 部分適用後の同一 plan 再実行 → exit 7。
- `destructive_delete` でリモート変更 → exit 7。
- v1 plan 拒否 / v2 で digest 欠落 → 拒否（いずれも exit code を pin）。
- 各型の projection ⟺ `syncable_eq` 同値性の単体テスト。

## Breaking

plan file version 2。v1 は拒否される（`diff --plan-out` で再生成し、新しい plan をレビューし直すこと）。

## /review-loop での修正

`/review-loop 102 --cross-review`（correctness / interfaces & compat / security & data / tests の4レンズ + Codex GPT-6 Astra のクロスベンダーレビュー）を回し、以下を追加コミットした。

**must-fix（1件）**
- `PlanFile::validate` が `RemotePrecondition::Digest` の**variant しか見ておらず** payload を検証していなかった。非 hex の digest を持つ plan（手編集・破損）が v2 ゲートを通過し、`describe()` の `&d[..d.len().min(12)]` が multi-byte 文字を割って panic → 文書化された exit 7 ではなく exit 101。本 PR が新設した経路そのもの。`validate` で 64 桁 lowercase hex を要求（API 呼び出し前に落ちる）し、`describe` も文字単位 truncate に変更。

**nit（適用済み）**
- `digest::catalog` が field pair の `Vec` を sort する一方 `diff_fields` は `BTreeMap` で同名フィールドを畳むため、diff が区別できない2つの catalog が別 digest になり得た。projection も同じく name でキーイング。**snapshot は不変**（wire encoding は動いていない）。
- 各 `digest_equivalence` に destructure によるコンパイル時ガードを追加。mutation リストは手書きなので、`syncable_eq` に足して projection に足し忘れた field を suite green のまま見逃す。
- `local_only_edit_between_plan_and_apply_still_applies` が「write が飛んだ」ことしか見ておらず、plan 時点の内容を書いた apply でも通っていた。body 照合を追加。
- malformed plan の stderr ヘッダが、precondition が「余分にある」分岐でも "missing" と言っていた。
- README / CHANGELOG / module contract の「Braze に write する全 op に digest を記録する」を訂正（`add` は absence、`deprecate` / `reactivate` は無し＝op 形状で担保）。local edit の記述に「op 形状が変わらない限り」を付記。plan file を無条件に「publish して安全」と言うのをやめた（unkeyed・encoding 公開なので推測の confirmation oracle にはなる）。

**won't-fix（理由付き）**
- CHANGELOG の `### Breaking` 見出し語彙 — このファイルには既に `### Changed (breaking)` / `### Migration / breaking notes` / `### Breaking changes` の3種が併存しており、統一はリポジトリ全体の別作業。
- Rust ライブラリ API の破壊（`PlanOp` の必須フィールド追加・`Ord`/`Hash` 喪失）を Breaking に明記 — 本プロジェクトが凍結対象として列挙しているのは CLI flags / config schema / file formats / JSON output / exit codes であり、lib API は意図的にその外。

**残る blind spot**
- 4レンズは**同一モデルの別視点**であり独立した複数レビュアではない。独立性があるのは Codex GPT-6 Astra の1本のみで、そちらは NO FINDINGS。
- このループは読むだけで**アプリを実行していない**（`cargo test` は回した）。実 Braze API に対する挙動は未検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plan-based applies now verify that remote resources have not changed since the plan was created.
  - Catalog field removals are represented as destructive deletions.
  - Plan files now include remote-state checks and require version 2.

- **Bug Fixes**
  - Prevents writes when plan operations or remote resources drift; exits with code 7.
  - Rejects malformed or outdated plan files before making API calls.

- **Documentation**
  - Clarified plan guarantees, drift behavior, regeneration requirements, and exit code 7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->