### PR TITLE
Write the plan file atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,16 +145,35 @@ file formats, JSON output, exit codes) for the full v1.x line.
   artifact, and a job that dies while writing one should not take the
   previous one with it.
 
+  "Atomic" is a claim about visibility, not durability. The plan's own
+  bytes are flushed before the rename, but the directory entry the
+  rename creates is not, so a machine that loses power just after a
+  successful `diff --plan-out` can come back holding the previous plan.
+  That is still "the previous plan or no plan"; it is called out because
+  the success message does not distinguish the two.
+
   The temporary file is a sibling of the destination because `rename`
   across filesystems fails with `EXDEV`. A run killed in the window
   between creating it and the rename leaves that sibling behind — it is
-  never read as a plan, but a job collecting `plan*` as an artifact will
-  pick it up.
+  never read as a plan, but nothing reaps it either, so repeated
+  cancellations accumulate one file each, and a job collecting `plan*`
+  as an artifact will pick them all up.
 
-  Two other consequences of writing a new file rather than rewriting one
-  in place: the plan takes the mode a newly created file gets instead of
-  inheriting the mode of a plan already at that path, and a symlink at
-  that path is replaced by the plan rather than written through.
+  **`--plan-out` now asks more of its destination.** Writing a new file
+  rather than rewriting one in place means the *parent directory* must
+  be writable: a read-only directory holding a writable `plan.json` used
+  to work and now fails with `Permission denied`. For the same reason
+  the destination must be an ordinary file — `--plan-out /dev/null`,
+  `--plan-out /dev/stdout`, a FIFO, or a bind-mounted file all worked
+  before and now fail (as root, replacing a device node rather than
+  writing through it) — and its name needs ~29 bytes of headroom under
+  the filesystem's `NAME_MAX` for the temporary suffix.
+
+  Two further consequences: the plan takes the mode a newly created file
+  gets instead of inheriting the mode of a plan already at that path —
+  which can *loosen* one that had been chmod'd to `0o600` — and a
+  symlink at that path is replaced by the plan rather than written
+  through, so a symlinked artifact path silently stops being updated.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,11 +163,15 @@ file formats, JSON output, exit codes) for the full v1.x line.
   rather than rewriting one in place means the *parent directory* must
   be writable: a read-only directory holding a writable `plan.json` used
   to work and now fails with `Permission denied`. For the same reason
-  the destination must be an ordinary file — `--plan-out /dev/null`,
-  `--plan-out /dev/stdout`, a FIFO, or a bind-mounted file all worked
-  before and now fail (as root, replacing a device node rather than
-  writing through it) — and its name needs ~29 bytes of headroom under
-  the filesystem's `NAME_MAX` for the temporary suffix.
+  the destination must be an ordinary file. `--plan-out /dev/null`,
+  `--plan-out /dev/stdout`, a FIFO and a bind-mounted file all worked
+  before; unprivileged, they now fail with `Permission denied`. **As
+  root the failure is worse than an error:** `/dev` is writable, so the
+  temp file is created and the rename *replaces the device node or
+  symlink with a regular file*, and every later writer to `/dev/null` on
+  that box appends to it instead. Finally, the destination's name needs
+  ~29 bytes of headroom under the filesystem's `NAME_MAX` for the
+  temporary suffix.
 
   Two further consequences: the plan takes the mode a newly created file
   gets instead of inheriting the mode of a plan already at that path —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,34 @@ file formats, JSON output, exit codes) for the full v1.x line.
   the check moved to the reachable one. The `--allow-destructive` gate
   itself was already correct; this aligns the plan's vocabulary with it.
 
