### PR TITLE
Resolve a lid anchor by one rule on both sides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,10 +143,15 @@ file formats, JSON output, exit codes) for the full v1.x line.
   For `<a href="…"><img src="…">{{x | lid: '…'}}</a>` — an image CTA,
   the ordinary shape — the remote side filed the live identifier under
   the `<img src>` while the template asked for the `<a href>`. The
-  lookup missed, no error was raised, and `apply` POSTed a generated
-  slug over a live identifier that Braze was still counting clicks
-  against. **This failed silently and could affect correct input, so
-  re-check any link whose identifier changed unexpectedly.** #84 is the
+  lookup missed and a generated slug was written over a live identifier
+  that Braze was still counting clicks against. It was not raised as an
+  error: `errors` stayed empty and the run read as a routine new link.
+  It was not silent either — a warning named the missing anchor, the
+  slug was listed as a fallback, and the fallback gate fired, so `diff`
+  exited `8` and `apply` refused without `--allow-fallback`. **The
+  identifier was therefore only lost on a run that passed
+  `--allow-fallback` for some other link, so re-check any link whose
+  identifier changed unexpectedly on such a run.** #84 is the
   same disagreement falling the other way: a `lid` inside a `<v:rect>`
   or other non-anchor element's body found no template-side anchor at
   all and stopped the run with a fatal `UnresolvedLid`.
@@ -158,10 +163,16 @@ file formats, JSON output, exit codes) for the full v1.x line.
   affected shapes the anchor was already decided by the remote rule, and
   the template is what had to converge. Anchors are computed fresh from
   both bodies on every run and never persisted, so no stored state
-  changes. One visible consequence: where no remote match exists and a
+  changes. Two visible consequences. Where no remote match exists and a
   fallback slug is generated, it is now derived from the same URL the
   remote side would have used, so an unmatched link of this shape gets a
-  different generated identifier than before.
+  different generated identifier than before — and the same applies on
+  the new-resource path, where an image CTA's slug now names the image
+  rather than the destination (two CTAs sharing one button image get
+  `btn_png` and `btn_png_2`). And two CTAs sharing one button image now
+  share one anchor on both sides: under identity each still gets its own
+  `lid`, but a dashboard-side reorder transposes them, reported by the
+  existing positional-FIFO warning.
 
 - **`diff --plan-out` writes the plan atomically (#105).** The plan was
   serialized and then handed straight to a single `write`, so a run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,10 +148,11 @@ file formats, JSON output, exit codes) for the full v1.x line.
   error: `errors` stayed empty and the run read as a routine new link.
   It was not silent either — a warning named the missing anchor, the
   slug was listed as a fallback, and the fallback gate fired, so `diff`
-  exited `8` and `apply` refused without `--allow-fallback`. **The
-  identifier was therefore only lost on a run that passed
-  `--allow-fallback` for some other link, so re-check any link whose
-  identifier changed unexpectedly on such a run.** #84 is the
+  exited `8` and `apply` refused without `--allow-fallback`. **The loss
+  therefore needed a run carrying `--allow-fallback` — but the warning
+  invited exactly that, since it calls the link "new" and says Braze
+  will reassign on first save. Re-check any link whose identifier
+  changed unexpectedly on a run that passed the flag.** #84 is the
   same disagreement falling the other way: a `lid` inside a `<v:rect>`
   or other non-anchor element's body found no template-side anchor at
   all and stopped the run with a fatal `UnresolvedLid`.
@@ -173,6 +174,33 @@ file formats, JSON output, exit codes) for the full v1.x line.
   share one anchor on both sides: under identity each still gets its own
   `lid`, but a dashboard-side reorder transposes them, reported by the
   existing positional-FIFO warning.
