### PR TITLE
Record the Braze endpoint in the plan scope (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,16 @@ file formats, JSON output, exit codes) for the full v1.x line.
   the key — same endpoint, a different workspace — is still not
   detected: the plan records where it looked, not whose data it saw.
 
-  For the same reason, `api_endpoint` may no longer embed credentials.
-  `Url` serializes a `user:password@` prefix verbatim, so writing the
-  endpoint into the plan would have put it in the artifact; config load
-  now rejects such an endpoint (exit 3) rather than stripping it, which
-  would leave the plan disagreeing with the endpoint `apply` calls.
-  braze-sync has always authenticated with the API key from
-  `api_key_env`, so userinfo there was never meaningful.
+  For the same reason, `api_endpoint` must now be a bare host. `Url`
+  serializes a `user:password@` prefix, a query string and a fragment
+  all verbatim, so writing the endpoint into the plan would have put
+  any of them in the artifact — and since request building keeps the
+  query, `https://proxy.example/?access_token=…` is a working config
+  whose token would ship in every plan file. Config load now rejects
+  all three (exit 3) rather than stripping them, which would leave the
+  plan disagreeing with the endpoint `apply` calls. braze-sync has
+  always authenticated with the API key from `api_key_env`, so none of
+  them was ever meaningful here.
 
 - **`apply --plan` now checks the remote, not just the op shape (#100).**
   The plan file's own doc comment promised a Terraform-style plan/apply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ file formats, JSON output, exit codes) for the full v1.x line.
   the key — same endpoint, a different workspace — is still not
   detected: the plan records where it looked, not whose data it saw.
 
+  For the same reason, `api_endpoint` may no longer embed credentials.
+  `Url` serializes a `user:password@` prefix verbatim, so writing the
+  endpoint into the plan would have put it in the artifact; config load
+  now rejects such an endpoint (exit 3) rather than stripping it, which
+  would leave the plan disagreeing with the endpoint `apply` calls.
+  braze-sync has always authenticated with the API key from
+  `api_key_env`, so userinfo there was never meaningful.
+
 - **`apply --plan` now checks the remote, not just the op shape (#100).**
   The plan file's own doc comment promised a Terraform-style plan/apply
   lock — apply refuses to run when the live Braze state has drifted —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ### Changed
 
+- **The plan file now records the Braze endpoint it was generated
+  against (#106).** `scope.environment` is a name from the config, not
+  an identity: repointing that environment at a different Braze cluster
+  between `diff --plan-out` and `apply --plan` left the name matching
+  while every remote observation in the plan described a different
+  workspace's data. `scope` now carries `api_endpoint` as well, and
+  `apply` exits 7 before its first API call when the two disagree.
+
+  This settles the shape of plan **version 2**, which ships for the
+  first time in this release — the version number is unchanged, and a
+  v1 plan is still rejected with "regenerate with `diff --plan-out`".
+  That rejection is now decided by probing `version` before the rest of
+  the plan is parsed, so a format change can never turn a version-skew
+  message into a missing-field one.
+
+  The plan still records no API key or key digest, so it remains safe
+  to publish as a CI artifact. The consequence is that swapping only
+  the key — same endpoint, a different workspace — is still not
+  detected: the plan records where it looked, not whose data it saw.
+
 - **`apply --plan` now checks the remote, not just the op shape (#100).**
   The plan file's own doc comment promised a Terraform-style plan/apply
   lock — apply refuses to run when the live Braze state has drifted —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,16 +31,18 @@ file formats, JSON output, exit codes) for the full v1.x line.
   the key — same endpoint, a different workspace — is still not
   detected: the plan records where it looked, not whose data it saw.
 
-  For the same reason, `api_endpoint` must now be a bare host. `Url`
-  serializes a `user:password@` prefix, a query string and a fragment
-  all verbatim, so writing the endpoint into the plan would have put
-  any of them in the artifact — and since request building keeps the
+  For the same reason, `api_endpoint` may no longer carry userinfo, a
+  query string or a fragment. `Url` serializes all three verbatim, so
+  writing the endpoint into the plan would have put any of them in the
+  artifact — and since request building keeps the
   query, `https://proxy.example/?access_token=…` is a working config
   whose token would ship in every plan file. Config load now rejects
   all three (exit 3) rather than stripping them, which would leave the
   plan disagreeing with the endpoint `apply` calls. braze-sync has
   always authenticated with the API key from `api_key_env`, so none of
-  them was ever meaningful here.
+  them was ever meaningful here. A *path* is still accepted — request
+  building discards it — but it too is recorded in the plan verbatim,
+  so the endpoint is not the place to put anything secret.
 
 - **`apply --plan` now checks the remote, not just the op shape (#100).**
   The plan file's own doc comment promised a Terraform-style plan/apply

--- a/README.md
+++ b/README.md
@@ -204,6 +204,15 @@ exactly this:
 > Apply the *current* local intent, provided the remote preconditions
 > the plan recorded still hold.
 
+The plan also records which environment it was generated for **and the
+Braze endpoint that environment pointed at**; `apply --plan` checks both
+before its first API call. An environment name is a config label that can
+be repointed at another Braze cluster, and a plan's remote observations
+say nothing about a cluster it never talked to. What the plan does not
+record is the API key, so it stays safe to publish as a CI artifact —
+the cost is that swapping only the key, on the same endpoint, is not
+caught.
+
 It deliberately does **not** freeze the change set: editing a local file
 between plan and apply still applies, as long as the op shapes match.
 Nor is it concurrency control — Braze's REST API offers no `If-Match`,

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ across all v1.x releases.
 | `4` | Authentication failed (invalid API key) |
 | `5` | Rate limit retries exhausted |
 | `6` | Destructive change blocked (pass `--allow-destructive`) |
-| `7` | Plan/apply mismatch (`apply --plan`: op set differs, or the remote moved since the plan) |
+| `7` | Plan/apply mismatch (`apply --plan`: op set differs, the remote moved since the plan, or the plan's scope — environment or endpoint — no longer matches) |
 | `8` | Fallback gate (unmatched placeholder + unconsumed remote lid). Unlike `2`, `diff` has no opt-in flag for this — it always exits `8` when the gate fires; `apply` requires `--allow-fallback` |
 
 ## Output formats

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ Map of environment name → settings. Pick the active one with
 
 | Field | Type | Required | Notes |
 |:---|:---|:---|:---|
-| `api_endpoint` | URL | yes | Braze REST endpoint for your instance (see [Braze API endpoints](https://www.braze.com/docs/api/basics/#endpoints)). The scaffold defaults to the EU `fra-02` cluster — change it if your instance lives elsewhere. |
+| `api_endpoint` | URL | yes | Braze REST endpoint for your instance (see [Braze API endpoints](https://www.braze.com/docs/api/basics/#endpoints)). The scaffold defaults to the EU `fra-02` cluster — change it if your instance lives elsewhere. Must be a bare `http`/`https` host: a `user:password@` prefix, a query string, or a fragment is rejected at load (exit `3`), because `diff --plan-out` writes this URL verbatim into the plan file it publishes. |
 | `api_key_env` | string | yes | Name of the **environment variable** holding the API key. The key itself must never appear in this file. |
 
 API keys are loaded into `secrecy::SecretString` at startup and never

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ Map of environment name → settings. Pick the active one with
 
 | Field | Type | Required | Notes |
 |:---|:---|:---|:---|
-| `api_endpoint` | URL | yes | Braze REST endpoint for your instance (see [Braze API endpoints](https://www.braze.com/docs/api/basics/#endpoints)). The scaffold defaults to the EU `fra-02` cluster — change it if your instance lives elsewhere. Must be a bare `http`/`https` host: a `user:password@` prefix, a query string, or a fragment is rejected at load (exit `3`), because `diff --plan-out` writes this URL verbatim into the plan file it publishes. |
+| `api_endpoint` | URL | yes | Braze REST endpoint for your instance (see [Braze API endpoints](https://www.braze.com/docs/api/basics/#endpoints)). The scaffold defaults to the EU `fra-02` cluster — change it if your instance lives elsewhere. Must use `http`/`https`, and must not carry a `user:password@` prefix, a query string, or a fragment — each is rejected at load (exit `3`), because `diff --plan-out` writes this URL verbatim into the plan file it publishes. A path is accepted but discarded when requests are built; it is still recorded in the plan, so keep secrets out of the endpoint entirely. |
 | `api_key_env` | string | yes | Name of the **environment variable** holding the API key. The key itself must never appear in this file. |
 
 API keys are loaded into `secrecy::SecretString` at startup and never

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -29,6 +29,7 @@ use crate::values::{format_fallback_reports, gated_fallback_count, FallbackRepor
 use anyhow::{anyhow, Context as _};
 use clap::Args;
 use std::path::{Path, PathBuf};
+use url::Url;
 
 use super::diff::{
     compute_catalog_schema_diffs, compute_content_block_plan, compute_custom_attribute_diffs,
@@ -90,7 +91,12 @@ pub async fn run(
     let saved_plan = if let Some(path) = &args.plan {
         let plan = PlanFile::read_from(path)
             .with_context(|| format!("reading plan file {}", path.display()))?;
-        check_plan_scope(&plan, &resolved.environment_name, args)?;
+        check_plan_scope(
+            &plan,
+            &resolved.environment_name,
+            &resolved.api_endpoint,
+            args,
+        )?;
         warn_on_plan_metadata(&plan);
         Some(plan)
     } else {
@@ -579,17 +585,12 @@ fn enforce_tag_preflight(
 }
 
 /// Reject obvious plan-vs-CLI mismatches before doing any remote work.
-fn check_plan_scope(plan: &PlanFile, environment: &str, args: &ApplyArgs) -> anyhow::Result<()> {
-    if plan.version != plan::CURRENT_PLAN_VERSION {
-        return Err(anyhow!(
-            "plan file version {} is not supported by this binary \
-             (expected {}). Regenerate with `diff --plan-out` and review \
-             the new plan — an older plan carries no evidence this binary \
-             can check.",
-            plan.version,
-            plan::CURRENT_PLAN_VERSION,
-        ));
-    }
+fn check_plan_scope(
+    plan: &PlanFile,
+    environment: &str,
+    api_endpoint: &Url,
+    args: &ApplyArgs,
+) -> anyhow::Result<()> {
     if let Err(problems) = plan.validate() {
         eprintln!("✗ malformed plan file: ops carry the wrong remote preconditions");
         for problem in &problems {
@@ -604,6 +605,17 @@ fn check_plan_scope(plan: &PlanFile, environment: &str, args: &ApplyArgs) -> any
             "✗ plan drift: plan was generated for environment '{}' \
              but apply targets '{}'",
             plan.scope.environment, environment,
+        );
+        return Err(Error::PlanDrift.into());
+    }
+    // The environment *name* matching is not enough: the same name can be
+    // repointed at a different Braze cluster between plan and apply, and
+    // then the plan's remote observations describe someone else's data.
+    if plan.scope.api_endpoint != api_endpoint.to_string() {
+        eprintln!(
+            "✗ plan drift: plan was generated against Braze endpoint '{}' \
+             but apply targets '{}'",
+            plan.scope.api_endpoint, api_endpoint,
         );
         return Err(Error::PlanDrift.into());
     }

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -162,6 +162,7 @@ pub async fn run(
         let plan = PlanFile::from_summary(
             &summary,
             resolved.environment_name.clone(),
+            resolved.api_endpoint.to_string(),
             args.resource,
             args.name.clone(),
         );

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -135,8 +135,8 @@ impl ConfigFile {
                      — it is written verbatim into the plan file that \
                      `diff --plan-out` publishes, so a token there would be \
                      published with it. braze-sync reads its API key from the \
-                     '{}' environment variable; give api_endpoint as a bare \
-                     REST host.",
+                     '{}' environment variable; give api_endpoint as a plain \
+                     REST host without one.",
                     env.api_key_env,
                 )));
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -100,6 +100,19 @@ impl ConfigFile {
                     )));
                 }
             }
+            // Credentials in the endpoint are rejected, not stripped.
+            // braze-sync authenticates with the API key from
+            // `api_key_env`, so userinfo here is never meaningful — and
+            // `Url` serializes it verbatim into the `scope.api_endpoint`
+            // that `diff --plan-out` writes, which is a file meant to be
+            // publishable as a CI artifact. Stripping instead would make
+            // the plan disagree with the endpoint apply actually calls.
+            if !env.api_endpoint.username().is_empty() || env.api_endpoint.password().is_some() {
+                return Err(Error::Config(format!(
+                    "environment '{name}': api_endpoint must not embed credentials                      (found a username or password in the URL). braze-sync reads its                      API key from the '{}' environment variable; remove the                      'user:password@' prefix from the endpoint.",
+                    env.api_key_env,
+                )));
+            }
         }
         // Compile every resource's exclude_patterns at load time so
         // malformed regexes fail fast instead of at first use.
@@ -421,6 +434,52 @@ environments:
         let msg = err.to_string();
         assert!(msg.contains("http"), "expected http scheme hint: {msg}");
         assert!(msg.contains("ftp"), "expected actual scheme: {msg}");
+    }
+
+    #[test]
+    fn rejects_endpoint_embedding_credentials() {
+        // `Url` serializes userinfo verbatim, and `diff --plan-out`
+        // writes the endpoint into a plan file meant to be publishable
+        // as a CI artifact. Config load is the place to stop it.
+        for endpoint in [
+            "https://apiuser:s3cret@rest.braze.eu",
+            "https://apiuser@rest.braze.eu",
+        ] {
+            let yaml = format!(
+                r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: {endpoint}
+    api_key_env: BRAZE_DEV_API_KEY
+"#
+            );
+            let f = write_config(&yaml);
+            let err = ConfigFile::load(f.path()).unwrap_err();
+            assert!(matches!(err, Error::Config(_)), "endpoint: {endpoint}");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("must not embed credentials"),
+                "endpoint {endpoint}: {msg}"
+            );
+            // The error must not echo the secret back into logs or CI output.
+            assert!(!msg.contains("s3cret"), "error leaked the password: {msg}");
+        }
+    }
+
+    #[test]
+    fn accepts_endpoint_without_credentials() {
+        let yaml = r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_DEV_API_KEY
+"#;
+        let f = write_config(yaml);
+        assert!(ConfigFile::load(f.path()).is_ok());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -109,7 +109,34 @@ impl ConfigFile {
             // the plan disagree with the endpoint apply actually calls.
             if !env.api_endpoint.username().is_empty() || env.api_endpoint.password().is_some() {
                 return Err(Error::Config(format!(
-                    "environment '{name}': api_endpoint must not embed credentials                      (found a username or password in the URL). braze-sync reads its                      API key from the '{}' environment variable; remove the                      'user:password@' prefix from the endpoint.",
+                    "environment '{name}': api_endpoint must not embed credentials \
+                     (found a username or password in the URL). braze-sync reads its \
+                     API key from the '{}' environment variable; remove the \
+                     'user:password@' prefix from the endpoint.",
+                    env.api_key_env,
+                )));
+            }
+            // Same reasoning, same artifact: `Url` serializes the query
+            // and fragment verbatim too, and `url_for` keeps the query on
+            // every request — so `https://proxy.example/?access_token=…`
+            // is a *working* config today, and its token would be
+            // published in every plan file. Neither part addresses a Braze
+            // REST endpoint, so rejecting them costs nothing real.
+            // The message never echoes the value back into logs.
+            let leaked = match (env.api_endpoint.query(), env.api_endpoint.fragment()) {
+                (Some(_), Some(_)) => Some("a query string and a fragment"),
+                (Some(_), None) => Some("a query string"),
+                (None, Some(_)) => Some("a fragment"),
+                (None, None) => None,
+            };
+            if let Some(found) = leaked {
+                return Err(Error::Config(format!(
+                    "environment '{name}': api_endpoint must not carry {found} \
+                     — it is written verbatim into the plan file that \
+                     `diff --plan-out` publishes, so a token there would be \
+                     published with it. braze-sync reads its API key from the \
+                     '{}' environment variable; give api_endpoint as a bare \
+                     REST host.",
                     env.api_key_env,
                 )));
             }
@@ -465,6 +492,56 @@ environments:
             );
             // The error must not echo the secret back into logs or CI output.
             assert!(!msg.contains("s3cret"), "error leaked the password: {msg}");
+            // A multi-line literal that lost its `\` continuations renders
+            // with runs of indentation inside the sentence. `contains` alone
+            // passes over that, so pin the whitespace too.
+            assert!(
+                !msg.contains("  "),
+                "message has collapsed indentation: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_endpoint_with_query_or_fragment() {
+        // Userinfo is not the only URL component `Url` serializes into
+        // the plan: `url_for` keeps the query on every request, so a
+        // proxy token in `?access_token=` is a *working* config whose
+        // secret would be published with every plan file.
+        for (endpoint, want) in [
+            (
+                "https://proxy.example/?access_token=s3cret",
+                "a query string",
+            ),
+            ("https://rest.braze.eu/#s3cret", "a fragment"),
+            (
+                "https://proxy.example/?access_token=s3cret#f",
+                "a query string and a fragment",
+            ),
+        ] {
+            let yaml = format!(
+                r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: {endpoint}
+    api_key_env: BRAZE_DEV_API_KEY
+"#
+            );
+            let f = write_config(&yaml);
+            let err = ConfigFile::load(f.path()).unwrap_err();
+            assert!(matches!(err, Error::Config(_)), "endpoint: {endpoint}");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(&format!("must not carry {want}")),
+                "endpoint {endpoint}: {msg}"
+            );
+            assert!(!msg.contains("s3cret"), "error leaked the token: {msg}");
+            assert!(
+                !msg.contains("  "),
+                "message has collapsed indentation: {msg}"
+            );
         }
     }
 

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -35,9 +35,13 @@
 //! - **It does not cover catalog items.** Deleting a catalog deletes its
 //!   items, which braze-sync never fetches; the schema digest says
 //!   nothing about rows added since the plan.
-//! - **`scope.environment` is a config name, not a workspace identity.**
-//!   Repointing an environment at a different Braze workspace is not
-//!   visible here.
+//! - **`scope` pins the cluster, not the workspace.** `scope.environment`
+//!   is a config label and `scope.api_endpoint` the REST host `diff`
+//!   talked to; both are checked at apply time, so repointing an
+//!   environment at a *different* Braze cluster is now caught. Swapping
+//!   only the API key — same endpoint, different workspace — is not: the
+//!   key is deliberately absent from the plan so it stays publishable as
+//!   a CI artifact, and the plan therefore records no workspace identity.
 //! - **A digest is not confidentiality.** Predictable content can be
 //!   guessed and confirmed. It is small enough to publish as a CI
 //!   artifact, which is why the plan carries digests rather than payloads.
@@ -70,6 +74,12 @@ pub struct PlanFile {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanScope {
     pub environment: String,
+    /// The Braze API endpoint `diff` actually talked to, as
+    /// [`url::Url`] normalized it. Required: an environment *name* is a
+    /// config label that can be repointed at a different Braze cluster
+    /// between plan and apply, so the name alone is not evidence about
+    /// where the plan's observations came from.
+    pub api_endpoint: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource: Option<ResourceKind>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -189,6 +199,7 @@ impl PlanFile {
     pub fn from_summary(
         summary: &DiffSummary,
         environment: impl Into<String>,
+        api_endpoint: impl Into<String>,
         resource: Option<ResourceKind>,
         name: Option<String>,
     ) -> Self {
@@ -198,6 +209,7 @@ impl PlanFile {
             braze_sync_version: env!("CARGO_PKG_VERSION").to_string(),
             scope: PlanScope {
                 environment: environment.into(),
+                api_endpoint: api_endpoint.into(),
                 resource,
                 name,
             },
@@ -205,10 +217,37 @@ impl PlanFile {
         }
     }
 
+    /// Read a plan, gating the schema parse on `version`.
+    ///
+    /// The version is probed on its own first so a plan from an older
+    /// format fails with "regenerate", not with whichever field this
+    /// binary's schema happens to have gained since. Every other field
+    /// is then required: a plan that cannot be fully parsed carries no
+    /// evidence this binary can check.
     pub fn read_from(path: &Path) -> std::io::Result<Self> {
         let bytes = std::fs::read(path)?;
-        serde_json::from_slice(&bytes)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        let invalid =
+            |e: serde_json::Error| std::io::Error::new(std::io::ErrorKind::InvalidData, e);
+
+        #[derive(Deserialize)]
+        struct VersionProbe {
+            version: u32,
+        }
+        let probe: VersionProbe = serde_json::from_slice(&bytes).map_err(invalid)?;
+        if probe.version != CURRENT_PLAN_VERSION {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "plan file version {} is not supported by this binary \
+                     (expected {}). Regenerate with `diff --plan-out` and review \
+                     the new plan — an older plan carries no evidence this binary \
+                     can check.",
+                    probe.version, CURRENT_PLAN_VERSION,
+                ),
+            ));
+        }
+
+        serde_json::from_slice(&bytes).map_err(invalid)
     }
 
     pub fn write_to(&self, path: &Path) -> std::io::Result<()> {
@@ -492,6 +531,7 @@ mod tests {
             braze_sync_version: "test".into(),
             scope: PlanScope {
                 environment: "dev".into(),
+                api_endpoint: "https://rest.iad-01.braze.com/".into(),
                 resource: None,
                 name: None,
             },
@@ -557,6 +597,7 @@ mod tests {
             braze_sync_version: "0.12.0".into(),
             scope: PlanScope {
                 environment: "dev".into(),
+                api_endpoint: "https://rest.iad-01.braze.com/".into(),
                 resource: Some(ResourceKind::ContentBlock),
                 name: None,
             },

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -280,7 +280,12 @@ async fn apply_plan_endpoint_mismatch_exits_7_before_api_call() {
     // check did not fire first, apply would fail on a connection error,
     // not on exit 7.
     let repointed = write_config(tmp.path(), "http://127.0.0.1:1");
-    assert_eq!(repointed, config_path);
+    // `write_config` returns a path built from `dir` alone, so comparing
+    // paths would hold whether or not the rewrite landed. Read the file
+    // back instead — the repoint is this test's entire premise.
+    assert!(std::fs::read_to_string(&repointed)
+        .unwrap()
+        .contains("http://127.0.0.1:1"));
 
     let plan_in = format!("--plan={}", plan_path.display());
     tokio::task::spawn_blocking(move || {
@@ -292,7 +297,8 @@ async fn apply_plan_endpoint_mismatch_exits_7_before_api_call() {
             .assert()
             .failure()
             .code(7)
-            .stderr(predicates::str::contains("Braze endpoint"));
+            .stderr(predicates::str::contains("Braze endpoint"))
+            .stderr(predicates::str::contains("http://127.0.0.1:1"));
     })
     .await
     .unwrap();
@@ -627,7 +633,17 @@ async fn v1_plan_file_is_rejected() {
             // deliberately distinct from the 7 that means "the world
             // moved".
             .code(1)
-            .stderr(predicates::str::contains("diff --plan-out"));
+            // Name the version explicitly. The malformed-plan branch of
+            // `check_plan_scope` also exits 1 and also says "regenerate
+            // with `diff --plan-out`", and this fixture's op carries no
+            // precondition — so it would satisfy a looser assertion even
+            // if the version probe stopped running first, which is the
+            // one thing this test exists to prove.
+            .stderr(predicates::str::contains(
+                "plan file version 1 is not supported",
+            ))
+            .stderr(predicates::str::contains("diff --plan-out"))
+            .stderr(predicates::str::contains("malformed plan file").not());
     })
     .await
     .unwrap();

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -54,6 +54,9 @@ async fn diff_plan_out_writes_plan_file() {
     let plan: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(plan["version"], 2);
     assert_eq!(plan["scope"]["environment"], "test");
+    // Recorded as `Url` normalizes it — mock server URIs carry no
+    // trailing slash, the parsed form does.
+    assert_eq!(plan["scope"]["api_endpoint"], format!("{}/", server.uri()));
     assert_eq!(plan["scope"]["resource"], "catalog_schema");
     let ops = plan["ops"].as_array().unwrap();
     assert_eq!(ops.len(), 1);
@@ -220,7 +223,7 @@ async fn apply_plan_environment_mismatch_exits_7_before_api_call() {
         "version": 2,
         "generated_at": "2026-05-18T00:00:00Z",
         "braze_sync_version": env!("CARGO_PKG_VERSION"),
-        "scope": {"environment": "prod"},
+        "scope": {"environment": "prod", "api_endpoint": format!("{}/", server.uri())},
         "ops": []
     });
     std::fs::write(&plan_path, serde_json::to_vec_pretty(&plan_json).unwrap()).unwrap();
@@ -235,6 +238,61 @@ async fn apply_plan_environment_mismatch_exits_7_before_api_call() {
             .assert()
             .failure()
             .code(7);
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_plan_endpoint_mismatch_exits_7_before_api_call() {
+    // Issue #106: the environment *name* is a config label, not a
+    // workspace identity. Here the name matches on both sides and only
+    // the endpoint moved — a name-only scope check would wave this
+    // through and apply the plan's observations to a different cluster.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"catalogs": []})))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(tmp.path(), "newcat", &[("id", "string")]);
+    let plan_path = tmp.path().join("plan.json");
+
+    let plan_arg = format!("--plan-out={}", plan_path.display());
+    let cfg = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", cfg.to_str().unwrap()])
+            .args(["diff", "--resource", "catalog_schema", &plan_arg])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    // Repoint environment `test` at a dead endpoint, leaving the name
+    // untouched. A dead address is the sharper assertion: if the scope
+    // check did not fire first, apply would fail on a connection error,
+    // not on exit 7.
+    let repointed = write_config(tmp.path(), "http://127.0.0.1:1");
+    assert_eq!(repointed, config_path);
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--confirm", &plan_in])
+            .assert()
+            .failure()
+            .code(7)
+            .stderr(predicates::str::contains("Braze endpoint"));
     })
     .await
     .unwrap();
@@ -546,6 +604,9 @@ async fn v1_plan_file_is_rejected() {
             "version": 1,
             "generated_at": "2026-05-18T00:00:00Z",
             "braze_sync_version": "0.20.0",
+            // No `api_endpoint`: a real v1 plan predates the field. The
+            // version probe must reject it before the schema parse can
+            // complain about a missing field.
             "scope": {"environment": "test"},
             "ops": [{"kind": "content_block", "name": "promo", "op": "modify"}]
         }))
@@ -592,7 +653,7 @@ async fn v2_plan_missing_a_required_digest_is_rejected_before_any_api_call() {
             "version": 2,
             "generated_at": "2026-05-18T00:00:00Z",
             "braze_sync_version": env!("CARGO_PKG_VERSION"),
-            "scope": {"environment": "test"},
+            "scope": {"environment": "test", "api_endpoint": format!("{}/", server.uri())},
             "ops": [{"kind": "content_block", "name": "promo", "op": "modify"}]
         }))
         .unwrap(),


### PR DESCRIPTION
Refs #106.

## Problem

`scope.environment` is a name from the config file, not an identity. If an
environment is repointed at a different Braze cluster between
`diff --plan-out` and `apply --plan`, the name still matches — while every
remote observation the plan recorded describes a different workspace's
data. The plan lock waves it through.

## Change

`PlanScope` now carries `api_endpoint` as `url::Url` normalizes it, and
`check_plan_scope` compares it, so `apply` exits 7 before its first API
call when plan and config disagree.

The field is **required — no `serde(default)`**. A plan that omits it
carries no evidence about where its observations came from, and silently
accepting one would reinstate exactly the failure mode #100 closed.

### The version gate had to move

Making the field required broke the v1 rejection path: `read_from` would
fail with serde's `missing field api_endpoint` *before* `check_plan_scope`
ran, so the "plan version 1 is not supported, regenerate" message became
unreachable for v1 — the only format actually released.

`read_from` now probes `version` on its own before parsing the schema. A
v1 plan fails with "regenerate with `diff --plan-out`" rather than with
whichever field this binary's schema has since gained. The
now-unreachable version branch in `check_plan_scope` is deleted.

### Plan version stays 2

v2 is merged (#102) but **unreleased**, so this settles its shape rather
than superseding it. Bumping to v3 here would create compatibility logic
rejecting a v2 plan that never shipped.

## Scope of the guarantee

The plan records **no API key or key digest**, so it stays publishable as
a CI artifact. The cost, stated in the module doc, README and CHANGELOG:
swapping only the key — same endpoint, different workspace — is still not
caught. That is why this is `Refs`, not `Closes`: the endpoint solves the
cluster half of #106, and the whoami-endpoint investigation stays open
there.

## Tests

New `apply_plan_endpoint_mismatch_exits_7_before_api_call`: generates a
plan against the mock server, then repoints environment `test` at a
**dead** address, leaving the name untouched. A dead endpoint is the
sharper assertion — if the scope check did not fire first, apply would
fail on a connection error rather than exit 7.

`v1_plan_file_is_rejected` keeps its plan with `api_endpoint` genuinely
absent, which is what proves the version probe runs before the schema
parse.

624 tests pass (+4), clippy and fmt clean.

## /review-loop での修正

このPRに対して `/review-loop 107 --cross-review` を実行し、以下を追加で修正した（コミット `9103e61`, `c9eee52`, `d33d778`）。上の本文は作者の記述で、この節だけがループの追記。

**must-fix（修正済み）**

- **`api_endpoint` の query / fragment も拒否** — userinfo を塞いだのは `Url` が verbatim に直列化する URL 成分の一つだけだった。`BrazeClient::url_for` はパスだけを消して query は毎リクエストに残すので `https://proxy.example/?access_token=…` は*今も動く*設定であり、そのトークンが `scope.api_endpoint` としてすべての plan file に載る。userinfo と同じ理由で load 時に拒否（exit 3）し、メッセージは見つかった成分の名前だけを出して値は出さない。security & data レンズと cross-vendor（gpt-6-astra）レンズが独立に指摘。
- **`v1_plan_file_is_rejected` が版チェックを証明していなかった** — `check_plan_scope` の malformed 分岐も exit 1 で同じ "regenerate with `diff --plan-out`" を出し、このフィクスチャの op は precondition を持たないので `validate()` にも引っかかる。つまり版プローブが先に走らなくてもテストは通った。版番号を名指しし、malformed メッセージが出ないことも表明するようにした。

**nit（修正済み）**

- userinfo エラーメッセージの `\` 継続が失われ、文中に22スペースの塊が3箇所入ったまま出力されていた。継続を復元し、両メッセージのテストに「二重スペースを含まないこと」を追加（`contains` だけでは素通りする）。
- `assert_eq!(repointed, config_path)` は `write_config` が `dir` だけからパスを組むため必ず成立する。ファイル内容を読み直す形に変更。mismatch の stderr 表明も、実際に向け先となったアドレスを名指しするようにした。
- 上記の文面が `api_endpoint` を「bare host であること」と書いていたが、path は今も受理される（`url_for` が捨てるため拒否すると既存設定が無駄に壊れる）。拒否する3成分を名指しし、path は plan には載る旨を明記した。
- README の exit code 表の `7` は原因を2つしか挙げていなかった（scope 不一致が3つ目。これはこのPR以前からの記述）。docs/configuration.md の `api_endpoint` 行に load 時制約を追記。

**won't-fix（理由つき）**

- `check_plan_scope` の不一致メッセージは plan 側の endpoint をそのまま出す。ただし plan にシークレットが載る経路は config load 側で塞いだので、残るのは「手で編集した plan file の中に既にシークレットがある」場合のみで、echo を伏せても回収できない。
- endpoint 比較は完全な文字列一致。`url_for` がパスを捨てるため、パスだけを変えた設定変更は実質同じクラスタなのに exit 7 になる。方向は保守的（別ホストは必ず文字列として異なる）で、設定は実際に変わっているため許容。

**残る blind spot**: このループは読むだけで、アプリを実バックエンドに対して動かしていない（`cargo test` 624 件は通過、clippy / fmt clean）。4レンズはいずれも同一モデルの別視点であり、独立したレビュアーではない。cross-vendor レンズ（gpt-6-astra）のみ別ベンダー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plan files now record the Braze API endpoint alongside the environment.
  - `apply --plan` detects endpoint changes and exits with code 7 before making API calls.

- **Bug Fixes**
  - Incompatible plan versions are identified before detailed parsing, producing a clear regeneration message instead of unrelated validation errors.

- **Documentation**
  - Documented endpoint validation and clarified that changing only the API key is not detected.
  - Plan format version 2 is now documented; version 1 plans remain rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->