+### Fixed
+
+- **`diff --plan-out` writes the plan atomically (#105).** The plan was
+  serialized and then handed straight to a single `write`, so a run
+  killed mid-write left a truncated plan on disk — and, when the path
+  already held a plan, destroyed the previous one on the way. The bytes
+  now go to a sibling temporary file which is flushed and then `rename`d
+  into place, so an interrupted run leaves either the previous plan or
+  no plan.
+
+  This was never a correctness hole in `apply`: a truncated plan fails
+  `read_from`'s JSON parse and is rejected as `InvalidData`, so a half
+  written plan could not be applied as if it were whole. What it cost
+  was the older, still-valid plan and a clear failure — the plan is a CI
+  artifact, and a job that dies while writing one should not take the
+  previous one with it.
+
+  The temporary file is a sibling of the destination because `rename`
+  across filesystems fails with `EXDEV`. A run killed in the window
+  between creating it and the rename leaves that sibling behind — it is
+  never read as a plan, but a job collecting `plan*` as an artifact will
+  pick it up.
+
+  Two other consequences of writing a new file rather than rewriting one
+  in place: the plan takes the mode a newly created file gets instead of
+  inheriting the mode of a plan already at that path, and a symlink at
+  that path is replaced by the plan rather than written through.
+
 ### Breaking
 
 - **Plan file version 2; version 1 files are rejected.** A v1 plan

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,11 @@ anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
-# Jitter for 429 backoff. Tiny, zero-dep PRNG — the Braze client is the
-# only caller and only needs U(0, N) for jitter.
+# Tiny, zero-dep PRNG. Two callers, neither needing a CSPRNG: jitter for
+# the Braze client's 429 backoff, and the suffix on the temp file
+# `diff --plan-out` renames into place (`src/diff/plan.rs`). The latter
+# only has to miss a leftover sibling from a crashed run — `create_new`,
+# not the entropy, is what makes a collision safe.
 fastrand = "2"
 
 # File system

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -352,15 +352,31 @@ impl PlanFile {
     /// or no plan, never a half-written one. The temporary file has to be
     /// a *sibling*: `rename` across filesystems fails with `EXDEV`.
     ///
+    /// *Atomic* is a claim about visibility, not about durability: the
+    /// `sync_all` below makes the plan's own bytes durable before the
+    /// rename, but the directory entry the rename creates is not synced,
+    /// so a machine that loses power just after a successful `write_to`
+    /// can come back holding the *previous* plan. That stays inside the
+    /// guarantee above — previous plan or no plan — and callers who need
+    /// the new plan to survive a power cut need more than this function.
+    ///
     /// A run killed between creating the temporary file and the rename
     /// leaves that sibling behind. It is never mistaken for a plan —
     /// nothing reads it and its name is not the one that was asked for —
-    /// but a job collecting `plan*` as an artifact will pick it up.
+    /// but nothing reaps it either, so N interrupted runs leave N of
+    /// them, and a job collecting `plan*` as an artifact picks them up.
     ///
     /// The plan is a fresh inode on every write, so it takes the
     /// umask-derived mode a newly created file gets rather than the mode
-    /// of a plan already at `path`, and a symlink at `path` is replaced
-    /// by the plan rather than followed.
+    /// of a plan already at `path` — which can *loosen* a plan that had
+    /// been chmod'd tighter — and a symlink at `path` is replaced by the
+    /// plan rather than followed.
+    ///
+    /// Creating a sibling also asks more of `path` than a plain write
+    /// did: the parent directory must be writable (a read-only directory
+    /// holding a writable plan no longer works), `path` must be a regular
+    /// file rather than a device node, FIFO or mount point, and its name
+    /// must leave ~29 bytes of headroom under `NAME_MAX` for the suffix.
     pub fn write_to(&self, path: &Path) -> std::io::Result<()> {
         let json = serde_json::to_vec_pretty(self)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
@@ -967,6 +983,68 @@ mod tests {
         assert_eq!(stray_siblings(dir.path()), Vec::<String>::new());
     }
 
+    /// `write_atomically` claims every path out of it either renames the
+    /// temp file into place or removes it. The removal is only reached
+    /// when the rename fails *after* the temp file exists, which nothing
+    /// else here exercises — a directory at `path` produces exactly that.
+    #[test]
+    fn write_to_removes_the_temp_file_when_the_rename_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.json");
+        std::fs::create_dir(&path).unwrap();
+
+        plan_with(vec![]).write_to(&path).unwrap_err();
+
+        assert_eq!(stray_siblings(dir.path()), Vec::<String>::new());
+    }
+
+    /// The rename replaces the directory entry rather than the bytes of
+    /// the inode already there — that substitution is what buys
+    /// atomicity, and it is the one thing the `std::fs::write` this
+    /// replaced could not do. A reader holding the old plan open goes on
+    /// reading the old plan; under `write` it would have seen the new
+    /// bytes, or a truncated prefix of them.
+    #[test]
+    fn write_to_leaves_a_reader_of_the_previous_plan_on_the_previous_plan() {
+        use std::io::Read;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.json");
+        std::fs::write(&path, b"the previous plan").unwrap();
+        let mut previous = File::open(&path).unwrap();
+
+        plan_with(vec![op(ResourceKind::CatalogSchema, "x", PlanOpType::Add)])
+            .write_to(&path)
+            .unwrap();
+
+        let mut held = String::new();
+        previous.read_to_string(&mut held).unwrap();
+        assert_eq!(held, "the previous plan");
+        assert_eq!(PlanFile::read_from(&path).unwrap().ops.len(), 1);
+    }
+
+    /// A symlink at `path` is replaced rather than written through. The
+    /// CHANGELOG states this as a consequence of the new write, so it is
+    /// pinned here rather than left to be discovered — under the old
+    /// `write` the target was overwritten and the symlink survived.
+    #[test]
+    #[cfg(unix)]
+    fn write_to_replaces_a_symlink_instead_of_following_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.json");
+        std::fs::write(&target, b"not a plan").unwrap();
+        let path = dir.path().join("plan.json");
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+
+        plan_with(vec![]).write_to(&path).unwrap();
+
+        assert!(!std::fs::symlink_metadata(&path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(std::fs::read(&target).unwrap(), b"not a plan");
+    }
+
     /// The plan is a CI artifact other steps read, so the rename must not
     /// quietly tighten its mode the way a 0o600 temp file would.
     #[test]
@@ -979,6 +1057,31 @@ mod tests {
         std::fs::write(&reference, b"{}").unwrap();
 
         let path = dir.path().join("plan.json");
+        plan_with(vec![]).write_to(&path).unwrap();
+
+        let mode = |p: &Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode(&path), mode(&reference));
+    }
+
+    /// The other half of the mode story, and the half that can *loosen*
+    /// permissions: the plan is a fresh inode, so it does not inherit the
+    /// mode of a plan already at `path`. A 0o600 plan replaced under the
+    /// usual 0o022 umask comes back 0o644. Under a 0o077 umask the two
+    /// modes coincide and this only re-pins the previous test, which is
+    /// why the loosening direction is spelled out in the CHANGELOG too.
+    #[test]
+    #[cfg(unix)]
+    fn write_to_does_not_inherit_the_mode_of_the_plan_it_replaces() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reference = dir.path().join("reference");
+        std::fs::write(&reference, b"{}").unwrap();
+
+        let path = dir.path().join("plan.json");
+        std::fs::write(&path, b"{}").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
         plan_with(vec![]).write_to(&path).unwrap();
 
         let mode = |p: &Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -65,7 +65,10 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::ffi::OsStr;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use crate::diff::custom_attribute::CustomAttributeOp;
 use crate::diff::{digest, DiffOp, DiffSummary, ResourceDiff};
@@ -342,10 +345,26 @@ impl PlanFile {
         serde_json::from_slice(&bytes).map_err(invalid)
     }
 
+    /// Serialize and replace `path` atomically.
+    ///
+    /// The bytes go to a sibling temporary file which is then `rename`d
+    /// over `path`, so an interrupted run leaves either the previous plan
+    /// or no plan, never a half-written one. The temporary file has to be
+    /// a *sibling*: `rename` across filesystems fails with `EXDEV`.
+    ///
+    /// A run killed between creating the temporary file and the rename
+    /// leaves that sibling behind. It is never mistaken for a plan —
+    /// nothing reads it and its name is not the one that was asked for —
+    /// but a job collecting `plan*` as an artifact will pick it up.
+    ///
+    /// The plan is a fresh inode on every write, so it takes the
+    /// umask-derived mode a newly created file gets rather than the mode
+    /// of a plan already at `path`, and a symlink at `path` is replaced
+    /// by the plan rather than followed.
     pub fn write_to(&self, path: &Path) -> std::io::Result<()> {
         let json = serde_json::to_vec_pretty(self)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        std::fs::write(path, json)
+        write_atomically(path, &json)
     }
 
     /// Compare saved ops against `fresh` as a multiset over
@@ -584,6 +603,94 @@ fn classify_orphanable<T>(
     }
 }
 
+/// Temp-name attempts before giving up. A collision needs a sibling
+/// carrying both this process's pid and the same random suffix, which in
+/// practice means a leftover from a crashed run rather than a live writer.
+const TEMP_NAME_ATTEMPTS: u32 = 8;
+
+fn invalid_path(msg: String) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, msg)
+}
+
+/// The directory the temp file for `path` belongs in.
+///
+/// It must be `path`'s own directory: `rename` across filesystems fails
+/// with `EXDEV`.
+fn temp_sibling_dir(path: &Path) -> std::io::Result<&Path> {
+    match path.parent() {
+        // A bare file name (`plan.json`) parents to `""`, which nothing
+        // can be created in.
+        Some(parent) if parent.as_os_str().is_empty() => Ok(Path::new(".")),
+        Some(parent) => Ok(parent),
+        None => Err(invalid_path(format!(
+            "{} has no parent directory",
+            path.display()
+        ))),
+    }
+}
+
+/// Replace `path` with `bytes` via a sibling temp file and `rename`.
+///
+/// Hand-rolled rather than pulled from `tempfile`: that crate would add
+/// `rustix` / `errno` / `getrandom` to the binary for the create-flush-
+/// rename below, and it creates temp files 0o600, which would tighten the
+/// mode of a plan meant to be read as a CI artifact.
+fn write_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let dir = temp_sibling_dir(path)?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| invalid_path(format!("{} does not name a file", path.display())))?;
+
+    let (mut file, temp_path) = create_temp_sibling(dir, file_name)?;
+
+    // The temp file exists from here on; every path out of this function
+    // either renames it into place or removes it.
+    let written = file.write_all(bytes).and_then(|()| {
+        // `rename` buys atomicity, not durability: without this a crash
+        // just after it can leave the plan present but empty, which is
+        // the same symptom by another route.
+        file.sync_all()
+    });
+    // Windows will not rename a file that is still open.
+    drop(file);
+
+    let result = written.and_then(|()| std::fs::rename(&temp_path, path));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+/// Create a new file in `dir` whose name is derived from `file_name`.
+///
+/// `create_new` is what keeps two concurrent writers off each other's
+/// temp file, so a name that is already taken is retried rather than
+/// truncated.
+fn create_temp_sibling(dir: &Path, file_name: &OsStr) -> std::io::Result<(File, PathBuf)> {
+    let pid = std::process::id();
+    for _ in 0..TEMP_NAME_ATTEMPTS {
+        let mut name = file_name.to_os_string();
+        name.push(format!(".tmp.{pid}.{:016x}", fastrand::u64(..)));
+        let candidate = dir.join(name);
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => return Ok((file, candidate)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        format!(
+            "could not create a temporary file next to {} in {TEMP_NAME_ATTEMPTS} attempts",
+            dir.join(file_name).display()
+        ),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::TimeDelta;
@@ -784,6 +891,98 @@ mod tests {
             },
             ops,
         }
+    }
+
+    /// Entries in `dir` that are not `plan.json` — i.e. temp siblings
+    /// `write_atomically` failed to clean up.
+    fn stray_siblings(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|n| n != "plan.json")
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn write_to_round_trips_through_read_from() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.json");
+        let plan = plan_with(vec![op(
+            ResourceKind::ContentBlock,
+            "a",
+            PlanOpType::Modify,
+        )]);
+
+        plan.write_to(&path).unwrap();
+        let read = PlanFile::read_from(&path).unwrap();
+
+        assert_eq!(read.ops, plan.ops);
+        assert_eq!(read.scope.environment, plan.scope.environment);
+        assert_eq!(stray_siblings(dir.path()), Vec::<String>::new());
+    }
+
+    #[test]
+    fn write_to_replaces_an_existing_plan_and_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.json");
+        std::fs::write(&path, b"stale, and longer than the plan that replaces it").unwrap();
+
+        let plan = plan_with(vec![op(ResourceKind::CatalogSchema, "x", PlanOpType::Add)]);
+        plan.write_to(&path).unwrap();
+
+        assert_eq!(PlanFile::read_from(&path).unwrap().ops, plan.ops);
+        assert_eq!(stray_siblings(dir.path()), Vec::<String>::new());
+    }
+
+    #[test]
+    fn a_bare_file_name_puts_the_temp_file_in_the_current_directory() {
+        // `Path::new("plan.json").parent()` is `Some("")`, which nothing
+        // can be created in — `diff --plan-out plan.json` reaches here.
+        assert_eq!(
+            temp_sibling_dir(Path::new("plan.json")).unwrap(),
+            Path::new(".")
+        );
+        assert_eq!(
+            temp_sibling_dir(Path::new("out/plan.json")).unwrap(),
+            Path::new("out")
+        );
+        temp_sibling_dir(Path::new("/")).unwrap_err();
+    }
+
+    #[test]
+    fn write_to_fails_without_creating_anything_when_the_directory_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("no-such-dir");
+        let plan = plan_with(vec![op(
+            ResourceKind::ContentBlock,
+            "a",
+            PlanOpType::Modify,
+        )]);
+
+        plan.write_to(&missing.join("plan.json")).unwrap_err();
+
+        assert!(!missing.exists());
+        assert_eq!(stray_siblings(dir.path()), Vec::<String>::new());
+    }
+
+    /// The plan is a CI artifact other steps read, so the rename must not
+    /// quietly tighten its mode the way a 0o600 temp file would.
+    #[test]
+    #[cfg(unix)]
+    fn write_to_gives_the_plan_the_mode_a_plain_write_would() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reference = dir.path().join("reference");
+        std::fs::write(&reference, b"{}").unwrap();
+
+        let path = dir.path().join("plan.json");
+        plan_with(vec![]).write_to(&path).unwrap();
+
+        let mode = |p: &Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode(&path), mode(&reference));
     }
 
     #[test]


