### PR TITLE
Write through destinations a rename would destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,11 +181,11 @@ file formats, JSON output, exit codes) for the full v1.x line.
   Following the link means the *target* is what gets replaced, so it is
   the target's inode and mode that change: a target chmod'd `0o600` comes
   back at the umask default. Two destinations do not keep their old
-  behaviour. A **dangling** symlink is replaced by the plan rather than
-  having its target created. And a link whose destination exists but
-  cannot be stat'd — `EACCES` on a directory along the chain, `ELOOP`,
-  `ENAMETOOLONG` — is now an **error**; letting it fall through to the
-  rename destroyed a live link and reported success.
+  behaviour: a symlink whose target is **absent** is replaced by the
+  plan rather than having that target created. Every other way of
+  failing to stat the destination — `EACCES` on a directory along the
+  chain, `ELOOP`, `ENOTDIR`, `ENAMETOOLONG` — surfaces as the error it
+  always did.
 
   **`--plan-out /dev/stdout` depends on what fd 1 is.** Piped or on a
   tty it resolves to a stream and is written through, as before.
@@ -194,10 +194,10 @@ file formats, JSON output, exit codes) for the full v1.x line.
   did — it takes the rename route: the redirect target is replaced by a
   new inode, so the shell's fd 1 is left on the old one and anything
   written to that redirection afterwards goes to an unlinked file. Where
-  the two resolutions disagree, the plan is written through the name that
-  was asked for; on macOS `realpath` answers `/dev/fd/<basename>`, which
-  does not exist, and before that check the run failed with `No such file
-  or directory` without writing a plan.
+  the two resolutions disagree the plan is written through the name that
+  was asked for, which is what keeps this working on macOS, where
+  `realpath` answers `/dev/fd/<basename>` — a name that does not
+  resolve.
 
   **`--plan-out` still asks more of an ordinary destination.** Writing a
   new file rather than rewriting one in place means the *parent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,12 +162,12 @@ file formats, JSON output, exit codes) for the full v1.x line.
   **A destination that cannot be replaced is written through instead.**
   A device node, FIFO or socket is a stream with an identity of its own;
   `rename` does not update one, it unlinks it and leaves a regular file
-  where it was. `--plan-out /dev/null` and `--plan-out /dev/stdout`
-  both worked before, and as root the rename would have replaced `/dev/null`
-  itself, so every later writer to it on that machine appended to a
-  growing file. These destinations therefore keep the plain write they
-  always had — and with it the absence of any atomicity, which is what
-  they had before and all that is meaningful for a stream.
+  where it was. `--plan-out /dev/null` worked before, and as root the
+  rename would have replaced `/dev/null` itself, so every later writer to
+  it on that machine appended to a growing file. These destinations
+  therefore keep the plain write they always had — and with it the
+  absence of any atomicity, which is what they had before and all that is
+  meaningful for a stream.
 
   **A symlink is followed, not replaced.** A link points *at* the
   artifact rather than being it, so the rename targets the file it names
@@ -176,24 +176,41 @@ file formats, JSON output, exit codes) for the full v1.x line.
   the kernel's, not a `read_link` walk here: on Linux `/dev/stdout` is
   `/proc/self/fd/1`, whose target for a piped stdout reads as
   `pipe:[12345]`, a string that is not a path, and walking the chain
-  would take it for a destination and create a file by that name. The
-  one destination whose old behaviour is *not* preserved is a dangling
-  symlink: the plain write created its target, and the plan now replaces
-  the link instead.
+  would take it for a destination and create a file by that name.
+
+  Following the link means the *target* is what gets replaced, so it is
+  the target's inode and mode that change: a target chmod'd `0o600` comes
+  back at the umask default. Two destinations do not keep their old
+  behaviour. A **dangling** symlink is replaced by the plan rather than
+  having its target created. And a link whose destination exists but
+  cannot be stat'd — `EACCES` on a directory along the chain, `ELOOP`,
+  `ENAMETOOLONG` — is now an **error**; letting it fall through to the
+  rename destroyed a live link and reported success.
+
+  **`--plan-out /dev/stdout` depends on what fd 1 is.** Piped or on a
+  tty it resolves to a stream and is written through, as before.
+  *Redirected to a regular file* it resolves to that file, and on Linux —
+  where `realpath` follows `/proc/self/fd/1` to the same file the kernel
+  did — it takes the rename route: the redirect target is replaced by a
+  new inode, so the shell's fd 1 is left on the old one and anything
+  written to that redirection afterwards goes to an unlinked file. Where
+  the two resolutions disagree, the plan is written through the name that
+  was asked for; on macOS `realpath` answers `/dev/fd/<basename>`, which
+  does not exist, and before that check the run failed with `No such file
+  or directory` without writing a plan.
 
   **`--plan-out` still asks more of an ordinary destination.** Writing a
   new file rather than rewriting one in place means the *parent
-  directory* must be writable: a read-only directory holding a writable
-  `plan.json` used to work and now fails with `Permission denied`. A
-  bind-mounted file is an ordinary file, so it takes the rename and
-  fails there. And the destination's name needs ~29 bytes of headroom
-  under the filesystem's `NAME_MAX` for the temporary suffix.
+  directory* must be writable — for a symlink, the **target's** parent,
+  not the link's: a read-only directory holding a writable `plan.json`
+  used to work and now fails with `Permission denied`. A bind-mounted
+  file is an ordinary file, so it takes the rename and fails there. And
+  the resolved name needs ~29 bytes of headroom under the filesystem's
+  `NAME_MAX` for the temporary suffix.
 