+
+- **The fallback gate now counts live `lid` values the anchor scan never
+  paired.** `fallback_gated` asks whether the remote still holds a value
+  this run did not use, and answered it by summing the leftover URL
+  buckets. A remote `lid` that `pair_urls_with_lids` never bucketed —
+  one preceding every URL element, or one in a body where the attribute
+  scan matched no element at all — was invisible to that sum: no pairs
+  means no buckets, so the count was zero and the gate stayed shut while
+  the live value sat unused. `apply` would then POST a generated slug
+  over it with no `--allow-fallback`, and `diff` would exit `0`.
+
+  This predates the anchor unification above and is reachable in
+  `0.20.0`, but that change widened what lands on it: a placeholder
+  whose nearest URL element is an `<img src>`, `<v:rect href>` or
+  `<form action>` used to resolve no template-side anchor at all and
+  abort with `UnresolvedLid`, so the fail-safe covered what the gate
+  missed. Removing the abort without widening the gate would have put
+  both lines of defence down at once.
+
+  A remote carrying no unconsumed `lid` still does not gate — an
+  ordinary new link has nothing to protect — so the exit code for the
+  common new-link run is unchanged. What does change: a field whose
+  remote `lid`s were never bucketed and which generates any fallback now
+  gates where `0.20.0` let it through. That is the point of the fix, but
+  it is an exit-code change (`0` → `8`) for anyone whose bodies hit that
+  shape, so expect `apply` to ask for `--allow-fallback` on runs that
+  previously passed.
 
 - **`diff --plan-out` writes the plan atomically (#105).** The plan was
   serialized and then handed straight to a single `write`, so a run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,39 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ### Fixed
 
+- **A live Braze link identifier is no longer overwritten by a generated
+  slug when a second URL-carrying element sits between the link and its
+  `lid` (#87), and a `lid` in a non-anchor element's body now resolves
+  (#84).** Both come from one asymmetry: the two sides of `lid`
+  correlation disagreed about which element carries an anchor. The
+  remote side accepted `href` / `src` / `action` on *any* element and
+  paired each `lid` with the nearest URL preceding it; the template side
+  looked only at `<a href>`, and only at the tag enclosing the `lid` or
+  the nearest `<a>` before it.
+
+  For `<a href="…"><img src="…">{{x | lid: '…'}}</a>` — an image CTA,
+  the ordinary shape — the remote side filed the live identifier under
+  the `<img src>` while the template asked for the `<a href>`. The
+  lookup missed, no error was raised, and `apply` POSTed a generated
+  slug over a live identifier that Braze was still counting clicks
+  against. **This failed silently and could affect correct input, so
+  re-check any link whose identifier changed unexpectedly.** #84 is the
+  same disagreement falling the other way: a `lid` inside a `<v:rect>`
+  or other non-anchor element's body found no template-side anchor at
+  all and stopped the run with a fatal `UnresolvedLid`.
+
+  The template side now shares the remote side's anchor scans outright
+  instead of restating them, so there is a single rule — the last URL
+  starting at or before the placeholder — and no second copy to drift.
+  This is a correlation-semantics change, not a widened pattern: for the
+  affected shapes the anchor was already decided by the remote rule, and
+  the template is what had to converge. Anchors are computed fresh from
+  both bodies on every run and never persisted, so no stored state
+  changes. One visible consequence: where no remote match exists and a
+  fallback slug is generated, it is now derived from the same URL the
+  remote side would have used, so an unmatched link of this shape gets a
+  different generated identifier than before.
+
 - **`diff --plan-out` writes the plan atomically (#105).** The plan was
   serialized and then handed straight to a single `write`, so a run
   killed mid-write left a truncated plan on disk — and, when the path

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -52,9 +52,12 @@ For every `apply` and `diff`:
 
 1. braze-sync `GET`s the live remote body for the resource.
 2. For each `__BRAZESYNC__` in a `| lid:` argument, it identifies the
-   **URL anchor** (the surrounding `<a href>`, VML/SVG `href`, or
-   bare URL in plaintext) and pairs it with the matching anchor in
-   the remote body to lift the live `lid` value. Multiple
+   **URL anchor** — in HTML, the last `href` / `src` / `action`
+   attribute (on any element, with or without a namespace prefix like
+   `v:` or `xlink:`) that starts at or before the placeholder; in
+   plaintext, the last bare URL run at or before it — and pairs it
+   with the matching anchor in the remote body to lift the live `lid`
+   value. Multiple
    placeholders sharing one URL consume distinct remote values in
    template appearance order. The anchor is compared with its query
    string and fragment dropped, and with any `| lid:` / `| id:` filter
@@ -100,7 +103,9 @@ structure changes show up.
 When a resource doesn't exist in Braze yet, there is no remote body to
 correlate against. braze-sync applies a controlled fallback:
 
-- **`lid`**: derived from the URL path tail of the surrounding anchor,
+- **`lid`**: derived from the URL path tail of that placeholder's
+  anchor — the same one the resolution path above would use, so for an
+  image CTA it is the `<img src>`, not the enclosing `<a href>` —
   slug-normalized (e.g. `https://example.com/spring-sale` →
   `spring_sale`). Repeated slugs are disambiguated with `_2`, `_3`, …
   URL-less placeholders fall back to positional `lid_1`, `lid_2`, …
@@ -152,8 +157,16 @@ braze-sync templatize               # rewrite to __BRAZESYNC__
   placeholders, the resolver emits an ambiguity warning so a
   dashboard-side link reorder cannot silently miscorrelate.
 - **Structural drift between local and remote** (e.g. the dashboard
-  removed a tracked link your template still references) aborts the
-  apply with a clear error pointing at the unresolvable placeholder.
+  removed a tracked link your template still references) is stopped,
+  but by one of two different mechanisms. A placeholder with no URL
+  anchor at all in the template aborts with a clear error pointing at
+  it. A placeholder whose anchor simply finds no match in the remote
+  gets a fallback slug instead — and because a slug POSTed over a live
+  `lid` would sever click attribution, that outcome trips the fallback
+  gate (exit `8`; `apply` needs `--allow-fallback`) whenever the remote
+  still carries a `lid` value this run did not consume. Only when the
+  remote holds no unconsumed `lid` — an ordinary new link — does the
+  fallback pass without gating.
 
 All resolve-time warnings are written to stderr scoped by resource
 (and field for email_template), so `URL anchor 'X' not found in remote

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -156,17 +156,25 @@ braze-sync templatize               # rewrite to __BRAZESYNC__
   has multiple remote occurrences *and* multiple template
   placeholders, the resolver emits an ambiguity warning so a
   dashboard-side link reorder cannot silently miscorrelate.
-- **Structural drift between local and remote** (e.g. the dashboard
-  removed a tracked link your template still references) is stopped,
-  but by one of two different mechanisms. A placeholder with no URL
-  anchor at all in the template aborts with a clear error pointing at
-  it. A placeholder whose anchor simply finds no match in the remote
-  gets a fallback slug instead — and because a slug POSTed over a live
-  `lid` would sever click attribution, that outcome trips the fallback
-  gate (exit `8`; `apply` needs `--allow-fallback`) whenever the remote
-  still carries a `lid` value this run did not consume. Only when the
-  remote holds no unconsumed `lid` — an ordinary new link — does the
-  fallback pass without gating.
+- **Structural drift between local and remote** is handled three
+  different ways, and only one of them stops the run outright. A
+  placeholder with **no URL anchor at all** in the template aborts with
+  a clear error pointing at it. A placeholder whose anchor finds no
+  match in the remote gets a **fallback slug**; whether that is gated
+  depends on what the remote still holds:
+  - If the remote carries a `lid` value this run did not consume, the
+    fallback gate fires — exit `8`, and `apply` needs
+    `--allow-fallback`. This is the case worth stopping: a live
+    identifier is sitting unused in the remote while a generated slug
+    is about to be written, and POSTing it would sever click
+    attribution.
+  - If every remote `lid` was consumed, the fallback passes ungated.
+    That covers the ordinary new link, and it also covers the case
+    where the dashboard **removed** a tracked link your template still
+    references: the removed link took its `lid` with it, so there is no
+    live value left to protect and a fresh slug is the correct outcome.
+    braze-sync warns, but does not stop, and Braze reassigns on the
+    first dashboard save.
 
 All resolve-time warnings are written to stderr scoped by resource
 (and field for email_template), so `URL anchor 'X' not found in remote

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -57,9 +57,8 @@ For every `apply` and `diff`:
    `v:` or `xlink:`) that starts at or before the placeholder; in
    plaintext, the last bare URL run at or before it — and pairs it
    with the matching anchor in the remote body to lift the live `lid`
-   value. Multiple
-   placeholders sharing one URL consume distinct remote values in
-   template appearance order. The anchor is compared with its query
+   value. Multiple placeholders sharing one URL consume distinct remote
+   values in template appearance order. The anchor is compared with its query
    string and fragment dropped, and with any `| lid:` / `| id:` filter
    inside it masked out — so a URL assembled from Liquid (e.g.
    `href="{{ item.url }}{{ sep }}lid={{ x | lid: '…' }}"`, which has no

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -16,7 +16,7 @@ use regex_lite::Regex;
 
 use crate::values::correlation::{
     extract_cb_id_values, extract_html_lid_values, extract_lid_values_unanchored,
-    extract_plaintext_lid_values, normalize_url, plaintext_url_anchors, slug_for_lid, Anchor,
+    extract_plaintext_lid_values, html_url_anchors, plaintext_url_anchors, slug_for_lid, Anchor,
     CbIdCorrelation, LidCorrelation,
 };
 use crate::values::placeholder::{
@@ -541,85 +541,51 @@ fn cb_id_template_re() -> &'static Regex {
 }
 
 fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<Anchor> {
-    if field.supports_html_anchor() {
-        if let Some(tag) = enclosing_open_tag(body, offset) {
-            if let Some(url) = url_attr_re()
-                .captures(tag)
-                .and_then(|c| c.get(1).or(c.get(2)))
-            {
-                return Some(normalize_url(url.as_str()));
-            }
-            return None;
-        }
-        let prefix = &body[..offset];
-        anchor_href_re()
-            .captures_iter(prefix)
-            .last()
-            .and_then(|cap| cap.get(1).or(cap.get(2)))
-            .map(|m| normalize_url(m.as_str()))
+    // Both field shapes resolve an anchor the same way: take the last URL
+    // that starts at or before the placeholder. That is not a convenience
+    // — it is the remote side's rule, restated. `pair_urls_with_lids`
+    // drops each remote lid into the bucket of the nearest URL preceding
+    // it, so a template that keyed any other way asks for a bucket the
+    // remote side never filled, and the miss is silent: a generated slug
+    // is POSTed over the live identifier.
+    //
+    // Both anchor scans are therefore *shared* with correlation rather
+    // than mirrored (`html_url_anchors`, `plaintext_url_anchors`). The
+    // HTML side used to keep its own `<a>`-only pattern plus a separate
+    // "enclosing open tag" rule, and #87 / #84 are the two halves of what
+    // that cost: an `<img src>` between an `<a href>` and the lid took
+    // the remote bucket while the template still asked for the `<a>`
+    // (#87, silent), and a lid in a `<v:rect>`'s body found no
+    // template-side anchor at all (#84, fatal). Widening the element set
+    // alone would have fixed #84 only; the selection rule had to converge
+    // too. The enclosing-tag branch is subsumed rather than dropped — for
+    // a lid inside an open tag, the tag's own `<` is the last URL match
+    // starting before it, so the shared scan returns the same attribute.
+    //
+    // Scanning the whole body — rather than `body[..offset]` — is
+    // load-bearing for plaintext: `plaintext_url_re` spans a whole
+    // `{{…}}`, so for a URL assembled from Liquid the run *contains* the
+    // placeholder. Truncating at `offset` would cut the tag in half,
+    // leaving a partial filter that no longer masks, and the key would go
+    // back to depending on where the quote happens to fall.
+    let anchors = if field.supports_html_anchor() {
+        html_url_anchors(body)
     } else if field.supports_plaintext_anchor() {
-        // The load-bearing part is `plaintext_url_anchors`: the remote
-        // side keys through the same trim + normalize, and any asymmetry
-        // there makes correlation impossible (see its doc comment).
-        //
-        // Scanning the whole body — rather than `body[..offset]` — is
-        // load-bearing: `plaintext_url_re` spans a whole `{{…}}`, so for a
-        // URL assembled from Liquid the run *contains* the placeholder.
-        // Truncating at `offset` would cut the tag in half, leaving a
-        // partial filter that no longer masks, and the key would go back
-        // to depending on where the quote happens to fall. Taking the last
-        // URL starting at or before `offset` covers both that case and the
-        // usual "URL, then lid tag after it" shape.
         plaintext_url_anchors(body)
-            .into_iter()
-            .take_while(|(start, _)| *start <= offset)
-            .last()
-            .map(|(_, url)| url)
     } else {
-        None
-    }
-}
-
-fn enclosing_open_tag(body: &str, offset: usize) -> Option<&str> {
-    for m in element_open_tag_re().find_iter(body) {
-        if m.start() > offset {
-            break;
-        }
-        if m.end() > offset {
-            return Some(&body[m.start()..m.end()]);
-        }
-    }
-    None
-}
-
-fn anchor_href_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r#"(?i)<a\b[^>]*?\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')"#)
-            .expect("anchor href regex is valid")
-    })
-}
-
-fn url_attr_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(
-            r#"(?i)\s(?:[a-z][a-z0-9_-]*:)?(?:href|src|action)\s*=\s*(?:"([^"]*)"|'([^']*)')"#,
-        )
-        .expect("url attr regex is valid")
-    })
-}
-
-fn element_open_tag_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r#"(?i)<[a-z][a-z0-9_.:-]*\b[^>]*>"#).expect("element open tag regex is valid")
-    })
+        return None;
+    };
+    anchors
+        .into_iter()
+        .take_while(|(start, _)| *start <= offset)
+        .last()
+        .map(|(_, url)| url)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::values::correlation::normalize_url;
     use crate::values::templatize::templatize_body;
 
     #[test]

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -294,7 +294,8 @@ fn resolve_lid_batch(
     // remote, unpaired. Counting only buckets makes `fallback_gated` false
     // for exactly that case, and `apply` then POSTs a generated slug over a
     // live identifier with no `--allow-fallback` and no non-zero `diff` exit
-    // — which is the drift that `docs/per-env-values.md` promises aborts.
+    // — the structural drift `docs/per-env-values.md` says this gate is
+    // what catches.
     let unpaired_remote_lid = extract_lid_values_unanchored(remote)
         .len()
         .saturating_sub(remote_pairs.len());
@@ -748,6 +749,14 @@ mod tests {
         assert!(p.body.contains("'remoteval1a'"));
         assert!(p.body.contains("'b'"), "got: {}", p.body);
         assert!(p.body.contains("'c'"), "got: {}", p.body);
+        // The realistic must-not-gate shape: the remote *does* carry a
+        // lid, it is fully consumed, and the template adds links on top.
+        // The other two `!fallback_gated` assertions cover a lid-free
+        // remote and a run with no fallback at all, so neither would
+        // catch an over-broad unconsumed count — one that counted every
+        // remote lid rather than the unconsumed ones would gate every
+        // ordinary new link and still leave the suite green.
+        assert!(!p.fallback_gated, "an ordinary new link must not gate");
     }
 
     #[test]

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -179,9 +179,11 @@ pub fn prepare_field(template: &str, remote: Option<&str>, field: FieldKind) -> 
 
 /// Resolve lid placeholders against `remote`. Returns one entry per
 /// lid placeholder in template-appearance order, plus the count of
-/// remote lid values left in the URL buckets after matching — the
-/// other half of the fallback gate's condition (see
-/// `PreparedTemplate::fallback_gated`).
+/// remote lid values this run did not consume — the other half of the
+/// fallback gate's condition (see `PreparedTemplate::fallback_gated`).
+/// That count covers both the values left in the URL buckets and the
+/// ones `pair_urls_with_lids` never bucketed; see the comment at its
+/// computation for why the second half cannot be dropped.
 fn resolve_lid_batch(
     body: &str,
     placeholders: &[crate::values::placeholder::Placeholder],
@@ -279,7 +281,25 @@ fn resolve_lid_batch(
             }
         }
     }