### PR DESCRIPTION
Closes #105.

`PlanFile::write_to` serialized the plan and handed it to a single `std::fs::write`, so a run killed mid-write left a truncated plan on disk and, when the path already held a plan, destroyed the previous one on the way.

The bytes now go to a sibling temporary file which is flushed and then renamed into place. The temp file has to be a *sibling*: `rename` across filesystems fails with `EXDEV`. `sync_all` before the rename is what keeps a crash from leaving the plan present but empty — the same symptom by another route.

This was never a correctness hole in `apply`: a truncated plan fails `read_from`'s JSON parse and is rejected as `InvalidData`, so a half-written plan could not be applied as if it were whole. What it cost was the older, still-valid plan and a clear failure.

## `tempfile` or hand-rolled

The issue asks for a decision. **Hand-rolled**, for two reasons:

- Promoting `tempfile` from dev-dependency to a normal one adds `rustix`, `errno` and `getrandom` to the shipped binary (measured with `cargo tree -e normal` before/after) for what is a create-flush-rename. That is the trade `regex-lite` and `fastrand` are already annotated with in `Cargo.toml`.
- `NamedTempFile` creates the file 0o600. The plan is meant to be readable as a CI artifact, so that would quietly tighten its mode. A `#[cfg(unix)]` test pins the plan's mode against what a plain `write` in the same directory produces.