-  Two further consequences: the plan takes the mode a newly created file
+  One further consequence: the plan takes the mode a newly created file
   gets instead of inheriting the mode of a plan already at that path —
-  which can *loosen* one that had been chmod'd to `0o600` — and a
-  symlink at that path is replaced by the plan rather than written
-  through, so a symlinked artifact path silently stops being updated.
+  which can *loosen* one that had been chmod'd to `0o600`.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,19 +159,35 @@ file formats, JSON output, exit codes) for the full v1.x line.
   cancellations accumulate one file each, and a job collecting `plan*`
   as an artifact will pick them all up.
 
-  **`--plan-out` now asks more of its destination.** Writing a new file
-  rather than rewriting one in place means the *parent directory* must
-  be writable: a read-only directory holding a writable `plan.json` used
-  to work and now fails with `Permission denied`. For the same reason
-  the destination must be an ordinary file. `--plan-out /dev/null`,
-  `--plan-out /dev/stdout`, a FIFO and a bind-mounted file all worked
-  before; unprivileged, they now fail with `Permission denied`. **As
-  root the failure is worse than an error:** `/dev` is writable, so the
-  temp file is created and the rename *replaces the device node or
-  symlink with a regular file*, and every later writer to `/dev/null` on
-  that box appends to it instead. Finally, the destination's name needs
-  ~29 bytes of headroom under the filesystem's `NAME_MAX` for the
-  temporary suffix.
+  **A destination that cannot be replaced is written through instead.**
+  A device node, FIFO or socket is a stream with an identity of its own;
+  `rename` does not update one, it unlinks it and leaves a regular file
+  where it was. `--plan-out /dev/null` and `--plan-out /dev/stdout`
+  both worked before, and as root the rename would have replaced `/dev/null`
+  itself, so every later writer to it on that machine appended to a
+  growing file. These destinations therefore keep the plain write they
+  always had — and with it the absence of any atomicity, which is what
+  they had before and all that is meaningful for a stream.
+
+  **A symlink is followed, not replaced.** A link points *at* the
+  artifact rather than being it, so the rename targets the file it names
+  and the link survives — replacing the link would leave whatever reads
+  the target on a plan that silently stops being updated. Resolution is
+  the kernel's, not a `read_link` walk here: on Linux `/dev/stdout` is
+  `/proc/self/fd/1`, whose target for a piped stdout reads as
+  `pipe:[12345]`, a string that is not a path, and walking the chain
+  would take it for a destination and create a file by that name. The
+  one destination whose old behaviour is *not* preserved is a dangling
+  symlink: the plain write created its target, and the plan now replaces
+  the link instead.
+
+  **`--plan-out` still asks more of an ordinary destination.** Writing a
+  new file rather than rewriting one in place means the *parent
+  directory* must be writable: a read-only directory holding a writable
+  `plan.json` used to work and now fails with `Permission denied`. A
+  bind-mounted file is an ordinary file, so it takes the rename and
+  fails there. And the destination's name needs ~29 bytes of headroom
+  under the filesystem's `NAME_MAX` for the temporary suffix.
 
   Two further consequences: the plan takes the mode a newly created file
   gets instead of inheriting the mode of a plan already at that path —

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -345,7 +345,8 @@ impl PlanFile {
         serde_json::from_slice(&bytes).map_err(invalid)
     }
 
-    /// Serialize and replace `path` atomically.
+    /// Serialize and write `path`, atomically where that means
+    /// anything — see the last paragraph for where it does not.
     ///
     /// The bytes go to a sibling temporary file which is then `rename`d
     /// over `path`, so an interrupted run leaves either the previous plan
@@ -369,18 +370,25 @@ impl PlanFile {
     /// The plan is a fresh inode on every write, so it takes the
     /// umask-derived mode a newly created file gets rather than the mode
     /// of a plan already at `path` — which can *loosen* a plan that had
-    /// been chmod'd tighter — and a symlink at `path` is replaced by the
-    /// plan rather than followed.
+    /// been chmod'd tighter.
+    ///
+    /// A symlink at `path` is followed and the file it points at is
+    /// replaced, so the link survives; a dangling one is the exception
+    /// and is replaced by the plan itself. See [`write_plan_bytes`].
     ///
     /// Creating a sibling also asks more of `path` than a plain write
-    /// did: the parent directory must be writable (a read-only directory
-    /// holding a writable plan no longer works), `path` must be a regular
-    /// file rather than a device node, FIFO or mount point, and its name
-    /// must leave ~29 bytes of headroom under `NAME_MAX` for the suffix.
+    /// did: the parent directory must be writable — a read-only
+    /// directory holding a writable plan no longer works — and `path`'s
+    /// name must leave ~29 bytes of headroom under `NAME_MAX` for the
+    /// suffix. A destination that cannot be replaced at all, because it
+    /// is a device node, FIFO or socket, is written *through* instead
+    /// and keeps every guarantee it had before, which is none of the
+    /// above. A mount point is a regular file and so takes the rename
+    /// route, where it fails.
     pub fn write_to(&self, path: &Path) -> std::io::Result<()> {
         let json = serde_json::to_vec_pretty(self)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        write_atomically(path, &json)
+        write_plan_bytes(path, &json)
     }
 
     /// Compare saved ops against `fresh` as a multiset over
@@ -645,13 +653,80 @@ fn temp_sibling_dir(path: &Path) -> std::io::Result<&Path> {
     }
 }
 