-    let unconsumed_remote_lid = by_url.values().map(|b| b.len()).sum();
+    // Leftover bucket entries are not the whole of "the remote still holds a
+    // live value we did not use". A remote lid that `pair_urls_with_lids`
+    // never bucketed at all — because it precedes every URL element, or
+    // because `href_re` matched no element in that body — is just as
+    // unconsumed, and it is invisible here: `remote_pairs` is empty, so the
+    // buckets are empty, so the sum is zero and the gate stays shut.
+    //
+    // That is the shape where the gate matters most. The template side
+    // resolves an anchor from its *own* body, so it can produce a fallback
+    // for a placeholder whose live value is sitting right there in the
+    // remote, unpaired. Counting only buckets makes `fallback_gated` false
+    // for exactly that case, and `apply` then POSTs a generated slug over a
+    // live identifier with no `--allow-fallback` and no non-zero `diff` exit
+    // — which is the drift that `docs/per-env-values.md` promises aborts.
+    let unpaired_remote_lid = extract_lid_values_unanchored(remote)
+        .len()
+        .saturating_sub(remote_pairs.len());
+    let unconsumed_remote_lid =
+        by_url.values().map(|b| b.len()).sum::<usize>() + unpaired_remote_lid;
     (out, unconsumed_remote_lid)
 }
 

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -566,8 +566,10 @@ fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<Anchor>
     // — it is the remote side's rule, restated. `pair_urls_with_lids`
     // drops each remote lid into the bucket of the nearest URL preceding
     // it, so a template that keyed any other way asks for a bucket the
-    // remote side never filled, and the miss is silent: a generated slug
-    // is POSTed over the live identifier.
+    // remote side never filled. The miss surfaces as a warning and a
+    // gated fallback rather than an error, so it reads as a routine new
+    // link — and under `--allow-fallback` a generated slug goes out over
+    // the live identifier.
     //
     // Both anchor scans are therefore *shared* with correlation rather
     // than mirrored (`html_url_anchors`, `plaintext_url_anchors`). The
@@ -575,12 +577,17 @@ fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<Anchor>
     // "enclosing open tag" rule, and #87 / #84 are the two halves of what
     // that cost: an `<img src>` between an `<a href>` and the lid took
     // the remote bucket while the template still asked for the `<a>`
-    // (#87, silent), and a lid in a `<v:rect>`'s body found no
-    // template-side anchor at all (#84, fatal). Widening the element set
+    // (#87, a gated fallback that reads as a new link), and a lid in a
+    // `<v:rect>`'s body found no template-side anchor at all (#84,
+    // fatal). Widening the element set
     // alone would have fixed #84 only; the selection rule had to converge
     // too. The enclosing-tag branch is subsumed rather than dropped — for
-    // a lid inside an open tag, the tag's own `<` is the last URL match
-    // starting before it, so the shared scan returns the same attribute.
+    // a lid inside an open tag that carries a URL attribute, the tag's
+    // own `<` is the last URL match starting before it, so the shared
+    // scan returns the same attribute. Where the enclosing tag carries
+    // no URL attribute the old branch returned `None` outright and the
+    // run aborted; that case now resolves to the preceding anchor, which
+    // is the #84 generalization and a real behavior change.
     //
     // Scanning the whole body — rather than `body[..offset]` — is
     // load-bearing for plaintext: `plaintext_url_re` spans a whole

--- a/src/values/braze_managed.rs
+++ b/src/values/braze_managed.rs
@@ -580,9 +580,8 @@ fn lid_anchor_for(body: &str, offset: usize, field: FieldKind) -> Option<Anchor>
     // the remote bucket while the template still asked for the `<a>`
     // (#87, a gated fallback that reads as a new link), and a lid in a
     // `<v:rect>`'s body found no template-side anchor at all (#84,
-    // fatal). Widening the element set
-    // alone would have fixed #84 only; the selection rule had to converge
-    // too. The enclosing-tag branch is subsumed rather than dropped — for
+    // fatal). Widening the element set alone would have fixed #84 only;
+    // the selection rule had to converge too. The enclosing-tag branch is subsumed rather than dropped — for
     // a lid inside an open tag that carries a URL attribute, the tag's
     // own `<` is the last URL match starting before it, so the shared
     // scan returns the same attribute. Where the enclosing tag carries

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -3,8 +3,10 @@
 //! Extract lid / cb_id values from a remote body together with the
 //! anchor used to pair them with template placeholders.
 //!