## What this does not promise

Stated in the `write_to` doc and the CHANGELOG rather than left implicit:

- **Atomicity is visibility, not durability.** The plan's bytes are `sync_all`'d before the rename, but the directory entry the rename creates is not, so a power cut just after a successful write can come back holding the previous plan. Still inside "previous plan or no plan".
- A run killed between creating the temp file and the rename leaves the sibling behind. Nothing reads it as a plan, and nothing reaps it either, so cancellations accumulate one file each; a job collecting `plan*` as an artifact will pick them all up.
- The plan is a fresh inode on every write, so it no longer inherits the mode of a plan already at that path — which can *loosen* one chmod'd to `0o600` — and a symlink at that path is replaced rather than written through.
- **The destination has to be an ordinary file in a writable directory.** A read-only directory holding a writable `plan.json`, `--plan-out /dev/null`, `--plan-out /dev/stdout`, a FIFO and a bind-mounted file all worked under `fs::write` and now fail — after the full set of API calls has already run.

## Tests

Nine tests in `src/diff/plan.rs`. Five cover the shape of the write: round-trip through `read_from`, replacing an existing plan, no stray temp sibling on success, failing without creating anything when the parent directory is missing, and the mode pin.

Four cover the rename itself, because the first five all pass against the `std::fs::write` this replaces and so constrained none of it: a reader holding the previous plan open still reads the previous plan, a symlink at the destination is replaced with its target untouched, the mode is not inherited from a plan already at the path, and the temp file is removed when the rename fails (a directory at the destination is what reaches that branch). Reverting `write_to` to `std::fs::write` fails three of the four, which is the check that they pin anything.

