### PR TITLE
Expire a plan with `apply --max-plan-age` (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ file formats, JSON output, exit codes) for the full v1.x line.
   running `apply` is tolerated; past that the plan's age cannot be
   established, and a generous `--max-plan-age` does not launder it.
 
+  Note what the expiry rests on: `generated_at` is the only plan field
+  `apply` consults that nothing outside the file corroborates, so the
+  flag bounds elapsed time rather than defending against a tampered
+  artifact. Documented in the README and in `src/diff/plan.rs`'s "what
+  this does not promise" list.
+
 ### Changed
 
 - **The plan file now records the Braze endpoint it was generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ## [Unreleased]
 
+### Added
+
+- **`apply --max-plan-age <DURATION>` expires a plan (#104).** A plan
+  older than 24 hours has always printed a warning and then applied
+  anyway. Pass `--max-plan-age 1h30m` (any human-readable duration) and
+  `apply` instead exits **9** before its first API call, so an expired
+  approval costs neither a write nor a read. The check runs once at
+  startup rather than per write — expiring mid-run would abandon the
+  apply half-finished, which is exactly the state the
+  applied/failed/not-attempted report exists to avoid.
+
+  This is a new **exit code 9**, not a reuse of 7. Elapsed time is not
+  by itself evidence that the remote moved, so folding it into plan
+  drift would make CI unable to tell "the approval expired" from "the
+  world changed". Exit codes freeze at v1.0; this is added inside that
+  window deliberately.
+
+  The flag requires `--plan` and is opt-in: without it the 24-hour
+  warning is unchanged, so existing pipelines keep working.
+
+  A `generated_at` in the *future* is rejected the same way, as the
+  other edge of one validity window (`generated_at - 5min <= now <=
+  generated_at + max_age`) rather than as a separate policy. Five
+  minutes of clock skew between the machine that ran `diff` and the one
+  running `apply` is tolerated; past that the plan's age cannot be
+  established, and a generous `--max-plan-age` does not launder it.
+
 ### Changed
 
 - **The plan file now records the Braze endpoint it was generated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "dotenvy",
  "fastrand",
  "futures",
+ "humantime",
  "indicatif",
  "insta",
  "predicates",
@@ -736,6 +737,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ path = "src/lib.rs"
 [dependencies]
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
+# Human-readable durations for `apply --max-plan-age` (e.g. `1h30m`).
+humantime = "2"
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "time", "sync", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -259,6 +259,19 @@ between the machine that ran `diff` and the one running `apply`; beyond
 that the plan's age cannot be established at all, and a generous
 `--max-plan-age` does not launder it.
 
+One caveat worth stating plainly, because this flag is the first check
+that rests on it: `generated_at` is written into the plan by `diff`, and
+it is the only field `apply` consults that nothing outside the file
+corroborates. The plan version is checked against the binary, the scope
+against your resolved config and endpoint, the op set against a freshly
+computed diff, and every remote precondition against a fresh fetch — so
+editing those is caught. Editing `generated_at` is not. Whoever can
+write the plan artifact between `diff --plan-out` and `apply --plan` can
+reset it to now and replay an approval of any age. `--max-plan-age`
+bounds elapsed time; it is not a defence against a tampered artifact, so
+keep the artifact store write-restricted the way you would any other
+build output that authorises a production write.
+
 ## Limitations
 
 These will be lifted across the v0.x → v1.0 milestones:

--- a/README.md
+++ b/README.md
@@ -233,6 +233,32 @@ API keys never live in the config file. The config only references the
 held in `secrecy::SecretString` from the moment it leaves the OS so
 that `tracing` / `Debug` / panic messages cannot leak it.
 
+### Expiring an approval (`--max-plan-age`)
+
+A plan is only a snapshot of what `diff` saw. By default a plan older
+than 24 hours prints a warning and applies anyway; pass
+`apply --max-plan-age <DURATION>` to make that fail-closed instead:
+
+```bash
+braze-sync apply --confirm --plan plan.json --max-plan-age 1h30m
+```
+
+The duration is human-readable (`30m`, `2h`, `1h30m`, `7d`). Outside the
+window `apply` exits **9** before its first API call, so nothing is
+written and nothing is even read. It is checked once, at startup — not
+per write, which would abandon a run half-applied.
+
+This is an expiry on the *approval*, not another drift check: elapsed
+time is not by itself evidence that the remote moved, which is why it
+gets its own exit code rather than folding into **7**. The flag requires
+`--plan` and is opt-in, so existing pipelines are unaffected.
+
+A `generated_at` in the future is rejected the same way — it is the other
+edge of the same window. Up to 5 minutes ahead is tolerated as clock skew
+between the machine that ran `diff` and the one running `apply`; beyond
+that the plan's age cannot be established at all, and a generous
+`--max-plan-age` does not launder it.
+
 ## Limitations
 
 These will be lifted across the v0.x → v1.0 milestones:
@@ -285,6 +311,7 @@ across all v1.x releases.
 | `6` | Destructive change blocked (pass `--allow-destructive`) |
 | `7` | Plan/apply mismatch (`apply --plan`: op set differs, the remote moved since the plan, or the plan's scope — environment or endpoint — no longer matches) |
 | `8` | Fallback gate (unmatched placeholder + unconsumed remote lid). Unlike `2`, `diff` has no opt-in flag for this — it always exits `8` when the gate fires; `apply` requires `--allow-fallback` |
+| `9` | Plan outside its validity window (`apply --max-plan-age`: the plan is older than the limit, or its `generated_at` is too far in the future) |
 
 ## Output formats
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -60,6 +60,7 @@ Exit-code contract:
 | `4` | API key is invalid | Fail & page the operator |
 | `5` | Rate limit retries exhausted | Retry the job |
 | `6` | Destructive change blocked (see `apply --allow-destructive`) | Fail the build / block merge |
+| `7` | Plan/apply mismatch (`apply --plan`): the op set differs, the remote moved since the plan, or the plan's scope — environment or endpoint — no longer matches | Fail the build; regenerate the plan and re-review |
 | `8` | Fallback gate: unmatched placeholder + unconsumed remote lid value (see `apply --allow-fallback`). Unlike code `2`, this fires unconditionally — plain `diff` has no opt-in flag for it | Fail the build / block merge |
 | `9` | Plan outside its validity window (`apply --max-plan-age`) — the approval expired, or the plan's `generated_at` is too far in the future | Regenerate the plan and re-approve; do not retry the same plan |
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -61,6 +61,7 @@ Exit-code contract:
 | `5` | Rate limit retries exhausted | Retry the job |
 | `6` | Destructive change blocked (see `apply --allow-destructive`) | Fail the build / block merge |
 | `8` | Fallback gate: unmatched placeholder + unconsumed remote lid value (see `apply --allow-fallback`). Unlike code `2`, this fires unconditionally — plain `diff` has no opt-in flag for it | Fail the build / block merge |
+| `9` | Plan outside its validity window (`apply --max-plan-age`) — the approval expired, or the plan's `generated_at` is too far in the future | Regenerate the plan and re-approve; do not retry the same plan |
 
 ## Apply on merge
 

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -29,6 +29,7 @@ use crate::values::{format_fallback_reports, gated_fallback_count, FallbackRepor
 use anyhow::{anyhow, Context as _};
 use clap::Args;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use url::Url;
 
 use super::diff::{
@@ -71,6 +72,19 @@ pub struct ApplyArgs {
     /// code 7 on mismatch.
     #[arg(long, value_name = "PATH")]
     pub plan: Option<PathBuf>,
+
+    /// Treat the plan as an approval that expires: refuse to apply, before
+    /// any Braze API call, once the plan is older than this. Accepts
+    /// human-readable durations (`30m`, `2h`, `1h30m`, `7d`). Exits with
+    /// code 9. Without this flag an old plan only warns.
+    #[arg(long, value_name = "DURATION", requires = "plan", value_parser = parse_max_plan_age)]
+    pub max_plan_age: Option<Duration>,
+}
+
+/// Parse `--max-plan-age`. `0` is accepted: "regenerate the plan now" is
+/// a coherent policy, not a mistake.
+fn parse_max_plan_age(raw: &str) -> Result<Duration, String> {
+    humantime::parse_duration(raw).map_err(|e| format!("invalid duration {raw:?}: {e}"))
 }
 
 pub async fn run(
@@ -97,7 +111,7 @@ pub async fn run(
             &resolved.api_endpoint,
             args,
         )?;
-        warn_on_plan_metadata(&plan);
+        check_plan_metadata(&plan, args)?;
         Some(plan)
     } else {
         None
@@ -637,7 +651,15 @@ fn check_plan_scope(
     Ok(())
 }
 
-fn warn_on_plan_metadata(plan: &PlanFile) {
+/// Warn on a version mismatch, then check the plan's age once, here,
+/// before any Braze API call — so a
+/// rejected plan costs zero writes. Deliberately not re-checked per
+/// write: expiring mid-apply would leave a partial apply, which
+/// contradicts the applied/failed/not-attempted report.
+///
+/// With `--max-plan-age` this is fail-closed; without it, staleness stays
+/// the pre-existing warning.
+fn check_plan_metadata(plan: &PlanFile, args: &ApplyArgs) -> anyhow::Result<()> {
     let current = env!("CARGO_PKG_VERSION");
     if plan.braze_sync_version != current {
         eprintln!(
@@ -646,14 +668,28 @@ fn warn_on_plan_metadata(plan: &PlanFile) {
             plan.braze_sync_version, current,
         );
     }
-    let age = chrono::Utc::now().signed_duration_since(plan.generated_at);
+
+    let now = chrono::Utc::now();
+    if let Some(max_age) = args.max_plan_age {
+        let max_age = chrono::TimeDelta::from_std(max_age)
+            .map_err(|_| Error::Config(format!("--max-plan-age {max_age:?} is out of range")))?;
+        if let Err(outside) = plan::check_validity_window(plan.generated_at, now, max_age) {
+            eprintln!("✗ plan outside its validity window: {outside}");
+            eprintln!("  regenerate it with `diff --plan-out`.");
+            return Err(Error::PlanOutsideValidityWindow.into());
+        }
+        return Ok(());
+    }
+
+    let age = now.signed_duration_since(plan.generated_at);
     if age > plan::STALE_PLAN_WARN_THRESHOLD {
         eprintln!(
             "⚠ plan is {} hour(s) old — Braze may have drifted; consider \
-             regenerating with `diff --plan-out`.",
+             regenerating with `diff --plan-out` or enforcing `--max-plan-age`.",
             age.num_hours(),
         );
     }
+    Ok(())
 }
 
 /// Compare the saved plan against the freshly-computed summary: first the

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -287,6 +287,7 @@ fn exit_code_for(err: &anyhow::Error) -> i32 {
                 Error::Api(_) => {}
                 Error::DestructiveBlocked => return 6,
                 Error::PlanDrift => return 7,
+                Error::PlanOutsideValidityWindow => return 9,
                 Error::DriftDetected { .. } => return 2,
                 Error::Config(_) | Error::MissingEnv(_) => return 3,
                 Error::RateLimitExhausted { .. } => return 5,
@@ -449,6 +450,14 @@ mod tests {
     fn exit_code_for_destructive_blocked() {
         let err = anyhow::Error::new(Error::DestructiveBlocked);
         assert_eq!(exit_code_for(&err), 6);
+    }
+
+    #[test]
+    fn exit_code_for_plan_outside_validity_window() {
+        // Deliberately not 7: elapsed time is not evidence the remote
+        // moved, so CI can tell an expired approval apart from drift.
+        let err = anyhow::Error::new(Error::PlanOutsideValidityWindow);
+        assert_eq!(exit_code_for(&err), 9);
     }
 
     #[test]

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -48,6 +48,17 @@
 //!   plan as an approval with an expiry — a separate policy with its own
 //!   exit code, deliberately not part of the evidence above. See
 //!   [`check_validity_window`].
+//! - **The expiry trusts the plan's own clock.** `generated_at` is the
+//!   only field `apply` consults that nothing outside the file
+//!   corroborates: `version` is checked against
+//!   [`CURRENT_PLAN_VERSION`], `scope` against the resolved config and
+//!   endpoint, `ops` against a freshly computed diff, and each
+//!   `precondition` against a fresh remote fetch — so editing any of
+//!   those is caught. Editing `generated_at` is not. Anyone who can
+//!   write the artifact between `diff --plan-out` and `apply --plan`
+//!   can reset it to now and replay an approval of any age.
+//!   `--max-plan-age` bounds *elapsed time*, not a tampered file; it is
+//!   not a substitute for controlling who can write the artifact.
 //! - **A digest is not confidentiality.** Predictable content can be
 //!   guessed and confirmed. It is small enough to publish as a CI
 //!   artifact, which is why the plan carries digests rather than payloads.
@@ -80,7 +91,7 @@ pub const PLAN_CLOCK_SKEW_TOLERANCE: chrono::TimeDelta = chrono::TimeDelta::minu
 /// carries its own exit code.
 #[derive(Debug, thiserror::Error)]
 pub enum OutsideValidityWindow {
-    #[error("generated {} ago, but --max-plan-age is {}", fmt_delta(*age), fmt_delta(*max_age))]
+    #[error("generated {} ago, but --max-plan-age is {}", fmt_measured(*age), fmt_limit(*max_age))]
     Expired {
         age: chrono::TimeDelta,
         max_age: chrono::TimeDelta,
@@ -88,16 +99,32 @@ pub enum OutsideValidityWindow {
     #[error(
         "generated_at is {} in the future (tolerance {}) — check the clock on \
          the machine that ran `diff`",
-        fmt_delta(*ahead),
-        fmt_delta(PLAN_CLOCK_SKEW_TOLERANCE)
+        fmt_measured(*ahead),
+        fmt_limit(PLAN_CLOCK_SKEW_TOLERANCE)
     )]
     AheadOfClock { ahead: chrono::TimeDelta },
 }
 
-/// Render a `TimeDelta` the way `--max-plan-age` is written (`1h 30m`).
-/// Sub-second precision is noise here, so it is dropped.
-fn fmt_delta(d: chrono::TimeDelta) -> String {
+/// Render a configured *limit* the way `--max-plan-age` is written
+/// (`1h 30m`). Limits come from a human-typed flag or a constant, so
+/// truncating sub-second precision only ever restates what was asked for.
+fn fmt_limit(d: chrono::TimeDelta) -> String {
     let secs = d.num_seconds().unsigned_abs();
+    humantime::format_duration(std::time::Duration::from_secs(secs)).to_string()
+}
+
+/// Render a *measured* duration, rounding up to the next whole second.
+///
+/// Truncating here would print a falsehood at the boundary: a plan
+/// 3600.4s old rejected against `--max-plan-age 1h` rendered as
+/// "generated 1h ago, but --max-plan-age is 1h", two equal values
+/// offered as a rejection — and under the supported `--max-plan-age 0`
+/// *every* rejection read "generated 0s ago, but --max-plan-age is 0s".
+/// Rounding the measured side up keeps it strictly greater than the
+/// limit it exceeded, which is the whole claim the message makes.
+fn fmt_measured(d: chrono::TimeDelta) -> String {
+    let millis = d.num_milliseconds().unsigned_abs();
+    let secs = millis / 1000 + u64::from(millis % 1000 != 0);
     humantime::format_duration(std::time::Duration::from_secs(secs)).to_string()
 }
 
@@ -647,6 +674,71 @@ mod tests {
             TimeDelta::days(365),
         )
         .is_err());
+    }
+
+    #[test]
+    fn validity_window_accepts_generated_at_exactly_at_skew_tolerance() {
+        // The mirror of `validity_window_accepts_a_plan_exactly_at_max_age`
+        // for the lower edge: `age < -TOLERANCE` rejects, so exactly
+        // `PLAN_CLOCK_SKEW_TOLERANCE` ahead is still inside the window.
+        // Without this, flipping `<` to `<=` would ship undetected.
+        assert!(check_validity_window(
+            at("2026-09-07T00:05:00Z"),
+            at("2026-09-07T00:00:00Z"),
+            TimeDelta::hours(1),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn a_measured_duration_is_rounded_up_so_it_never_equals_the_limit() {
+        // A plan 3600.4s old against `--max-plan-age 1h` must not render
+        // as "generated 1h ago, but --max-plan-age is 1h" — two equal
+        // values offered as a rejection.
+        let err = check_validity_window(
+            at("2026-09-07T00:00:00Z"),
+            at("2026-09-07T01:00:00.400Z"),
+            TimeDelta::hours(1),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "generated 1h 1s ago, but --max-plan-age is 1h"
+        );
+    }
+
+    #[test]
+    fn zero_max_age_still_reports_a_nonzero_age() {
+        // `--max-plan-age 0` is supported, so its rejection message is
+        // the common case, not an edge: it must not read "generated 0s
+        // ago, but --max-plan-age is 0s".
+        let err = check_validity_window(
+            at("2026-09-07T00:00:00Z"),
+            at("2026-09-07T00:00:00.400Z"),
+            TimeDelta::zero(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "generated 1s ago, but --max-plan-age is 0s"
+        );
+    }
+
+    #[test]
+    fn ahead_of_clock_reports_the_measured_lead_and_the_configured_tolerance() {
+        // Pins `fmt_measured` / `fmt_limit` on the other edge too: the
+        // lead rounds up, the tolerance restates the constant verbatim.
+        let err = check_validity_window(
+            at("2026-09-07T00:06:00.400Z"),
+            at("2026-09-07T00:00:00Z"),
+            TimeDelta::hours(1),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "generated_at is 6m 1s in the future (tolerance 5m) — check the \
+             clock on the machine that ran `diff`"
+        );
     }
 
     use super::*;

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -42,6 +42,12 @@
 //!   only the API key — same endpoint, different workspace — is not: the
 //!   key is deliberately absent from the plan so it stays publishable as
 //!   a CI artifact, and the plan therefore records no workspace identity.
+//! - **It does not expire on its own.** A plan carries `generated_at`,
+//!   but age is not evidence that the remote moved, so staleness is only
+//!   a warning by default. `apply --max-plan-age` opts into treating the
+//!   plan as an approval with an expiry — a separate policy with its own
+//!   exit code, deliberately not part of the evidence above. See
+//!   [`check_validity_window`].
 //! - **A digest is not confidentiality.** Predictable content can be
 //!   guessed and confirmed. It is small enough to publish as a CI
 //!   artifact, which is why the plan carries digests rather than payloads.
@@ -61,6 +67,65 @@ pub const CURRENT_PLAN_VERSION: u32 = 2;
 
 /// Warn at apply time when the saved plan is older than this.
 pub const STALE_PLAN_WARN_THRESHOLD: chrono::TimeDelta = chrono::TimeDelta::hours(24);
+
+/// How far a plan's `generated_at` may sit in the future before apply
+/// treats it as a broken clock rather than tolerable skew between the
+/// machine that ran `diff` and the one running `apply`.
+pub const PLAN_CLOCK_SKEW_TOLERANCE: chrono::TimeDelta = chrono::TimeDelta::minutes(5);
+
+/// Why a plan fell outside the validity window `--max-plan-age` defines.
+///
+/// Not a form of plan drift: elapsed time is not evidence that the
+/// remote moved. This is the expiry of an *approval*, which is why it
+/// carries its own exit code.
+#[derive(Debug, thiserror::Error)]
+pub enum OutsideValidityWindow {
+    #[error("generated {} ago, but --max-plan-age is {}", fmt_delta(*age), fmt_delta(*max_age))]
+    Expired {
+        age: chrono::TimeDelta,
+        max_age: chrono::TimeDelta,
+    },
+    #[error(
+        "generated_at is {} in the future (tolerance {}) — check the clock on \
+         the machine that ran `diff`",
+        fmt_delta(*ahead),
+        fmt_delta(PLAN_CLOCK_SKEW_TOLERANCE)
+    )]
+    AheadOfClock { ahead: chrono::TimeDelta },
+}
+
+/// Render a `TimeDelta` the way `--max-plan-age` is written (`1h 30m`).
+/// Sub-second precision is noise here, so it is dropped.
+fn fmt_delta(d: chrono::TimeDelta) -> String {
+    let secs = d.num_seconds().unsigned_abs();
+    humantime::format_duration(std::time::Duration::from_secs(secs)).to_string()
+}
+
+/// Check `generated_at` against the validity window that `--max-plan-age`
+/// defines: `generated_at - PLAN_CLOCK_SKEW_TOLERANCE <= now <=
+/// generated_at + max_age`.
+///
+/// One window, both edges. A future `generated_at` is not a separate
+/// policy — it is the lower edge, and it is rejected for the same reason
+/// the upper edge is: the plan's age cannot be established, so there is
+/// no evidence the approval is still current.
+///
+/// Only reachable when the caller passed `--max-plan-age`; without it
+/// staleness stays a warning (see [`STALE_PLAN_WARN_THRESHOLD`]).
+pub fn check_validity_window(
+    generated_at: DateTime<Utc>,
+    now: DateTime<Utc>,
+    max_age: chrono::TimeDelta,
+) -> Result<(), OutsideValidityWindow> {
+    let age = now.signed_duration_since(generated_at);
+    if age < -PLAN_CLOCK_SKEW_TOLERANCE {
+        return Err(OutsideValidityWindow::AheadOfClock { ahead: -age });
+    }
+    if age > max_age {
+        return Err(OutsideValidityWindow::Expired { age, max_age });
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanFile {
@@ -494,6 +559,96 @@ fn classify_orphanable<T>(
 
 #[cfg(test)]
 mod tests {
+    use chrono::TimeDelta;
+
+    fn at(s: &str) -> DateTime<Utc> {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn validity_window_accepts_a_plan_inside_max_age() {
+        assert!(check_validity_window(
+            at("2026-09-07T00:00:00Z"),
+            at("2026-09-07T00:59:00Z"),
+            TimeDelta::hours(1),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validity_window_accepts_a_plan_exactly_at_max_age() {
+        // The bound is inclusive: `age > max_age` rejects, so a plan
+        // that is exactly `max_age` old is still inside the window.
+        assert!(check_validity_window(
+            at("2026-09-07T00:00:00Z"),
+            at("2026-09-07T01:00:00Z"),
+            TimeDelta::hours(1),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validity_window_rejects_a_plan_past_max_age() {
+        let err = check_validity_window(
+            at("2026-09-07T00:00:00Z"),
+            at("2026-09-07T01:00:01Z"),
+            TimeDelta::hours(1),
+        )
+        .unwrap_err();
+        assert!(matches!(err, OutsideValidityWindow::Expired { .. }));
+        assert!(err.to_string().contains("--max-plan-age"));
+    }
+
+    #[test]
+    fn zero_max_age_rejects_any_elapsed_time() {
+        // `--max-plan-age 0` is a coherent policy: regenerate now.
+        assert!(check_validity_window(
+            at("2026-09-07T00:00:00Z"),
+            at("2026-09-07T00:00:01Z"),
+            TimeDelta::zero(),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validity_window_tolerates_future_generated_at_within_skew() {
+        // A CI runner a few minutes ahead of the applying machine must
+        // not fail the build.
+        assert!(check_validity_window(
+            at("2026-09-07T00:04:00Z"),
+            at("2026-09-07T00:00:00Z"),
+            TimeDelta::hours(1),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validity_window_rejects_future_generated_at_beyond_skew() {
+        // Past the tolerance the age cannot be established at all, so
+        // there is no evidence the approval is current — same rejection
+        // as expiry, not a warning.
+        let err = check_validity_window(
+            at("2026-09-07T00:06:00Z"),
+            at("2026-09-07T00:00:00Z"),
+            TimeDelta::hours(1),
+        )
+        .unwrap_err();
+        assert!(matches!(err, OutsideValidityWindow::AheadOfClock { .. }));
+        assert!(err.to_string().contains("clock"));
+    }
+
+    #[test]
+    fn a_future_plan_is_rejected_even_when_max_age_is_generous() {
+        // The lower edge does not move with `max_age`: a huge window
+        // must not launder a broken clock.
+        assert!(check_validity_window(
+            at("2026-09-07T01:00:00Z"),
+            at("2026-09-07T00:00:00Z"),
+            TimeDelta::days(365),
+        )
+        .is_err());
+    }
+
     use super::*;
     use crate::diff::catalog::CatalogSchemaDiff;
     use crate::diff::content_block::ContentBlockDiff;

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,15 @@ pub enum Error {
     #[error("Plan drift: saved plan does not match the freshly-computed plan")]
     PlanDrift,
 
+    /// The plan's `generated_at` falls outside the validity window that
+    /// `--max-plan-age` defines. Distinct from [`Error::PlanDrift`]: age
+    /// is not itself evidence that the remote moved, so CI can tell
+    /// "the approval expired" apart from "the world changed". Which edge
+    /// of the window was crossed is printed at the call site, as for
+    /// [`Error::PlanDrift`].
+    #[error("Plan outside its validity window: --max-plan-age was exceeded")]
+    PlanOutsideValidityWindow,
+
     #[error("Rate limit exhausted after {retries} retries")]
     RateLimitExhausted { retries: u32 },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,12 @@ pub enum Error {
     /// "the approval expired" apart from "the world changed". Which edge
     /// of the window was crossed is printed at the call site, as for
     /// [`Error::PlanDrift`].
-    #[error("Plan outside its validity window: --max-plan-age was exceeded")]
+    ///
+    /// The text names the *window*, not one of its edges: a plan whose
+    /// `generated_at` is in the future crosses the lower edge without
+    /// exceeding `--max-plan-age` at all, so saying it was exceeded
+    /// would contradict the call-site line printed just above it.
+    #[error("Plan outside its validity window (`--max-plan-age`)")]
     PlanOutsideValidityWindow,
 
     #[error("Rate limit exhausted after {retries} retries")]

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -282,7 +282,14 @@ async fn apply_plan_past_max_plan_age_exits_9_before_any_api_call() {
             .assert()
             .failure()
             .code(9)
-            .stderr(predicates::str::contains("validity window"));
+            // Discriminate the branch: both edges of the window print
+            // the same "validity window" prefix and both exit 9, so a
+            // substring test on the prefix alone would stay green if the
+            // call site returned the other variant — or if this fixture
+            // were read on a host whose clock predates it, which turns
+            // the plan into a *future* one and silently tests the edge
+            // this test is not named for.
+            .stderr(predicates::str::contains("ago, but --max-plan-age is 1h"));
     })
     .await
     .unwrap();
@@ -325,7 +332,14 @@ async fn apply_plan_generated_in_the_future_exits_9() {
             .assert()
             .failure()
             .code(9)
-            .stderr(predicates::str::contains("clock"));
+            .stderr(predicates::str::contains("in the future"))
+            // The top-level `error:` line is the one a log aggregator
+            // keeps, and it must not claim the 365d limit was exceeded
+            // when this rejection is the clock-skew edge.
+            .stderr(predicates::str::contains(
+                "Plan outside its validity window (`--max-plan-age`)",
+            ))
+            .stderr(predicates::str::contains("--max-plan-age was exceeded").not());
     })
     .await
     .unwrap();
@@ -490,6 +504,118 @@ async fn max_plan_age_rejects_an_unparseable_duration() {
             .assert()
             .failure()
             .code(3);
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn max_plan_age_out_of_chrono_range_is_a_clean_config_error() {
+    // `humantime` happily parses a duration that `chrono::TimeDelta`
+    // cannot hold, so `TimeDelta::from_std` fails on user input. It must
+    // stay a clean exit 3 — rewriting that `map_err` as an `expect`
+    // would turn a typo into a panic and a stack trace.
+    let server = MockServer::start().await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    let plan_path = tmp.path().join("plan.json");
+    // A *valid* plan: unlike an unparseable duration, this one clears
+    // clap and the plan is read before the range check is reached.
+    let plan_json = serde_json::json!({
+        "version": 2,
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "braze_sync_version": env!("CARGO_PKG_VERSION"),
+        "scope": {"environment": "test", "api_endpoint": format!("{}/", server.uri())},
+        "ops": []
+    });
+    std::fs::write(&plan_path, serde_json::to_vec_pretty(&plan_json).unwrap()).unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--confirm",
+                &plan_in,
+                "--max-plan-age",
+                "300000000y",
+            ])
+            .assert()
+            .failure()
+            .code(3)
+            .stderr(predicates::str::contains("out of range"));
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn max_plan_age_replaces_the_staleness_warning_rather_than_adding_to_it() {
+    // The early return in `check_plan_metadata` is a deliberate design
+    // decision — a window the operator set IS the staleness policy, so
+    // the 24-hour warning is not also printed inside it. Nothing pinned
+    // that in either direction, so deleting the `return Ok(())` (making
+    // an old-but-in-window plan warn again) passed the whole suite.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"catalogs": []})))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({"message": "success"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(tmp.path(), "newcat", &[("id", "string")]);
+    let plan_path = tmp.path().join("plan.json");
+
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_for_diff = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_for_diff.to_str().unwrap()])
+            .args(["diff", "--resource", "catalog_schema", &plan_out])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    // 25 hours old: past the warn threshold, inside a 48h window.
+    let mut plan: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&plan_path).unwrap()).unwrap();
+    let generated = chrono::Utc::now() - chrono::TimeDelta::hours(25);
+    plan["generated_at"] = serde_json::json!(generated.to_rfc3339());
+    std::fs::write(&plan_path, serde_json::to_vec_pretty(&plan).unwrap()).unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "catalog_schema",
+                "--confirm",
+                &plan_in,
+                "--max-plan-age",
+                "48h",
+            ])
+            .assert()
+            .success()
+            .stderr(predicates::str::contains("hour(s) old").not());
     })
     .await
     .unwrap();

--- a/tests/cli_plan_lock.rs
+++ b/tests/cli_plan_lock.rs
@@ -244,6 +244,258 @@ async fn apply_plan_environment_mismatch_exits_7_before_api_call() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_plan_past_max_plan_age_exits_9_before_any_api_call() {
+    // Issue #104. Every verb is mocked to fail and expected zero times:
+    // an expired approval must cost no API call at all, not just no
+    // write.
+    let server = MockServer::start().await;
+    for verb in ["GET", "POST", "PUT", "DELETE"] {
+        Mock::given(method(verb))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    let plan_path = tmp.path().join("plan.json");
+
+    // Scope matches on every axis — age is the only thing wrong, so a
+    // pass here can only come from the age check.
+    let plan_json = serde_json::json!({
+        "version": 2,
+        "generated_at": "2026-05-18T00:00:00Z",
+        "braze_sync_version": env!("CARGO_PKG_VERSION"),
+        "scope": {"environment": "test", "api_endpoint": format!("{}/", server.uri())},
+        "ops": []
+    });
+    std::fs::write(&plan_path, serde_json::to_vec_pretty(&plan_json).unwrap()).unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--confirm", &plan_in, "--max-plan-age", "1h"])
+            .assert()
+            .failure()
+            .code(9)
+            .stderr(predicates::str::contains("validity window"));
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_plan_generated_in_the_future_exits_9() {
+    // Clock skew past the tolerance: the same window, its lower edge.
+    let server = MockServer::start().await;
+    for verb in ["GET", "POST", "PUT", "DELETE"] {
+        Mock::given(method(verb))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    let plan_path = tmp.path().join("plan.json");
+
+    let future = chrono::Utc::now() + chrono::TimeDelta::hours(1);
+    let plan_json = serde_json::json!({
+        "version": 2,
+        "generated_at": future.to_rfc3339(),
+        "braze_sync_version": env!("CARGO_PKG_VERSION"),
+        "scope": {"environment": "test", "api_endpoint": format!("{}/", server.uri())},
+        "ops": []
+    });
+    std::fs::write(&plan_path, serde_json::to_vec_pretty(&plan_json).unwrap()).unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            // A generous window must not launder a broken clock.
+            .args(["apply", "--confirm", &plan_in, "--max-plan-age", "365d"])
+            .assert()
+            .failure()
+            .code(9)
+            .stderr(predicates::str::contains("clock"));
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_without_max_plan_age_still_only_warns_on_an_old_plan() {
+    // The default is unchanged: `--max-plan-age` is opt-in, so a plan
+    // old enough to exit 9 with the flag still applies without it.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"catalogs": []})))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({"message": "success"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(tmp.path(), "newcat", &[("id", "string")]);
+    let plan_path = tmp.path().join("plan.json");
+
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_for_diff = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_for_diff.to_str().unwrap()])
+            .args(["diff", "--resource", "catalog_schema", &plan_out])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    // Backdate a real, matching plan so age is the only thing off.
+    let mut plan: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&plan_path).unwrap()).unwrap();
+    plan["generated_at"] = serde_json::json!("2026-05-18T00:00:00Z");
+    std::fs::write(&plan_path, serde_json::to_vec_pretty(&plan).unwrap()).unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "catalog_schema",
+                "--confirm",
+                &plan_in,
+            ])
+            .assert()
+            .success()
+            .stderr(predicates::str::contains("hour(s) old"));
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_within_max_plan_age_proceeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"catalogs": []})))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/catalogs"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({"message": "success"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_schema(tmp.path(), "newcat", &[("id", "string")]);
+    let plan_path = tmp.path().join("plan.json");
+
+    let plan_out = format!("--plan-out={}", plan_path.display());
+    let config_for_diff = config_path.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_for_diff.to_str().unwrap()])
+            .args(["diff", "--resource", "catalog_schema", &plan_out])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "apply",
+                "--resource",
+                "catalog_schema",
+                "--confirm",
+                &plan_in,
+                "--max-plan-age",
+                "1h30m",
+            ])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn max_plan_age_without_a_plan_is_a_config_error() {
+    // The flag is an expiry on a specific approval; with no plan there
+    // is nothing to expire, so silently ignoring it would be a trap.
+    let server = MockServer::start().await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--confirm", "--max-plan-age", "1h"])
+            .assert()
+            .failure()
+            .code(3);
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn max_plan_age_rejects_an_unparseable_duration() {
+    let server = MockServer::start().await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    let plan_path = tmp.path().join("plan.json");
+    std::fs::write(&plan_path, "{}").unwrap();
+
+    let plan_in = format!("--plan={}", plan_path.display());
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["apply", "--confirm", &plan_in, "--max-plan-age", "soon"])
+            .assert()
+            .failure()
+            .code(3);
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn apply_plan_endpoint_mismatch_exits_7_before_api_call() {
     // Issue #106: the environment *name* is a config label, not a
     // workspace identity. Here the name matches on both sides and only


### PR DESCRIPTION
Closes #104.

`STALE_PLAN_WARN_THRESHOLD` (24h) printed a warning and then applied
anyway — the tool concluded the plan might be stale and used it.
`apply --max-plan-age <DURATION>` makes that fail-closed instead.

## What it does

```bash
braze-sync apply --confirm --plan plan.json --max-plan-age 1h30m
```

Outside the window `apply` exits **9** before its first Braze API call,
so an expired approval costs neither a write nor a read. Durations are
human-readable (`30m`, `2h`, `1h30m`, `7d`) via `humantime`.

## The four decisions in the issue

- **Default**: opt-in. Without the flag the 24-hour warning is
  unchanged, so existing pipelines keep working. The flag `requires`
  `--plan`.
- **Exit code**: a new variant → **9**, not a reuse of 7. Elapsed time
  is not by itself evidence that the remote moved, so folding it into
  plan drift would leave CI unable to tell "the approval expired" from
  "the world changed" — and would make the README's description of 7
  untrue. Exit codes freeze at v1.0; this is added inside that window
  deliberately.
- **When it is checked**: once, at startup, right after the scope check
  and before any API call. Not per write — expiring mid-apply would
  abandon the run half-applied, which is the state the
  applied/failed/not-attempted report (#96/#97) exists to prevent.
- **Future `generated_at`**: rejected, as the other edge of *one*
  validity window rather than a separate policy:

  ```
  generated_at - 5min  ≤  now  ≤  generated_at + max_age
  ```

  Five minutes of clock skew between the machine that ran `diff` and the
  one running `apply` is tolerated; past that the plan's age cannot be
  established at all, and a generous `--max-plan-age` does not launder
  it. One window means one error variant and one exit code.

## Notes

- This is an expiry on the **approval**, deliberately kept out of the
  plan lock's evidence chain (digests, preconditions) — the distinction
  Codex raised on #100 and recorded in the issue. `src/diff/plan.rs`'s
  "what this does not promise" list says so explicitly.
- `humantime` is a new dependency: MIT/Apache-2.0, zero deps, MSRV 1.60
  (project MSRV is 1.86). `cargo deny check` passes.
- `--max-plan-age 0` is accepted — "regenerate now" is a coherent
  policy.
- #105 (`write_to` atomicity) is left to a separate PR.

## Verification

- 644 tests pass (was 624; +14 in the original change, +6 more from the
  review pass below), `cargo clippy --all-targets -D warnings` and
  `cargo fmt --check` clean, `cargo deny check` ok.
- The two rejection tests mock GET/POST/PUT/DELETE with `.expect(0)`, so
  they fail if *any* API call fires — not just a write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## /review-loop での修正

4レンズ + cross-vendor (Codex gpt-6-astra) のレビューを回した結果。コードの
判定ロジック（いつ弾くか）に欠陥はなく、修正はすべて「弾いたときに何を伝えるか」
と、その前提の明示。

**fixed (must-fix)**

- `Error::PlanOutsideValidityWindow` の Display が `--max-plan-age was
  exceeded` と断定していた。同じ variant は未来 `generated_at`（下端）でも
  返るため、`--max-plan-age 365d` の時計ずれ拒否で最終 `error:` 行が直上の
  call-site 行と矛盾していた。エッジ名ではなくウィンドウ名を出す。
- `fmt_delta` の秒切り捨てにより、3600.4 秒古い plan を `1h` で弾くと
  `generated 1h ago, but --max-plan-age is 1h` と同値を並べて拒否していた。
  サポート済みの `--max-plan-age 0` では**毎回**
  `generated 0s ago, but --max-plan-age is 0s` になる。`fmt_measured`
  （実測値・切り上げ）と `fmt_limit`（設定値・切り捨て）に分割。
- README が本フラグを fail-closed として説明する一方、`generated_at` が
  「apply が参照する plan フィールドのうち、ファイル外の何とも突き合わされない
  唯一のもの」である点に触れていなかった（version→バイナリ定数、scope→解決済み
  config、ops→再計算 diff、precondition→再取得リモート、に対し generated_at は
  ローカル時計のみ）。artifact を書ける者は値を現在時刻に書き換えて任意の古い
  承認をリプレイできる。README / plan.rs の "what this does not promise" /
  CHANGELOG に明記。

**fixed (nit)**

- `docs/integration.md` の CI exit-code 表に `9` を追加。表を読んだ際に `7`
  も欠けていた（#100 由来の既存欠落）ことが判明したため、オーナー判断のうえ
  そちらも 1 行追加。
- テスト: 2つのフォーマッタは完全に未固定（アサーションは format 文字列の
  リテラルにしか一致していなかった）、下端の境界値（ちょうど 5 分）は上端と
  違い未テスト、`TimeDelta::from_std` 範囲外は未到達、警告抑制の設計判断は
  両方向とも未固定だった。いずれの修正を戻しても新テストが落ちることを確認済み。

**won't-fix**

- `--max-plan-age` 指定時に 24時間警告が出ない件は仕様どおり（3箇所に明記）。
  ただし未固定だったのでテストで固定した。

**refuted**

- 3レンズが揃って「`humantime` は裸の `0` を拒否するので doc コメントが嘘」と
  報告したが、実機で反証。`parse_duration` は `duration.rs:364` で `"0"` を
  短絡しており、3レンズとも辿った `Parser` に到達しない。`--max-plan-age 0`
  は exit 9（ウィンドウ判定）に到達する。

**残る blind spot**

- レンズ4本は同一モデルの別視点であり、独立した複数レビュアーではない
  （上記 refuted はその相関の実例）。cross-vendor の gpt-6-astra のみ別系統で、
  0 findings。
- 実アプリの実行検証はこのループの範囲外（`--max-plan-age` 経路は手動 CLI 再現
  で確認済み、Braze 実 API は未接続）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `apply --max-plan-age <DURATION>` setting to enforce plan validity before any API calls.
  - Expired or excessively future-dated plans now fail with exit code 9 when the setting is enabled.
  - Valid plans continue to apply normally; without the setting, existing staleness warnings remain unchanged.
  - The option requires a plan and supports human-readable durations.

- **Documentation**
  - Documented plan validity enforcement and the new exit code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->