+/// Whether `meta` describes a sink that has to be written *through*
+/// rather than replaced.
+///
+/// A device node, FIFO or socket is a stream with an identity of its own
+/// that outlives any one write. `rename` does not update such a thing,
+/// it unlinks it and leaves a regular file where it was: as root,
+/// `--plan-out /dev/null` would replace `/dev/null` for every process on
+/// the box. Atomic replacement has no meaning for these, so they keep
+/// the plain write they have always had.
+///
+/// A directory is deliberately not one of these. Writing a plan to one
+/// fails under either route, and diverting it would only change which
+/// error it gets.
+#[cfg(unix)]
+fn is_stream_sink(meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+
+    let file_type = meta.file_type();
+    file_type.is_char_device()
+        || file_type.is_block_device()
+        || file_type.is_fifo()
+        || file_type.is_socket()
+}
+
+/// Windows has no destination `std` can recognise as one of these, and
+/// `rename` there replaces a directory entry the same way, so every
+/// destination takes the atomic route.
+#[cfg(not(unix))]
+fn is_stream_sink(_meta: &std::fs::Metadata) -> bool {
+    false
+}
+
+/// Write `bytes` to `path`, atomically where that means anything.
+///
+/// Symlinks are resolved by the kernel rather than by walking
+/// `read_link` here. That is not a shortcut: on Linux `/dev/stdout` is
+/// `/proc/self/fd/1`, whose target for a piped stdout reads as
+/// `pipe:[12345]` — a string that is not a path and cannot be opened by
+/// name. Walking the chain would take that for a destination and create
+/// a file called `pipe:[12345]`.
+fn write_plan_bytes(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    match std::fs::metadata(path) {
+        // Written through under the name that was asked for, so the
+        // kernel resolves the chain.
+        Ok(meta) if is_stream_sink(&meta) => std::fs::write(path, bytes),
+
+        // A symlink to an ordinary file points *at* the artifact rather
+        // than being it: replacing the link would leave whatever reads
+        // the target reading a plan that silently stops being updated.
+        // So the rename targets what it points at, and the link
+        // survives. `canonicalize` cannot fail here — the `metadata`
+        // call above already resolved the whole chain.
+        Ok(_) if path.is_symlink() => replace_atomically(&std::fs::canonicalize(path)?, bytes),
+
+        // An ordinary file, a directory (which fails in the rename, as
+        // it did in the write), or nothing there yet.
+        //
+        // A *dangling* symlink lands here too, and is replaced by the
+        // plan rather than having its target created the way the plain
+        // write did. It is the one destination whose old behaviour is
+        // not preserved; a plan is an output path, not a mailbox, so a
+        // link to a file nobody has created is not a workflow worth
+        // reconstructing.
+        _ => replace_atomically(path, bytes),
+    }
+}
+
 /// Replace `path` with `bytes` via a sibling temp file and `rename`.
 ///
 /// Hand-rolled rather than pulled from `tempfile`: that crate would add
 /// `rustix` / `errno` / `getrandom` to the binary for the create-flush-
 /// rename below, and it creates temp files 0o600, which would tighten the
 /// mode of a plan meant to be read as a CI artifact.
-fn write_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+fn replace_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let dir = temp_sibling_dir(path)?;
     let file_name = path
         .file_name()
@@ -910,7 +985,7 @@ mod tests {
     }
 
     /// Entries in `dir` that are not `plan.json` — i.e. temp siblings