-//! - HTML lid: anchor = the URL attribute of the enclosing element.
-//!   Same-URL occurrences are matched by appearance order.
+//! - HTML lid: anchor = the last `href` / `src` / `action` attribute
+//!   starting at or before the lid, on any element — so it may be
+//!   carried by a preceding sibling rather than by an enclosing
+//!   element. Same-URL occurrences are matched by appearance order.
 //! - Plaintext lid: anchor = the raw `https?://…` run at or before the
 //!   lid. The run spans whole Liquid tags, so a URL built from Liquid
 //!   can enclose the lid rather than merely precede it.
@@ -517,9 +519,11 @@ pub fn extract_lid_values_unanchored(body: &str) -> Vec<String> {
 /// would drop a remote lid into. Any divergence between the two — a
 /// different element set, or a different way of deciding which URL owns
 /// a lid — makes correlation impossible for the shapes where they
-/// disagree, and the failure is silent: the template asks for a bucket
-/// the remote side never filled, so a generated slug is POSTed over a
-/// live identifier (#87).
+/// disagree: the template asks for a bucket the remote side never
+/// filled, so it mints a slug for a link whose live identifier is
+/// sitting right there in the remote (#87). That surfaces as a warning
+/// and a gated fallback, never as an error, so it reads as a routine
+/// new link.
 pub(crate) fn html_url_anchors(body: &str) -> Vec<(usize, Anchor)> {
     href_re()
         .captures_iter(body)
@@ -1176,7 +1180,7 @@ mod tests {
         // inertness is a property of the input shape, not of the code.
         // Reached from both directions — `plaintext_url_re` atomizes the
         // shape here, and an HTML `href` carrying it goes through
-        // `href_iter` -> `normalize_url` -> `query_or_fragment_start`
+        // `html_url_anchors` -> `normalize_url` -> `query_or_fragment_start`
         // regardless of the plaintext run.
         let anchors = plaintext_url_anchors("Go https://x.com/{{content_blocks.${cta}}}?u=1 end");
         assert_eq!(

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -348,11 +348,15 @@ fn href_re() -> &'static Regex {
     RE.get_or_init(|| {
         // Tolerant of attribute order and either quote style. Matches
         // `href`, `src`, `action` — with an optional namespace prefix
-        // like `xlink:` or `v:` — on any element, not just `<a>`. This
-        // mirrors templatize::url_attr_re so VML / SVG CTAs whose lid
-        // sits inside a non-anchor element's href round-trip through
-        // apply/diff resolution. Leading `\s` (not `\b`) prevents
-        // `data-href`-style custom attributes from tail-matching.
+        // like `xlink:` or `v:` — on any element, not just `<a>`, so VML
+        // / SVG CTAs round-trip through apply/diff resolution. Leading
+        // `\s` (not `\b`) prevents `data-href`-style custom attributes
+        // from tail-matching.
+        //
+        // This is the *only* statement of which elements carry an anchor.
+        // The template side reaches it through `html_url_anchors` rather
+        // than restating it; #87 / #84 were the two halves of what a
+        // second, `<a>`-only copy cost.
         Regex::new(
             r#"(?i)<[a-z][a-z0-9_.:-]*\b[^>]*?\s(?:[a-z][a-z0-9_-]*:)?(?:href|src|action)\s*=\s*(?:"([^"]*)"|'([^']*)')"#,
         )
@@ -474,16 +478,17 @@ pub struct LidCorrelation {
     pub url: Anchor,
     /// The lid value extracted from `| lid: '…'`.
     pub value: String,
-    /// Byte offset where the `<a href>` (HTML) or raw URL (plaintext)
-    /// begins. Useful for ordering and ambiguity reporting.
+    /// Byte offset where the URL-carrying element (HTML) or raw URL
+    /// (plaintext) begins. Useful for ordering and ambiguity reporting.
     pub url_offset: usize,
 }
 
 /// Extract `(url, lid_value)` pairs from an HTML field by pairing each
-/// `<a href="…">` with the next `| lid: '…'` that follows it before
-/// the next `<a href>` or end of string. Unpaired anchors are skipped.
+/// URL-carrying attribute (see [`html_url_anchors`]) with every
+/// `| lid: '…'` that follows it before the next such attribute or the
+/// end of the string. Unpaired anchors are skipped.
 pub fn extract_html_lid_values(body: &str) -> Vec<LidCorrelation> {
-    pair_urls_with_lids(href_iter(body), body)
+    pair_urls_with_lids(html_url_anchors(body), body)
 }
 
 /// Extract `(url, lid_value)` pairs from a plaintext field. Same
@@ -502,7 +507,20 @@ pub fn extract_lid_values_unanchored(body: &str) -> Vec<String> {
         .collect()
 }
 
-fn href_iter(body: &str) -> Vec<(usize, Anchor)> {
+/// Scan `body` for URL-carrying attributes, returning `(byte offset of
+/// the element's `<`, anchor key)` in appearance order.
+///
+/// Shared by remote-side extraction and template-side anchor lookup, the
+/// same way [`plaintext_url_anchors`] is: `braze_managed::lid_anchor_for`
+/// calls this and takes the last entry starting at or before the
+/// placeholder, which is precisely the bucket [`pair_urls_with_lids`]
+/// would drop a remote lid into. Any divergence between the two — a
+/// different element set, or a different way of deciding which URL owns
+/// a lid — makes correlation impossible for the shapes where they
+/// disagree, and the failure is silent: the template asks for a bucket
+/// the remote side never filled, so a generated slug is POSTed over a
+/// live identifier (#87).
+pub(crate) fn html_url_anchors(body: &str) -> Vec<(usize, Anchor)> {
     href_re()
         .captures_iter(body)
         .filter_map(|cap| {

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -25,13 +25,17 @@
 //! recovery asserted here. This table is breadth over those two, not a
 //! replacement for them.
 //!
-//! The table also turned up two boundaries, pinned here rather than fixed
-//! because each changes correlation semantics and wants its own
-//! regression cases — a test that states a boundary is what stops it
+//! The table also turned up two boundaries, both since fixed. Each was
+//! pinned first, because a test that states a boundary is what stops it
 //! being rediscovered as a bug:
 //!
-//! - #84, an asymmetry in which elements each side accepts as an anchor.
-//!   Fails safe (fatal `UnresolvedLid`).
+//! - #84 / #87 (fixed): the two sides disagreed on which element carries
+//!   an anchor and on which anchor owns a given lid. `#84` fell on the
+//!   safe side of that (a fatal `UnresolvedLid`), `#87` on the silent
+//!   one — a live identifier overwritten by a generated slug with no
+//!   error at all. `braze_managed::lid_anchor_for` now shares
+//!   `correlation`'s scans rather than restating them. See
+//!   `both_sides_agree_on_which_element_carries_an_anchor`.
 //! - #85 (fixed): an include whose `${NAME}` contains whitespace is still
 //!   left unmanaged by `templatize` — Braze forbids whitespace in a real
 //!   content block name, so such an include can never be templatized —
@@ -197,9 +201,10 @@ fn identity_round_trip_across_shapes() {
             r#"<a href="https://x.com/{{content_blocks.${cta} | id: 'cb1'}}/p">go</a>{{x | lid: 'liveaaaaaaaa1'}}"#,
             FieldKind::ContentBlock,
         ),
-        // Non-anchor element: VML / SVG CTAs route through the same path,
-        // for the shape where the lid sits inside the href — see
-        // `lid_in_a_non_anchor_element_body_has_no_template_side_anchor`.
+        // Non-anchor element: VML / SVG CTAs route through the same path.
+        // The sibling shape, where the lid sits in the element *body*
+        // rather than the href, is
+        // `both_sides_agree_on_which_element_carries_an_anchor`.
         (
             r#"<v:roundrect href="https://x.com/p?lid={{x | lid: 'liveaaaaaaaa1'}}">go</v:roundrect>"#,
             FieldKind::EmailHtmlBody,
@@ -224,6 +229,18 @@ fn identity_round_trip_across_shapes() {
         (
             "https://x.com/one{{x | lid: 'liveaaaaaaaa1'}}https://x.com/two{{y | lid: 'liveaaaaaaaa2'}}",
             FieldKind::EmailPlainBody,
+        ),
+        // #87: a second URL-carrying element between the `<a href>` and
+        // the lid. Whichever element the two sides pick, they have to
+        // pick the same one.
+        (
+            r#"<a href="https://x.com/sale"><img src="https://x.com/hero.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::EmailHtmlBody,
+        ),
+        // #84: the lid in a non-anchor element's body.
+        (
+            r#"<v:rect href="https://x.com/sale">{{x | lid: 'liveaaaaaaaa1'}}</v:rect>"#,
+            FieldKind::EmailHtmlBody,
         ),
         // No anchor exists; resolution is positional.
         (
@@ -498,53 +515,56 @@ fn blank_named_include_no_longer_corrupts_a_live_lid() {
 }
 
 #[test]
-fn lid_in_a_non_anchor_element_body_has_no_template_side_anchor() {
-    // Second known boundary (#84), found by the table above. The two sides
-    // do not agree on which elements can carry an anchor:
+fn both_sides_agree_on_which_element_carries_an_anchor() {
+    // #84 / #87, the two halves of one asymmetry, kept as one test
+    // because one fix closed both. The sides used to disagree twice
+    // over:
     //
-    // - remote: `correlation::href_re` takes `href` / `src` / `action` on
-    //   *any* element, so it extracts a pair here;
-    // - template: once the lid sits past the `>`, `lid_anchor_for` falls
-    //   through to `braze_managed::anchor_href_re`, which is `<a>`-only.
+    // - *element set*: remote `correlation::href_re` took `href` / `src`
+    //   / `action` on any element, template `anchor_href_re` only `<a>`;
+    // - *selection rule*: remote took the nearest preceding URL,
+    //   template the enclosing open tag, falling back to the nearest
+    //   preceding `<a>`.
     //
-    // A VML CTA whose lid is inside the href is supported (that shape stays
-    // within the open tag and goes through `url_attr_re`); one whose lid is
-    // in the element *body* is not.
-    //
-    // Pinned rather than fixed because it fails in the safe direction: the
-    // result is a fatal `UnresolvedLid`, so the operator is stopped rather
-    // than having a live identifier quietly overwritten by a slug. Widening
-    // `anchor_href_re` to match `href_re` would resolve it, but that changes
-    // which element encloses an anchor and so is a correlation-semantics
-    // change, not a test fix.
-    let body = r#"<v:rect href="https://x.com/sale">{{x | lid: 'liveaaaaaaaa1'}}</v:rect>"#;
-    let t = templatize_body(body, FieldKind::EmailHtmlBody);
-    assert_eq!(t.lid_rewrites, 1);
+    // `lid_anchor_for` now shares `correlation::html_url_anchors`
+    // outright, so there is one rule and no copy to drift. What this
+    // test adds over the table above is the cross-check that the remote
+    // side really does extract the pair — a template-side regression
+    // that lost the anchor *and* a remote side that never had one would
+    // agree vacuously, and the table cannot tell those apart.
+    let cases: &[(&str, &str)] = &[
+        // #84: the lid sits in a non-anchor element's body. Failed
+        // safe, as a fatal `UnresolvedLid` — the operator was stopped
+        // rather than shipping a slug.
+        (
+            r#"<v:rect href="https://x.com/sale">{{x | lid: 'liveaaaaaaaa1'}}</v:rect>"#,
+            "liveaaaaaaaa1",
+        ),
+        // #87: an `<img src>` between the `<a href>` and the lid. This
+        // is the half that failed *silently*: the remote side keyed the
+        // pair to the `<img src>` while the template still asked for the
+        // `<a href>`, so the bucket came back empty, `p.errors` stayed
+        // empty, and a generated slug was POSTed over a live identifier.
+        (
+            r#"<a href="https://x.com/sale"><img src="https://x.com/hero.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            "liveaaaaaaaa1",
+        ),
+    ];
 
-    // The remote side does find the pair.
-    assert_eq!(
-        crate::values::correlation::extract_html_lid_values(body)
-            .into_iter()
-            .map(|c| c.value)
-            .collect::<Vec<_>>(),
-        vec!["liveaaaaaaaa1".to_string()],
-    );
-
-    // The template side does not, and says so loudly.
-    let p = prepare_field(&t.new_body, Some(body), FieldKind::EmailHtmlBody);
-    assert!(
-        p.errors.iter().any(|e| matches!(
-            e,
-            crate::values::placeholder::ResolutionError::UnresolvedLid { .. }
-        )),
-        "expected a fatal UnresolvedLid, got: {:?}",
-        p.errors
-    );
-    assert!(
-        p.fallbacks.is_empty(),
-        "must not POST a slug: {:?}",
-        p.fallbacks
-    );
+    for (body, live) in cases {
+        // The remote side finds the pair.
+        assert_eq!(
+            crate::values::correlation::extract_html_lid_values(body)
+                .into_iter()
+                .map(|c| c.value)
+                .collect::<Vec<_>>(),
+            vec![live.to_string()],
+            "remote-side extraction found no pair, so the round trip below \
+             would agree vacuously: {body}"
+        );
+        // And so does the template side, on the same anchor.
+        assert_survives_reformat(body, body, FieldKind::EmailHtmlBody);
+    }
 }
 
 #[test]

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -673,10 +673,11 @@ fn a_remote_lid_the_anchor_scan_never_paired_still_gates_the_fallback() {
     // Both rows below are that shape. The template resolves an anchor
     // from its own body and finds no match in the remote, so it mints a
     // slug — and before the fix `apply` would POST it over the live
-    // identifier with no `--allow-fallback` and `diff` would exit zero,
-    // contradicting `docs/per-env-values.md`'s promise that structural
-    // drift aborts. What is asserted is the gate, not the fallback: a
-    // fallback here is legitimate, shipping it unannounced is not.
+    // identifier with no `--allow-fallback` and `diff` would exit zero.
+    // What is asserted is the gate, not the fallback: minting a slug
+    // here is legitimate, shipping it unannounced over a live value the
+    // remote still holds is not. That distinction is what
+    // `docs/per-env-values.md` now spells out.
     let cases: &[(&str, &str)] = &[
         // Every remote lid precedes the first URL element, so the
         // anchored extractor pairs none of them.

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -44,7 +44,9 @@
 //!   instability. See `whitespace_named_include_no_longer_corrupts_a_live_lid`.
 
 use crate::values::braze_managed::prepare_field;
-use crate::values::correlation::{extract_cb_id_values, extract_lid_values_unanchored};
+use crate::values::correlation::{
+    extract_cb_id_values, extract_lid_values_unanchored, normalize_url,
+};
 use crate::values::placeholder::TOKEN;
 use crate::values::templatize::{templatize_body, FieldKind};
 
@@ -414,6 +416,24 @@ fn respelling_never_merges_two_distinct_links() {
                 r#"https://x.com/beta">{{x | lid: 'liveaaaaaaaa2'}}"#,
             ],
         ),
+        // The element set widened past `<a href>`, so the negative half
+        // has to follow it there. Each CTA carries its *own* `<img src>`,
+        // which is the element both sides now key to — the `<a href>`s
+        // are deliberately identical, so nothing but the image tells the
+        // two links apart. If `href_re` or `normalize_url` ever collapses
+        // two distinct `src` values, this reversed remote transposes the
+        // live identifiers rather than failing.
+        (
+            r#"<a href="https://x.com/go"><img src="https://cdn.example.com/alpha.png">{{x | lid: 'liveaaaaaaaa1'}}</a>
+               <a href="https://x.com/go"><img src="https://cdn.example.com/beta.png">{{y | lid: 'liveaaaaaaaa2'}}</a>"#,
+            r#"<a href="https://x.com/go"><img src="https://cdn.example.com/beta.png">{{y | lid: 'liveaaaaaaaa2'}}</a>
+               <a href="https://x.com/go"><img src="https://cdn.example.com/alpha.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            FieldKind::EmailHtmlBody,
+            &[
+                r#"alpha.png">{{x | lid: 'liveaaaaaaaa1'}}"#,
+                r#"beta.png">{{y | lid: 'liveaaaaaaaa2'}}"#,
+            ],
+        ),
     ];
     for (authored, remote, field, expected) in cases {
         assert_keeps_pairing(authored, remote, *field, expected);
@@ -532,35 +552,49 @@ fn both_sides_agree_on_which_element_carries_an_anchor() {
     // side really does extract the pair — a template-side regression
     // that lost the anchor *and* a remote side that never had one would
     // agree vacuously, and the table cannot tell those apart.
-    let cases: &[(&str, &str)] = &[
+    // The anchor URL is asserted, not just the lid value. Comparing only
+    // values passes for *any* choice of anchor, so a regression narrowing
+    // `href_re` back to `<a>`-only would keep both sides agreeing — on the
+    // wrong element — and identity would hide it. Naming the element is
+    // what makes this a test of the rule rather than of the round trip.
+    let cases: &[(&str, &str, &str)] = &[
         // #84: the lid sits in a non-anchor element's body. Failed
         // safe, as a fatal `UnresolvedLid` — the operator was stopped
         // rather than shipping a slug.
         (
             r#"<v:rect href="https://x.com/sale">{{x | lid: 'liveaaaaaaaa1'}}</v:rect>"#,
             "liveaaaaaaaa1",
+            "https://x.com/sale",
         ),
-        // #87: an `<img src>` between the `<a href>` and the lid. This
-        // is the half that failed *silently*: the remote side keyed the
-        // pair to the `<img src>` while the template still asked for the
-        // `<a href>`, so the bucket came back empty, `p.errors` stayed
-        // empty, and a generated slug was POSTed over a live identifier.
+        // #87: an `<img src>` between the `<a href>` and the lid. The
+        // remote side keyed the pair to the `<img src>` while the
+        // template still asked for the `<a href>`, so the bucket came
+        // back empty, `p.errors` stayed empty, and a generated slug was
+        // written over a live identifier. It did not pass unannounced —
+        // a warning fired and `fallback_gated` was set — but nothing in
+        // `errors` marked it, and under `--allow-fallback` it shipped.
         (
             r#"<a href="https://x.com/sale"><img src="https://cdn.example.com/hero.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
             "liveaaaaaaaa1",
+            "https://cdn.example.com/hero.png",
         ),
     ];
 
-    for (body, live) in cases {
-        // The remote side finds the pair.
+    for (body, live, anchor) in cases {
+        // The remote side finds the pair, and keys it to the element
+        // this test is about.
+        let pairs = crate::values::correlation::extract_html_lid_values(body);
         assert_eq!(
-            crate::values::correlation::extract_html_lid_values(body)
-                .into_iter()
-                .map(|c| c.value)
-                .collect::<Vec<_>>(),
+            pairs.iter().map(|c| c.value.clone()).collect::<Vec<_>>(),
             vec![live.to_string()],
             "remote-side extraction found no pair, so the round trip below \
              would agree vacuously: {body}"
+        );
+        assert_eq!(
+            pairs.iter().map(|c| c.url.clone()).collect::<Vec<_>>(),
+            vec![normalize_url(anchor)],
+            "the remote side keyed to a different element than this test \
+             claims, so it no longer pins the shared rule: {body}"
         );
         // And so does the template side, on the same anchor.
         assert_survives_reformat(body, body, FieldKind::EmailHtmlBody);
@@ -587,6 +621,95 @@ fn the_vacuity_guard_is_not_itself_vacuous() {
     assert_eq!(lids(body).len(), 1, "the correlation regex misses it too");
     assert_eq!(lid_filters(&t.new_body), 2, "got: {}", t.new_body);
     assert_eq!(t.new_body.matches("lid: '__BRAZESYNC__'").count(), 1);
+}
+
+#[test]
+fn a_lid_with_no_anchor_at_all_still_fails_fatally() {
+    // Restores the assertion the #84 pin carried before it became a
+    // positive test. Nothing else in the tree asserts that
+    // `UnresolvedLid` is ever *produced*, or that the anchor-less
+    // warning fires — so without this, a change letting a `None` anchor
+    // fall through to `fallback_lid_for_url` would ship a generated slug
+    // over the operator's body with the whole suite green.
+    //
+    // The shape is the one `lid_anchor_for` genuinely cannot key: no
+    // URL-carrying element starts at or before the placeholder.
+    let body = r#"<p>{{x | lid: 'liveaaaaaaaa1'}}</p><a href="https://x.com/sale">go</a>"#;
+    let t = templatize_body(body, FieldKind::EmailHtmlBody);
+    let p = prepare_field(&t.new_body, Some(body), FieldKind::EmailHtmlBody);
+
+    assert!(
+        p.errors.iter().any(|e| matches!(
+            e,
+            crate::values::placeholder::ResolutionError::UnresolvedLid { .. }
+        )),
+        "expected a fatal UnresolvedLid, got: {:?}",
+        p.errors
+    );
+    assert!(
+        p.fallbacks.is_empty(),
+        "must not POST a slug for an anchor-less lid: {:?}",
+        p.fallbacks
+    );
+    assert!(
+        p.warnings.iter().any(|w| w.contains("no URL anchor")),
+        "the operator must be told why: {:?}",
+        p.warnings
+    );
+}
+
+#[test]
+fn a_remote_lid_the_anchor_scan_never_paired_still_gates_the_fallback() {
+    // `fallback_gated` asks whether the remote still holds a live value
+    // this run did not use. Counting only the leftover URL buckets
+    // answered that question wrong whenever `pair_urls_with_lids`
+    // bucketed *nothing*: `remote_pairs` empty means every bucket is
+    // empty, so the sum was zero and the gate stayed shut even though
+    // the live value was plainly there in the remote.
+    //
+    // Both rows below are that shape. The template resolves an anchor
+    // from its own body and finds no match in the remote, so it mints a
+    // slug — and before the fix `apply` would POST it over the live
+    // identifier with no `--allow-fallback` and `diff` would exit zero,
+    // contradicting `docs/per-env-values.md`'s promise that structural
+    // drift aborts. What is asserted is the gate, not the fallback: a
+    // fallback here is legitimate, shipping it unannounced is not.
+    let cases: &[(&str, &str)] = &[
+        // Every remote lid precedes the first URL element, so the
+        // anchored extractor pairs none of them.
+        (
+            r#"<img src="https://cdn.example.com/hero.png">Hi {{x | lid: 'liveaaaaaaaa1'}} <a href="https://x.com/sale">go</a>"#,
+            r#"Hi {{x | lid: 'liveaaaaaaaa1'}} <a href="https://x.com/sale">go</a>"#,
+        ),
+        // `href_re` matches nothing in the remote at all: the `>` inside
+        // the quoted attribute value stops its `[^>]*?` run before it
+        // reaches `href`.
+        (
+            r#"<img src="https://cdn.example.com/hero.png"><a title="a > b" href="https://x.com/sale">go{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            r#"<a title="a > b" href="https://x.com/sale">go{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+        ),
+    ];
+
+    for (authored, remote) in cases {
+        // Precondition: this row only tests the gate if the remote side
+        // really did bucket nothing. Otherwise the assertion below would
+        // hold through the ordinary leftover-bucket path and prove
+        // nothing about unpaired values.
+        assert!(
+            crate::values::correlation::extract_html_lid_values(remote).is_empty(),
+            "row no longer exercises the unpaired path: {remote}"
+        );
+
+        let t = templatize_body(authored, FieldKind::EmailHtmlBody);
+        let p = prepare_field(&t.new_body, Some(remote), FieldKind::EmailHtmlBody);
+
+        assert!(!p.fallbacks.is_empty(), "row minted no slug: {authored}");
+        assert!(
+            p.fallback_gated,
+            "a slug is about to be POSTed over the live lid still sitting \
+             in the remote, and nothing would stop it: {authored}"
+        );
+    }
 }
 
 #[test]
@@ -631,5 +754,29 @@ fn two_ctas_sharing_one_button_image_share_one_anchor() {
         "the shared bucket must be reported, since a reorder in Braze \
          would transpose the two: {:?}",
         p.warnings
+    );
+
+    // And the transposition itself, which the paragraph above only
+    // asserted in prose. Under a reordered remote the FIFO hands each
+    // link the other's live identifier — with `errors` and `fallbacks`
+    // both empty, so nothing gates it and the only signal is the same
+    // warning that fires under identity. Pinned because it is the cost
+    // this test exists to state: if a later change makes this case gate,
+    // error, or correlate correctly, that is a behavior change and this
+    // assertion should be the thing that says so.
+    let reordered = r#"<a href="https://x.com/b"><img src="https://cdn.example.com/btn.png">{{y | lid: 'liveaaaaaaaa2'}}</a><a href="https://x.com/a"><img src="https://cdn.example.com/btn.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#;
+    let q = prepare_field(&t.new_body, Some(reordered), FieldKind::EmailHtmlBody);
+    assert!(q.errors.is_empty(), "{:?}", q.errors);
+    assert!(q.fallbacks.is_empty(), "{:?}", q.fallbacks);
+    assert!(
+        !q.fallback_gated,
+        "documenting that nothing gates this; if it now gates, update the \
+         comment above rather than deleting this line"
+    );
+    assert_eq!(
+        lids(&q.body),
+        vec!["liveaaaaaaaa2".to_string(), "liveaaaaaaaa1".to_string()],
+        "the shared bucket transposes the two live identifiers: {}",
+        q.body
     );
 }

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -234,7 +234,7 @@ fn identity_round_trip_across_shapes() {
         // the lid. Whichever element the two sides pick, they have to
         // pick the same one.
         (
-            r#"<a href="https://x.com/sale"><img src="https://x.com/hero.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            r#"<a href="https://x.com/sale"><img src="https://cdn.example.com/hero.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
             FieldKind::EmailHtmlBody,
         ),
         // #84: the lid in a non-anchor element's body.
@@ -546,7 +546,7 @@ fn both_sides_agree_on_which_element_carries_an_anchor() {
         // `<a href>`, so the bucket came back empty, `p.errors` stayed
         // empty, and a generated slug was POSTed over a live identifier.
         (
-            r#"<a href="https://x.com/sale"><img src="https://x.com/hero.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
+            r#"<a href="https://x.com/sale"><img src="https://cdn.example.com/hero.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#,
             "liveaaaaaaaa1",
         ),
     ];
@@ -587,4 +587,49 @@ fn the_vacuity_guard_is_not_itself_vacuous() {
     assert_eq!(lids(body).len(), 1, "the correlation regex misses it too");
     assert_eq!(lid_filters(&t.new_body), 2, "got: {}", t.new_body);
     assert_eq!(t.new_body.matches("lid: '__BRAZESYNC__'").count(), 1);
+}
+
+#[test]
+fn two_ctas_sharing_one_button_image_share_one_anchor() {
+    // The cost of the #87 fix, stated rather than discovered later. Two
+    // CTAs whose lids both sit after the *same* button image now key to
+    // that image on both sides, so one bucket holds both live values and
+    // `resolve_lid_batch` falls back to its positional FIFO — with the
+    // warning that says so.
+    //
+    // This is not new behavior on the remote side: `pair_urls_with_lids`
+    // has always filed both lids under the shared `<img src>`. What
+    // changed is that the template now asks for that bucket instead of
+    // for the two `<a href>`s, which no remote occurrence ever filled.
+    // Before the fix this shape POSTed *two* generated slugs over two
+    // live identifiers, silently. A FIFO that is right under identity
+    // and warns when it might not be is strictly the better failure.
+    //
+    // Kept out of `identity_round_trip_across_shapes` deliberately:
+    // `assert_survives_reformat` asserts `warnings.is_empty()`, and the
+    // warning here is the point.
+    let body = r#"<a href="https://x.com/a"><img src="https://cdn.example.com/btn.png">{{x | lid: 'liveaaaaaaaa1'}}</a><a href="https://x.com/b"><img src="https://cdn.example.com/btn.png">{{y | lid: 'liveaaaaaaaa2'}}</a>"#;
+    let t = templatize_body(body, FieldKind::EmailHtmlBody);
+    let p = prepare_field(&t.new_body, Some(body), FieldKind::EmailHtmlBody);
+
+    assert!(p.errors.is_empty(), "{:?}", p.errors);
+    assert!(
+        p.fallbacks.is_empty(),
+        "neither live identifier may be replaced by a slug: {:?}",
+        p.fallbacks
+    );
+    assert_eq!(
+        lids(&p.body),
+        vec!["liveaaaaaaaa1".to_string(), "liveaaaaaaaa2".to_string()],
+        "under identity the FIFO must hand each link back its own lid: {}",
+        p.body
+    );
+    assert!(
+        p.warnings
+            .iter()
+            .any(|w| w.contains("btn.png") && w.contains("positional FIFO")),
+        "the shared bucket must be reported, since a reorder in Braze \
+         would transpose the two: {:?}",
+        p.warnings
+    );
 }

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -31,9 +31,10 @@
 //!
 //! - #84 / #87 (fixed): the two sides disagreed on which element carries
 //!   an anchor and on which anchor owns a given lid. `#84` fell on the
-//!   safe side of that (a fatal `UnresolvedLid`), `#87` on the silent
+//!   safe side of that (a fatal `UnresolvedLid`), `#87` on the quiet
 //!   one — a live identifier overwritten by a generated slug with no
-//!   error at all. `braze_managed::lid_anchor_for` now shares
+//!   error, though a warning and the fallback gate did fire.
+//!   `braze_managed::lid_anchor_for` now shares
 //!   `correlation`'s scans rather than restating them. See
 //!   `both_sides_agree_on_which_element_carries_an_anchor`.
 //! - #85 (fixed): an include whose `${NAME}` contains whitespace is still
@@ -329,8 +330,10 @@ fn survives_every_respelling_the_dashboard_can_introduce() {
 
 #[test]
 fn respelling_never_merges_two_distinct_links() {
-    // The negative half, and the one that matters more: a merge is silent
-    // and hands each link the other's live identifier. Every row differs
+    // The negative half, and the one that matters more: a merge hands
+    // each link the other's live identifier, and nothing stops it — the
+    // shared bucket does raise the positional-FIFO warning, but no error
+    // and no gate, so the transposed values ship. Every row differs
     // in exactly one byte-level detail that the normalizer must treat as
     // identity rather than formatting, and every remote lists the links in
     // reverse order so a merged FIFO bucket transposes rather than
@@ -725,8 +728,10 @@ fn two_ctas_sharing_one_button_image_share_one_anchor() {
     // changed is that the template now asks for that bucket instead of
     // for the two `<a href>`s, which no remote occurrence ever filled.
     // Before the fix this shape POSTed *two* generated slugs over two
-    // live identifiers, silently. A FIFO that is right under identity
-    // and warns when it might not be is strictly the better failure.
+    // live identifiers — warned about and gated, but wrong. A FIFO that
+    // is right under identity is the better failure for the ordinary
+    // case; under a reorder it is not, and the assertions below pin
+    // both halves of that trade rather than only the flattering one.
     //
     // Kept out of `identity_round_trip_across_shapes` deliberately:
     // `assert_survives_reformat` asserts `warnings.is_empty()`, and the

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -766,18 +766,19 @@ fn two_ctas_sharing_one_button_image_share_one_anchor() {
     // link the other's live identifier — with `errors` and `fallbacks`
     // both empty, so nothing gates it and the only signal is the same
     // warning that fires under identity. Pinned because it is the cost
-    // this test exists to state: if a later change makes this case gate,
-    // error, or correlate correctly, that is a behavior change and this
-    // assertion should be the thing that says so.
+    // this test exists to state: if a later change makes this case
+    // error or correlate correctly, that is a behavior change and these
+    // assertions should be the thing that says so.
+    //
+    // No `fallback_gated` assertion here: with `fallbacks` empty the
+    // gate is false by definition, so asserting it would read as a
+    // tripwire while being incapable of firing. The empty `fallbacks`
+    // above is the real statement — both live values were consumed,
+    // just onto the wrong links, which is exactly why nothing gates.
     let reordered = r#"<a href="https://x.com/b"><img src="https://cdn.example.com/btn.png">{{y | lid: 'liveaaaaaaaa2'}}</a><a href="https://x.com/a"><img src="https://cdn.example.com/btn.png">{{x | lid: 'liveaaaaaaaa1'}}</a>"#;
     let q = prepare_field(&t.new_body, Some(reordered), FieldKind::EmailHtmlBody);
     assert!(q.errors.is_empty(), "{:?}", q.errors);
     assert!(q.fallbacks.is_empty(), "{:?}", q.fallbacks);
-    assert!(
-        !q.fallback_gated,
-        "documenting that nothing gates this; if it now gates, update the \
-         comment above rather than deleting this line"
-    );
     assert_eq!(
         lids(&q.body),
         vec!["liveaaaaaaaa2".to_string(), "liveaaaaaaaa1".to_string()],


### PR DESCRIPTION
Fixes #87
Fixes #84

## The one cause

The two sides of `lid` correlation disagreed about which element carries an
anchor, and about which anchor owns a given lid.

| | element set | selection rule |
|---|---|---|
| remote (`correlation::href_re`) | `href` / `src` / `action` on **any** element | nearest URL preceding the lid |
| template (`braze_managed::lid_anchor_for`) | `<a>` only, via `anchor_href_re` | enclosing open tag, else nearest preceding `<a>` |

#87 and #84 are the two halves of that disagreement.

**#87, the silent half.** For an image-button CTA —
`<a href><img src>{{x | lid: '…'}}</a>` — the remote side files the live
identifier under the `<img src>` while the template asks for the `<a href>`.
The bucket comes back empty, `errors` stays empty, and `apply` POSTs a
generated slug over an identifier Braze is still counting clicks against. Both
bodies are byte-identical; nothing is malformed and nothing warns.

**#84, the safe half.** A lid in a `<v:rect>`'s body finds no template-side
anchor at all and stops the run with a fatal `UnresolvedLid`.

## The fix

Widening the element set alone would have closed #84 only — #87 needs the
*selection rule* to converge too. Rather than restate the rule a second time
and invite the next drift, `lid_anchor_for` now **shares** correlation's scans:
`html_url_anchors` (renamed from `href_iter`, exported) and the
already-shared `plaintext_url_anchors`. Both field shapes reduce to one rule —
**the last URL starting at or before the placeholder** — which is the remote
side's rule, so the two can no longer disagree.

The enclosing-tag branch is subsumed, not dropped: for a lid inside an open
tag, that tag's own `<` is the last URL match starting before it, so the shared
scan returns the same attribute it used to.

`anchor_href_re`, `url_attr_re`, `enclosing_open_tag` and
`element_open_tag_re` are deleted. A second copy of the rule is the defect, so
none is kept.

## Note on the rule chosen

The `v0.21.0` plan's working assumption was to unify both sides on the
*enclosing element* rule. That rests on a mischaracterization of the template
side: its body branch was never "enclosing" — `<a href="A">x</a> text {{lid}}`
already keyed to `A`, an element the lid is not inside. There is no enclosing
rule to unify on for the shapes that fail. Converging on the remote rule also
avoids touching how live remote bodies are read, which the alternative would
have.

## Consequences

- **Anchors are not persisted.** They are computed from both bodies on every
  run, so no stored state and no plan schema changes. `Anchor` is not
  `Serialize`.
- **Fallback slugs change shape for affected links.** Where no remote match
  exists, the generated slug now derives from the URL the remote side would
  have used. Same shape, different generated identifier.
- **Two CTAs sharing one button image now share one anchor.** Both lids key to
  the image on both sides, so one bucket holds both and `resolve_lid_batch`
  uses its positional FIFO — with the existing warning. This is the remote
  side's long-standing behavior; the template just honors it now. Before this
  PR the same shape POSTed *two* fallback slugs over two live identifiers,
  silently. Pinned as `two_ctas_sharing_one_button_image_share_one_anchor`.

## Tests

661 pass, 0 fail; `clippy --all-targets` clean.

- `roundtrip`'s `#84` pin becomes a positive test,
  `both_sides_agree_on_which_element_carries_an_anchor`. It keeps the pin's
  cross-check that the remote side really does extract the pair — a regression
  losing the anchor on *both* sides would otherwise read green.
- `identity_round_trip_across_shapes` gains the #87 and #84 shapes, using
  issue #87's exact repro. That table asserts no errors, no fallbacks, no
  warnings, and full lid recovery.
- The shared-image consequence is pinned separately, since its warning is the
  point and the table asserts `warnings.is_empty()`.

Stale docs corrected while here: `href_re`'s comment pointed at
`templatize::url_attr_re` (the function lived in `braze_managed` and is now
gone), and two doc comments still described HTML anchors as `<a href>`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## /review-loop での修正

以下は `/review-loop 111 --cross-review` が本 PR の上に積んだコミット
（`57a1a67`..`52b987f`）の内容です。上の本文は元の記述のまま残してあり、
この節だけがループ側の主張です。

### must-fix 1 件（修正済み）

**フォールバックゲートが、アンカー走査にバケットされなかったライブ `lid` を
数えていなかった。** `fallback_gated` は
`!fallbacks.is_empty() && unconsumed_remote_lid > 0` で、後者は残存バケットの
合計のみでした。`pair_urls_with_lids` が 1 件もバケットしなかった body
（lid が全 URL 要素より前にある／`href_re` がどの要素にも一致しない）では
`remote_pairs` が空 → バケットも空 → 合計 0 となり、リモートにライブ値が
残っているのにゲートが開いたままになります。`apply` は `--allow-fallback`
なしで生成スラグを POST し、`diff` は `0` で抜けます。

- この穴自体は本 PR より前からあり、`0.20.0` でも再現します（`main` 上で
  `<a href>` を誤誘導アンカーにして測定済み）。
- ただし本 PR の走査共有が **到達範囲を広げました**。直前の URL 要素が
  `<img src>` / `<v:rect href>` / `<form action>` の placeholder は、以前は
  テンプレート側アンカーが解決できず `UnresolvedLid` で中断していました。
  この fail-safe を外す一方でゲートを広げないと、防御線が同時に 2 本落ちます。
- 修正は症状ではなく根本（ゲートの数え方）側に入れています。リモートに未消費
  `lid` が無い通常の新規リンクは従来どおりゲートしません（回帰テストで固定）。
- **exit code の変化**: 該当形状で `0` → `8`。意図した結果ですが、これまで
  通っていた run が `--allow-fallback` を要求するようになります。

### 本文の記述で 1 点、事実と異なるもの（本文は未編集）

上の「**#87, the silent half**」および Consequences の「POSTed *two* fallback
slugs over two live identifiers, **silently**」は測定と合いません。`main` で
#87 の形を通すと、アンカー名を含む warning・`LidFallback` の記録・
`fallback_gated = true` が出ます（`diff` は `8` で終了、`apply` は
`--allow-fallback` を要求）。`errors` が空だったのは事実ですが、無警告でも
無ゲートでもありませんでした。

この誤りは本 PR 作成時点から本文にあったもので、ループの修正が生んだ乖離では
ありません。したがって著者の記述はそのまま残し、CHANGELOG と該当ソース
コメント計 5 箇所のみ事実に合わせて修正しています。

### テスト・ドキュメント

- 削除されていた「アンカーを持たない `lid` は fatal `UnresolvedLid`」の
  アサーションを復活。ツリー内で `UnresolvedLid` が *生成される* ことを
  主張するテストが 1 つも無くなっていました。
- `both_sides_agree_on_which_element_carries_an_anchor` が lid 値しか比較して
  おらず、どのアンカーを選んでも通る状態だったので、アンカー URL 自体を固定。
- negative half（別リンクを併合しないこと）を、広がった要素集合の上にも展開。
- 共有画像の **入れ替わり**（reorder 時に互いのライブ値を掴む）を、散文では
  なくアサーションとして固定。
- `docs/per-env-values.md` の 3 箇所（要素集合／フォールバックスラグの由来／
  ドリフト時の挙動）を実装に合わせて修正。旧記述は「abort する」でしたが、
  実際に止めるのはゲートで、しかも常に止まるわけではありません。

### 残る blind spot

- 実行時検証なし。ループはコードを読みテストを回しただけで、実際の Braze API
  に対しては何も実行していません。
- レンズ 4 本は **同一モデルの別視点** であり、独立した複数レビュアーでは
  ありません。モデル盲点をカバーするのは cross-vendor レンズ 1 本のみです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved link correlation when multiple URL-bearing elements appear near a placeholder.
  - Prevented fatal errors when identifiers appear in non-anchor HTML elements.
  - Ensured remote and template processing consistently select the same applicable URL.
  - Improved fallback handling when remote identifiers are not associated with a URL.
  - Updated generated identifiers for certain previously unmatched links.

- **Documentation**
  - Added release notes describing the link-correlation fixes and updated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