`cargo test --all`: 653 pass / 0 fail. Clippy and fmt clean.

## /review-loop での修正

4レンズ（correctness / interfaces & compat / security & data / tests）+ cross-vendor（Codex GPT-6 Astra、0 new findings）を回した結果:

- **テストが rename を一切固定していなかった** — 上記の4テストを追加。旧実装での失敗を実証済み。
- **CHANGELOG の「Two other consequences」が完全性を主張しつつ、実際にジョブを壊すクラスを落としていた** — 親ディレクトリの書き込み権限と「通常ファイルであること」の要求を明記。
- `fastrand` の依存注釈（「Braze client が唯一の caller」）が本 PR で偽になっていたため更新。

won't-fix: **rename 後の親ディレクトリ fsync**（CodeRabbit の指摘）。本 PR が主張しているのは atomic visibility であって durability ではなく、その区別を doc と CHANGELOG に明記する方を採った。

残る blind spot: `diff --plan-out` の実バイナリ実行は未検証（レビューは読みと単体テストのみ）。retry ループと `TEMP_NAME_ATTEMPTS` 枯渇分岐、`write_all` / `sync_all` のエラー経路は依然として未カバー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plan files are now written atomically, preventing interrupted runs from leaving truncated or invalid plans.
  - Existing plans remain intact if writing fails.
  - Plan replacement now safely handles symlink paths and preserves expected file permissions.

- **Documentation**
  - Added unreleased changelog notes describing atomic plan writes and their behavior during interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->