-    /// `write_atomically` failed to clean up.
+    /// `replace_atomically` failed to clean up.
     fn stray_siblings(dir: &Path) -> Vec<String> {
         let mut names: Vec<String> = std::fs::read_dir(dir)
             .unwrap()
@@ -983,7 +1058,7 @@ mod tests {
         assert_eq!(stray_siblings(dir.path()), Vec::<String>::new());
     }
 
-    /// `write_atomically` claims every path out of it either renames the
+    /// `replace_atomically` claims every path out of it either renames the
     /// temp file into place or removes it. The removal is only reached
     /// when the rename fails *after* the temp file exists, which nothing
     /// else here exercises — a directory at `path` produces exactly that.
@@ -1023,18 +1098,42 @@ mod tests {
         assert_eq!(PlanFile::read_from(&path).unwrap().ops.len(), 1);
     }
 
-    /// A symlink at `path` is replaced rather than written through. The
-    /// CHANGELOG states this as a consequence of the new write, so it is
-    /// pinned here rather than left to be discovered — under the old
-    /// `write` the target was overwritten and the symlink survived.
+    /// A symlink points *at* the artifact rather than being it, so the
+    /// link survives and the file it names is what gets replaced.
+    /// Replacing the link instead would leave whatever reads the target
+    /// on a plan that silently stops being updated.
     #[test]
     #[cfg(unix)]
-    fn write_to_replaces_a_symlink_instead_of_following_it() {
+    fn write_to_replaces_what_a_symlink_points_at_and_keeps_the_link() {
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("target.json");
         std::fs::write(&target, b"not a plan").unwrap();
         let path = dir.path().join("plan.json");
         std::os::unix::fs::symlink(&target, &path).unwrap();
+
+        let plan = plan_with(vec![op(ResourceKind::CatalogSchema, "x", PlanOpType::Add)]);
+        plan.write_to(&path).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the link must survive",
+        );
+        assert_eq!(PlanFile::read_from(&target).unwrap().ops, plan.ops);
+        assert_eq!(stray_siblings(dir.path()), vec!["target.json".to_string()]);
+    }
+
+    /// The one destination whose pre-atomic behaviour is not preserved:
+    /// the plain write created the target, the rename replaces the link.
+    /// Pinned so the exception stays a decision rather than a surprise.
+    #[test]
+    #[cfg(unix)]
+    fn write_to_replaces_a_dangling_symlink_rather_than_creating_its_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.json");
+        std::os::unix::fs::symlink(dir.path().join("absent.json"), &path).unwrap();
 
         plan_with(vec![]).write_to(&path).unwrap();
 
@@ -1042,7 +1141,124 @@ mod tests {
             .unwrap()
             .file_type()
             .is_symlink());
-        assert_eq!(std::fs::read(&target).unwrap(), b"not a plan");
+        assert!(!dir.path().join("absent.json").exists());
+    }
+
+    /// `/dev/stdout` in miniature: the destination is a symlink whose
+    /// target is a stream. The link must not be followed to a rename —
+    /// the stream is written through under the name that was asked for.
+    #[test]
+    #[cfg(unix)]
+    fn write_to_writes_through_a_symlink_to_a_stream() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("sink");
+        assert!(std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .unwrap()
+            .success());
+        let path = dir.path().join("plan.json");
+        std::os::unix::fs::symlink(&fifo, &path).unwrap();
+
+        let reader = std::thread::spawn({
+            let fifo = fifo.clone();
+            move || std::fs::read(fifo).unwrap()
+        });
+
+        let plan = plan_with(vec![op(ResourceKind::CatalogSchema, "x", PlanOpType::Add)]);
+        plan.write_to(&path).unwrap();
+
+        // Before the join, for the reason given on the FIFO test above.
+        assert!(
+            std::fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the link must survive",
+        );
+        assert!(
+            std::fs::symlink_metadata(&fifo)
+                .unwrap()
+                .file_type()
+                .is_fifo(),
+            "the FIFO must survive",
+        );
+        assert_eq!(
+            serde_json::from_slice::<PlanFile>(&reader.join().unwrap())
+                .unwrap()
+                .ops,
+            plan.ops,
+        );
+    }
+
+    /// The routing table, asserted by stat alone so that a regression
+    /// cannot damage the machine running the suite: a broken
+    /// `is_stream_sink` under root would have `write_to` replace
+    /// `/dev/null` itself, which is exactly what this exists to prevent.
+    #[test]
+    #[cfg(unix)]
+    fn stream_sinks_are_the_destinations_a_rename_would_destroy() {
+        let dir = tempfile::tempdir().unwrap();
+        let regular = dir.path().join("plan.json");
+        std::fs::write(&regular, b"{}").unwrap();
+
+        let sink = |path: &str| is_stream_sink(&std::fs::metadata(path).unwrap());
+        assert!(sink("/dev/null"), "character device");
+        assert!(!sink(regular.to_str().unwrap()), "regular file");
+        // A directory has to keep taking the rename route: it is what
+        // `write_to_removes_the_temp_file_when_the_rename_fails` uses to
+        // reach the cleanup branch.
+        assert!(!sink(dir.path().to_str().unwrap()), "directory");
+    }
+
+    /// End-to-end on a sink that can be created in a tempdir. Under the
+    /// unconditional rename this shipped with, the FIFO was unlinked and
+    /// a regular file left in its place; the reader below would have
+    /// blocked forever instead of seeing the plan.
+    #[test]
+    #[cfg(unix)]
+    fn write_to_writes_through_a_fifo_rather_than_replacing_it() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.json");
+        // `mkfifo(1)` rather than a libc dependency for one test.
+        assert!(std::process::Command::new("mkfifo")
+            .arg(&path)
+            .status()
+            .unwrap()
+            .success());
+
+        // Opening a FIFO for writing blocks until a reader arrives, so
+        // the reader has to be waiting before `write_to` is called.
+        let reader = std::thread::spawn({
+            let path = path.clone();
+            move || std::fs::read(path).unwrap()
+        });
+
+        let plan = plan_with(vec![op(ResourceKind::CatalogSchema, "x", PlanOpType::Add)]);
+        plan.write_to(&path).unwrap();
+
+        // Checked before the join, not after: if the FIFO was replaced,
+        // no writer ever opens it and the reader blocks forever. Failing
+        // here keeps a regression a failing test rather than a hung CI
+        // job — the abandoned thread does not hold up process exit.
+        assert!(
+            std::fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_fifo(),
+            "the FIFO must survive the write",
+        );
+
+        let received = reader.join().unwrap();
+        assert_eq!(
+            serde_json::from_slice::<PlanFile>(&received).unwrap().ops,
+            plan.ops,
+        );
+        assert_eq!(stray_siblings(dir.path()), Vec::<String>::new());
     }
 
     /// The plan is a CI artifact other steps read, so the rename must not

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -375,12 +375,13 @@ impl PlanFile {
     ///
     /// A symlink at `path` is followed and the file it points at is
     /// replaced, so the link survives — which means the *target's*
-    /// inode and mode are what change, not the link's. A dangling one
-    /// is the exception and is replaced by the plan itself. A link the
-    /// destination of which exists but cannot be stat'd — `EACCES` on a
-    /// directory along the chain, `ELOOP`, `ENAMETOOLONG` — is an error
-    /// rather than a third case: replacing it would destroy a live link
-    /// and report success.
+    /// inode and mode are what change, not the link's. A link whose
+    /// target is simply absent (`ENOENT`) is the exception and is
+    /// replaced by the plan itself. Every *other* way of failing to
+    /// stat the destination — `EACCES` on a directory along the chain,
+    /// `ELOOP`, `ENOTDIR`, `ENAMETOOLONG` — is surfaced as the error it
+    /// is, exactly as the plain write surfaced it: replacing the link
+    /// there would destroy a live link and report success.
     ///
     /// Creating a sibling also asks more of `path` than a plain write
     /// did: the parent directory must be writable — for a symlink, the
@@ -732,22 +733,25 @@ fn write_plan_bytes(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let meta = match std::fs::metadata(path) {
         Ok(meta) => meta,
 
-        // Nothing at `path` — a new plan, or a *dangling* symlink, which
-        // is replaced by the plan rather than having its target created
-        // the way the plain write did. It is the one destination whose
-        // old behaviour is deliberately not preserved; a plan is an
-        // output path, not a mailbox, so a link to a file nobody has
-        // created is not a workflow worth reconstructing.
+        // Nothing at `path` — a new plan, or a symlink whose target is
+        // absent, which is replaced by the plan rather than having that
+        // target created the way the plain write did. It is the one
+        // destination whose old behaviour is deliberately not preserved;
+        // a plan is an output path, not a mailbox, so a link to a file
+        // nobody has created is not a workflow worth reconstructing.
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return replace_atomically(path, bytes)
         }
 
         // Any *other* stat failure — `EACCES` on a directory along the
-        // target's chain, `ELOOP`, `ENAMETOOLONG` — says the destination
-        // exists but could not be classified. Falling through to the
-        // rename would replace a live symlink with a regular file and
-        // report success, which is the damage this routing exists to
-        // prevent, so the error is surfaced instead.
+        // target's chain, `ELOOP`, `ENOTDIR`, `ENAMETOOLONG` — leaves
+        // the destination unclassified. Note that this covers links that
+        // dangle for a reason other than a missing final component, so
+        // "a dangling link is replaced" holds for `ENOENT` alone. The
+        // error is surfaced, as the plain write surfaced it: falling
+        // through to the rename would replace a live symlink with a
+        // regular file and report success, which is the damage this
+        // routing exists to prevent.
         Err(e) => return Err(e),
     };
 

--- a/src/diff/plan.rs
+++ b/src/diff/plan.rs
@@ -370,21 +370,36 @@ impl PlanFile {
     /// The plan is a fresh inode on every write, so it takes the
     /// umask-derived mode a newly created file gets rather than the mode
     /// of a plan already at `path` — which can *loosen* a plan that had
-    /// been chmod'd tighter.
+    /// been chmod'd tighter. That applies to a symlink's target as much
+    /// as to `path` itself.
     ///
     /// A symlink at `path` is followed and the file it points at is
-    /// replaced, so the link survives; a dangling one is the exception
-    /// and is replaced by the plan itself. See [`write_plan_bytes`].
+    /// replaced, so the link survives — which means the *target's*
+    /// inode and mode are what change, not the link's. A dangling one
+    /// is the exception and is replaced by the plan itself. A link the
+    /// destination of which exists but cannot be stat'd — `EACCES` on a
+    /// directory along the chain, `ELOOP`, `ENAMETOOLONG` — is an error
+    /// rather than a third case: replacing it would destroy a live link
+    /// and report success.
     ///
     /// Creating a sibling also asks more of `path` than a plain write
-    /// did: the parent directory must be writable — a read-only
-    /// directory holding a writable plan no longer works — and `path`'s
-    /// name must leave ~29 bytes of headroom under `NAME_MAX` for the
-    /// suffix. A destination that cannot be replaced at all, because it
-    /// is a device node, FIFO or socket, is written *through* instead
-    /// and keeps every guarantee it had before, which is none of the
-    /// above. A mount point is a regular file and so takes the rename
-    /// route, where it fails.
+    /// did: the parent directory must be writable — for a symlink, the
+    /// *target's* parent, so a read-only directory holding a writable
+    /// plan no longer works — and the resolved name must leave ~29 bytes
+    /// of headroom under `NAME_MAX` for the suffix. A destination that
+    /// cannot be replaced at all, because it is a device node, FIFO or
+    /// socket, is written *through* instead and keeps every guarantee it
+    /// had before, which is none of the above. A mount point is a
+    /// regular file and so takes the rename route, where it fails.
+    ///
+    /// `/dev/stdout` splits on what the shell did with fd 1. Piped or on
+    /// a tty it resolves to a stream and is written through. **Redirected
+    /// to a regular file it resolves to that file**, and where the kernel
+    /// and `realpath` agree on which file that is — Linux, via
+    /// `/proc/self/fd/1` — it takes the rename route, so the redirect
+    /// target is replaced by a new inode and fd 1 is left on the old one.
+    /// Where they do not agree, the plan is written through the name that
+    /// was asked for instead.
     pub fn write_to(&self, path: &Path) -> std::io::Result<()> {
         let json = serde_json::to_vec_pretty(self)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
@@ -685,6 +700,26 @@ fn is_stream_sink(_meta: &std::fs::Metadata) -> bool {
     false
 }
 
+/// Whether two `Metadata` describe the same file.
+///
+/// Used to check that `realpath` and the kernel agree about where a
+/// symlink leads before a `rename` acts on `realpath`'s answer.
+#[cfg(unix)]
+fn is_same_file(a: &std::fs::Metadata, b: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    a.dev() == b.dev() && a.ino() == b.ino()
+}
+
+/// Windows exposes no stable file identity through `Metadata`
+/// (`file_index` is unstable behind `windows_by_handle`), so the check
+/// there is just that the canonical path still resolves — which the
+/// caller has already established by stat'ing it successfully.
+#[cfg(not(unix))]
+fn is_same_file(_a: &std::fs::Metadata, _b: &std::fs::Metadata) -> bool {
+    true
+}
+
 /// Write `bytes` to `path`, atomically where that means anything.
 ///
 /// Symlinks are resolved by the kernel rather than by walking
@@ -694,30 +729,60 @@ fn is_stream_sink(_meta: &std::fs::Metadata) -> bool {
 /// name. Walking the chain would take that for a destination and create
 /// a file called `pipe:[12345]`.
 fn write_plan_bytes(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    match std::fs::metadata(path) {
-        // Written through under the name that was asked for, so the
-        // kernel resolves the chain.
-        Ok(meta) if is_stream_sink(&meta) => std::fs::write(path, bytes),
+    let meta = match std::fs::metadata(path) {
+        Ok(meta) => meta,
 
-        // A symlink to an ordinary file points *at* the artifact rather
-        // than being it: replacing the link would leave whatever reads
-        // the target reading a plan that silently stops being updated.
-        // So the rename targets what it points at, and the link
-        // survives. `canonicalize` cannot fail here — the `metadata`
-        // call above already resolved the whole chain.
-        Ok(_) if path.is_symlink() => replace_atomically(&std::fs::canonicalize(path)?, bytes),
+        // Nothing at `path` — a new plan, or a *dangling* symlink, which
+        // is replaced by the plan rather than having its target created
+        // the way the plain write did. It is the one destination whose
+        // old behaviour is deliberately not preserved; a plan is an
+        // output path, not a mailbox, so a link to a file nobody has
+        // created is not a workflow worth reconstructing.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return replace_atomically(path, bytes)
+        }
 
-        // An ordinary file, a directory (which fails in the rename, as
-        // it did in the write), or nothing there yet.
-        //
-        // A *dangling* symlink lands here too, and is replaced by the
-        // plan rather than having its target created the way the plain
-        // write did. It is the one destination whose old behaviour is
-        // not preserved; a plan is an output path, not a mailbox, so a
-        // link to a file nobody has created is not a workflow worth
-        // reconstructing.
-        _ => replace_atomically(path, bytes),
+        // Any *other* stat failure — `EACCES` on a directory along the
+        // target's chain, `ELOOP`, `ENAMETOOLONG` — says the destination
+        // exists but could not be classified. Falling through to the
+        // rename would replace a live symlink with a regular file and
+        // report success, which is the damage this routing exists to
+        // prevent, so the error is surfaced instead.
+        Err(e) => return Err(e),
+    };
+
+    // Written through under the name that was asked for, so the kernel
+    // resolves the chain.
+    if is_stream_sink(&meta) {
+        return std::fs::write(path, bytes);
     }
+
+    // A symlink to an ordinary file points *at* the artifact rather than
+    // being it: replacing the link would leave whatever reads the target
+    // reading a plan that silently stops being updated. So the rename
+    // targets what it points at, and the link survives.
+    //
+    // `canonicalize` is `realpath(3)`, an independent resolution rather
+    // than a reuse of the stat above, and the two can disagree: on macOS
+    // `canonicalize("/dev/stdout")` under `> plan.json` answers
+    // `/dev/fd/plan.json`, a name that does not exist, and on Linux it
+    // fails outright when fd 1 holds an unlinked file. Both would put
+    // the temp sibling somewhere the caller never named. So the answer
+    // is only used when a fresh stat says it is the same file the
+    // routing decision was made about; otherwise the plain write goes
+    // through the name that was asked for.
+    if path.is_symlink() {
+        if let Ok(real) = std::fs::canonicalize(path) {
+            if std::fs::metadata(&real).is_ok_and(|m| is_same_file(&meta, &m)) {
+                return replace_atomically(&real, bytes);
+            }
+        }
+        return std::fs::write(path, bytes);
+    }
+
+    // An ordinary file, or a directory (which fails in the rename, as it
+    // did in the write).
+    replace_atomically(path, bytes)
 }
 
 /// Replace `path` with `bytes` via a sibling temp file and `rename`.
@@ -1102,14 +1167,28 @@ mod tests {
     /// link survives and the file it names is what gets replaced.
     /// Replacing the link instead would leave whatever reads the target
     /// on a plan that silently stops being updated.
+    ///
+    /// The link is deliberately **relative and into a subdirectory**,
+    /// and the target's inode is asserted to have been replaced. That
+    /// combination is what makes this test able to fail: resolving with
+    /// `read_link` instead of `canonicalize` yields the bare
+    /// `sub/target.json`, which does not resolve from the process cwd,
+    /// so the write would fall back to writing *through* the link — the
+    /// target would hold the right bytes on the same inode, and every
+    /// other assertion here would still pass.
     #[test]
     #[cfg(unix)]
     fn write_to_replaces_what_a_symlink_points_at_and_keeps_the_link() {
+        use std::os::unix::fs::MetadataExt;
+
         let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target.json");
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let target = sub.join("target.json");
         std::fs::write(&target, b"not a plan").unwrap();
+        let before = std::fs::metadata(&target).unwrap().ino();
         let path = dir.path().join("plan.json");
-        std::os::unix::fs::symlink(&target, &path).unwrap();
+        std::os::unix::fs::symlink("sub/target.json", &path).unwrap();
 
         let plan = plan_with(vec![op(ResourceKind::CatalogSchema, "x", PlanOpType::Add)]);
         plan.write_to(&path).unwrap();
@@ -1122,7 +1201,62 @@ mod tests {
             "the link must survive",
         );
         assert_eq!(PlanFile::read_from(&target).unwrap().ops, plan.ops);
-        assert_eq!(stray_siblings(dir.path()), vec!["target.json".to_string()]);
+        assert_ne!(
+            before,
+            std::fs::metadata(&target).unwrap().ino(),
+            "the target must be replaced by the rename, not written through",
+        );
+        // The temp sibling belongs next to the *target*, and nothing is
+        // left behind in either directory.
+        assert_eq!(stray_siblings(dir.path()), vec!["sub".to_string()]);
+        assert_eq!(stray_siblings(&sub), vec!["target.json".to_string()]);
+    }
+
+    /// A destination that exists but cannot be classified — here a link
+    /// whose target sits under a directory the caller may not search —
+    /// is an error, not an invitation to replace the link. Falling
+    /// through to the rename would destroy a live symlink and still
+    /// report success, which is the damage the routing exists to stop.
+    #[test]
+    #[cfg(unix)]
+    fn write_to_errors_rather_than_replacing_a_link_it_cannot_stat() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        let target = locked.join("target.json");
+        std::fs::write(&target, b"not a plan").unwrap();
+        let path = dir.path().join("plan.json");
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // Root searches a 0o000 directory regardless, so there is no
+        // unstattable destination to test with; skip rather than assert
+        // the opposite of what this pins.
+        let privileged = std::fs::metadata(&target).is_ok();
+
+        let result = plan_with(vec![]).write_to(&path);
+
+        // Restore before the tempdir is dropped, or the cleanup leaves
+        // the directory behind.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        if privileged {
+            return;
+        }
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied,
+        );
+        assert!(
+            std::fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the link must survive a destination that could not be classified",
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"not a plan");
     }
 
     /// The one destination whose pre-atomic behaviour is not preserved:
@@ -1204,13 +1338,20 @@ mod tests {
         let regular = dir.path().join("plan.json");
         std::fs::write(&regular, b"{}").unwrap();
 
-        let sink = |path: &str| is_stream_sink(&std::fs::metadata(path).unwrap());
-        assert!(sink("/dev/null"), "character device");
-        assert!(!sink(regular.to_str().unwrap()), "regular file");
+        // A bound socket has a name other processes are connected to,
+        // exactly like the FIFO; the listener is held for the assertion
+        // so the socket is still bound when it is stat'd.
+        let socket_path = dir.path().join("plan.sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
+
+        let sink = |path: &Path| is_stream_sink(&std::fs::metadata(path).unwrap());
+        assert!(sink(Path::new("/dev/null")), "character device");
+        assert!(sink(&socket_path), "socket");
+        assert!(!sink(&regular), "regular file");
         // A directory has to keep taking the rename route: it is what
         // `write_to_removes_the_temp_file_when_the_rename_fails` uses to
         // reach the cleanup branch.
-        assert!(!sink(dir.path().to_str().unwrap()), "directory");
+        assert!(!sink(dir.path()), "directory");
     }
 
     /// End-to-end on a sink that can be created in a tempdir. Under the


### PR DESCRIPTION
Follow-up to #109. That PR made `diff --plan-out` write the plan via a sibling temp file and `rename`, which asked something of the destination the plain write did not: that it be *replaceable*. Two kinds are not.

## Streams

A device node, FIFO or socket has an identity of its own that outlives any one write. `rename` does not update one — it unlinks it and leaves a regular file where it was. `--plan-out /dev/null` stopped working, and **as root the failure was worse than an error**: `/dev` is writable, so the temp file was created and the rename replaced `/dev/null` for every process on the box.

These now take the plain write they always had. That gives them no atomicity, which is what they had before and the only thing that means anything for a stream — there is no previous plan to preserve at `/dev/null`.

## Symlinks

A link points *at* the artifact rather than being it, so replacing it left whatever reads the target on a plan that silently stopped being updated. The rename now targets the file the link names, and the link survives.

## Where the two interact

`/dev/stdout` is a symlink, and that is the sharp edge. Piped, it resolves to a FIFO and is written through. **Redirected to a file** (`diff --plan-out /dev/stdout > plan.json`) it resolves to a regular file, so before this it took the rename route, put its temp file in `/dev`, and as root replaced the `/dev/stdout` link itself.

Verified with `stat -Lf '%HT' /dev/stdout`: `Fifo File` piped, `Regular File` redirected.

Resolution is the kernel's, not a `read_link` walk. On Linux `/dev/stdout` is `/proc/self/fd/1`, whose target for a piped stdout reads as `pipe:[12345]` — a string that is not a path and cannot be opened by name. Walking the chain would take it for a destination and create a file by that name. So the routing stats the path, writes through when the resolved type is a stream, and `canonicalize`s only in the branch where the whole chain is already known to exist.

## What is deliberately unchanged

- **Directories stay on the rename route.** Writing a plan to one fails either way, and it is what `write_to_removes_the_temp_file_when_the_rename_fails` uses to reach the cleanup branch.
- **A read-only directory holding a writable `plan.json` still fails.** That incompatibility is real, documented, and accepted.
- **A dangling symlink does not get its old behaviour back**: the plain write created its target, and the plan now replaces the link. Pinned by a test so the exception stays a decision rather than a surprise.

## Tests

The routing table is asserted **by stat alone, never by writing** — a regression in `is_stream_sink` under root would otherwise have the suite itself replace `/dev/null`. The end-to-end cases use a FIFO in a tempdir and check the FIFO survived *before* joining the reader: with the FIFO replaced no writer ever opens it, so a later join would hang CI rather than fail it. Verified by disabling the routing — the test fails in 0.01s.

`cargo test --all`: 658 pass / 0 fail. Clippy and fmt clean.

Note that `write_to_replaces_a_symlink_instead_of_following_it` from #109 is inverted here, deliberately: it pinned the behaviour this PR is changing.

## /review-loop での修正

このループ（correctness / interfaces & compat / security & data / tests の 4 レンズ + Codex GPT-6 Astra の cross-vendor レーン）で入った修正。

**must-fix 3 件を修正**

1. **macOS では `--plan-out /dev/stdout > plan.json` が動いていなかった。** 上の `stat -Lf` の観察は正しいが、そこから `canonicalize` に任せてよいという含意が macOS では成立しない。macOS の `realpath(3)` は `/dev/fd/1` をリダイレクト先の *ベース名* として devfs 内に解決するため、`canonicalize("/dev/stdout")` は `/dev/fd/plan.json`（存在しないパス）を返す。temp file が `/dev/fd` に作られ、`No such file or directory` で plan は書かれなかった。Linux は `/proc/self/fd/1` が magic link なので実ファイルに解決され、意図どおり動いていた。
2. **`metadata` が「不在」以外で失敗すると、生きた symlink を破壊して `Ok(())` を返していた。** 旧 `_` アームは全ての stat エラーを拾っていた。ターゲットが検索不可ディレクトリ配下にある link で実機再現済み（link が普通のファイルに置き換わり、ターゲットは旧内容のまま、成功扱い）。これは本 PR が防ごうとした「rename が宛先を壊す」事象そのもの。`NotFound` のみがこのアームを取るようにし、他は伝播させた。
3. **CHANGELOG が同一エントリ内で自己矛盾していた。** 「A symlink is followed, not replaced」と「a symlink at that path is replaced by the plan ... silently stops being updated」が併存。ほか、`/dev/stdout` が plain write を保つという記述、非保存の宛先は dangling symlink だけという記述（symlink のターゲットは inode とモードを失う。`0o600` → `0o644` を実機確認）、writable であるべき親ディレクトリがどちらかを言っていない点を修正。

修正は `canonicalize` の答えを再 stat し、`(dev, ino)` が元の `metadata` と一致したときだけ rename 経路に乗せる形。一致しなければ「頼まれた名前のまま write-through」に落ちる。

**テストの穴を 3 件塞いだ**（いずれも突然変異テストで確認）

- `canonicalize` を `read_link` に置換しても 657 件グリーンのままだった。symlink テストが絶対・同一ディレクトリのリンクを使っており、両者を区別できなかった。相対・サブディレクトリのリンクに変え、ターゲットの inode 交代を assert して pin。
- `is_socket()` を削除してもグリーンのままだった。`UnixListener::bind` で stat のみのルーティング表に追加。
- stat エラーのアームを旧フォールスルーに戻してもグリーンのままだった。新テスト `write_to_errors_rather_than_replacing_a_link_it_cannot_stat` で pin（root では検出できないので早期 return）。

**残る blind spot**（未対応・既知）

- **`is_same_file` ガード自体は未 pin。** 2 つの解決が食い違う宛先（`/dev/fd` 形状）は tempdir 上に作れないため、ガードを外しても suite はグリーンのまま。macOS 実機でのみ確認。
- **Linux 側は未実行。** リダイレクトされた `/dev/stdout` が rename 経路を取り、shell の fd 1 が unlink 済み inode に残る挙動はコード読解のみ。手元に Linux 環境がなく検証不能（refuted ではない）。
- **`is_block_device()` は未 pin、かつ分類として非対称。** block device への plain write は raw disk を破壊するが、rename ならデバイスノードが消えるだけでディスクは残る。「rename が壊す宛先」という本関数の基準と逆向き。ただし v0.20.0 の plain write も同じ破壊をしていたので、本 PR が持ち込んだものではない。方針判断はオーナーに委ねる。
- **Windows はカバレッジゼロ。** 新テストは全て `#[cfg(unix)]` だが、CI matrix には `windows-latest` があり、symlink（reparse point）のルーティングはそこでも変わっている。
- **CodeRabbit の TOCTOU 指摘（未解決スレッド）への回答**: symlink 追従による書き込み先すり替えは本 PR が導入したものではない。直近リリース v0.20.0 の `write_to` は `std::fs::write(path, json)` で、これも symlink を追従してターゲットを truncate していた（#109 が一時的にその挙動を変え、#110 が戻した形）。本 PR で新しいのは temp sibling が *ターゲット側* のディレクトリに作られる点で、オペレータが指定していないディレクトリにファイルが現れうる。TOCTOU 窓自体は残っており、閉じるには `O_NOFOLLOW` / dirfd ベースの書き換えが要る。
- このループはコードを **実行していない**（`cargo test` / clippy / fmt / rustdoc と上記の実機再現のみ）。`braze-sync` 本体を Braze API に対して走らせてはいない。
- 4 レンズは **同一モデルの別視点** であって独立レビュアーではない。異ベンダーは Codex レーンのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `--plan-out` now writes through device nodes, FIFOs, and sockets without replacing them, preserving their stream behavior.
  - Symlinks to existing files are followed and remain intact during atomic updates.
  - Dangling symlinks are replaced instead of creating their missing targets.
  - Atomic writes continue to enforce writable parent directories, bind-mount restrictions, and temporary filename space requirements.

- **Documentation**
  - Updated the changelog to accurately describe destination handling and platform-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
