### PR TITLE
Normalize the quote delimiter, not the quoted content (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,12 +151,20 @@ file formats, JSON output, exit codes) for the full v1.x line.
   The canonical delimiter is `'`, except for a value containing a `'`:
   Liquid has no string escapes, so such a value can only ever be written
   with `"`, and both sides therefore already agree on its spelling.
-  Re-quoting it anyway would turn `"a'b"` into `'a'b'`, which denotes
-  something else.
+  Re-quoting it anyway would turn `"a'b"` into `'a'b'`, a key that
+  transcribes no value anyone wrote.
 
   Unlike the four preceding normalization fixes (#68 / #70 / #73 / #77),
-  this closes an axis rather than approximating one: Liquid has exactly
-  two quote characters, so there is no next spelling behind this one.
+  this closes an axis rather than approximating one for the ordinary
+  case: Liquid has exactly two quote characters, so there is no next
+  spelling behind this one. Two documented residuals are unchanged and
+  still key on their exact spelling, quote style included — an unclosed
+  `{{`, and a tag carrying a literal `}}` inside a quoted argument, which
+  ends the tag early and leaves the quote after it unterminated. In the
+  other direction, literal `{{…}}` inside a `{% raw %}` block is
+  normalized like a real tag, so the fold merges two raw literals that
+  differ only in quote style — one more axis on a region the whitespace
+  pass already merged. See `docs/per-env-values.md`.
 
 - **A live Braze link identifier is no longer overwritten by a generated
   slug when a second URL-carrying element sits between the link and its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,34 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ### Fixed
 
+- **Quote style on an unrelated Liquid filter argument no longer costs a
+  link its live `lid` (#88).** `{{ segment | default: 'sale' }}` and
+  `{{ segment | default: "sale" }}` denote the same string in Liquid, but
+  the anchor key kept the delimiter bytes as written, so a dashboard-side
+  quote flip on a filter this tool does not manage made the two sides key
+  the link differently. The live identifier was then replaced by a
+  generated slug. As in #87 this was recorded rather than silent — a
+  warning named the anchor, the slug was listed as a fallback and the
+  fallback gate fired (`diff` exits `8`, `apply` refuses without
+  `--allow-fallback`) — so the loss needed a run carrying that flag.
+
+  Quoted regions are now re-emitted with a canonical delimiter while
+  their **contents stay verbatim**. The spaces in
+  `{{ sep | default: ' - ' }}` are the value, and collapsing them would
+  merge two genuinely different links onto one anchor — a strictly worse
+  failure, since the FIFO pairing would then hand each link the other's
+  live identifier. Only the delimiter moves.
+
+  The canonical delimiter is `'`, except for a value containing a `'`:
+  Liquid has no string escapes, so such a value can only ever be written
+  with `"`, and both sides therefore already agree on its spelling.
+  Re-quoting it anyway would turn `"a'b"` into `'a'b'`, which denotes
+  something else.
+
+  Unlike the four preceding normalization fixes (#68 / #70 / #73 / #77),
+  this closes an axis rather than approximating one: Liquid has exactly
+  two quote characters, so there is no next spelling behind this one.
+
 - **A live Braze link identifier is no longer overwritten by a generated
   slug when a second URL-carrying element sits between the link and its
   `lid` (#87), and a `lid` in a non-anchor element's body now resolves

--- a/docs/per-env-values.md
+++ b/docs/per-env-values.md
@@ -73,11 +73,26 @@ For every `apply` and `diff`:
    `${Plan (US)}` vs `${Plan(US)}`) stay distinct anchors, as they must.
    The padding *around* a name is formatting, though, so `${ plan }` and
    `${plan}` are one anchor.
-   Two narrower cases still key on their spacing, and a reformat there
-   falls back to a generated `lid`: an *unclosed* `{{`, whose extent is
-   unknown, and a tag carrying a literal `}}` inside a quoted argument,
-   which ends the tag early. Both are rare enough that widening the rule
-   was judged not worth the risk of merging two distinct links.
+   A quoted argument's *delimiter* is formatting rather than identity, so
+   `{{ segment | default: 'sale' }}` and `{{ segment | default: "sale" }}`
+   are one anchor: they denote the same string in Liquid, and a dashboard
+   quote flip on a filter this tool does not manage must not cost the link
+   its live `lid`. Only the delimiter moves — the bytes *between* the
+   quotes stay identity, which is what keeps `' - '` and `'-'` apart. A
+   value containing a `'` keeps its `"` delimiters, since Liquid has no
+   string escapes and that is the only way such a value can be written.
+   Two narrower cases still key on their exact spelling — spacing *and*
+   quote style alike — and a reformat there falls back to a generated
+   `lid`: an *unclosed* `{{`, whose extent is unknown, and a tag carrying
+   a literal `}}` inside a quoted argument, which ends the tag early (so
+   the quote that follows it never closes, and the rest of the tag is kept
+   verbatim). Both are rare enough that widening the rule was judged not
+   worth the risk of merging two distinct links.
+   One region is merged rather than kept apart: literal `{{…}}` text
+   inside a `{% raw %}` block is normalized like a real tag, even though
+   `raw` makes those bytes the rendered output. Two raw literals differing
+   only in spacing or quote style therefore share one anchor. Reaching it
+   needs a raw block *and* a Liquid-shaped literal inside a URL.
    Separately, a content block whose *name* contains a space
    (`{{content_blocks.${Plan (US)} | id: '…'}}`) does not correlate at
    all — no `${NAME}` pattern in braze-sync accepts one — so its `cb_id`

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -1020,9 +1020,14 @@ mod tests {
             normalize_url(r#"https://x.com/{{ sep | default: " - " }}/a"#),
             "https://x.com/{{sep|default:' - '}}/a"
         );
-        // A content that holds a `'` cannot be re-delimited — `'a'b'`
-        // would denote `a` — so it stays `"`-quoted and stays distinct
-        // from the link whose argument really is `a`.
+        // A content that holds a `'` cannot be re-delimited: `'a'b'` would
+        // denote `a`. It stays `"`-quoted — which is also the only way
+        // Liquid can spell it, so both sides already agree — and so stays
+        // distinct from the link whose argument really is `a`.
+        assert_eq!(
+            normalize_url(r#"https://x.com/{{ sep | default: "a'b" }}/p"#),
+            r#"https://x.com/{{sep|default:"a'b"}}/p"#
+        );
         assert_ne!(
             normalize_url(r#"https://x.com/{{ sep | default: "a'b" }}/p"#),
             normalize_url("https://x.com/{{ sep | default: 'a' }}/p")

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -141,6 +141,20 @@ pub fn normalize_url(url: &str) -> Anchor {
 /// copied verbatim. Liquid has no string escapes, so a quote of the
 /// opening kind always closes the run.
 ///
+/// The *delimiter* is not content, though, and is normalized (#88):
+/// `'sale'` and `"sale"` denote the same string, so leaving both spellings
+/// in the key let a dashboard-side quote flip on an unrelated filter
+/// argument cost the link its live `lid`. Unlike whitespace, this is a
+/// closed axis — Liquid has exactly two quote characters — so re-emitting
+/// one canonical kind closes it rather than approximating it.
+///
+/// The canonical kind is `'`, which is what `templatize` writes. The one
+/// exception is a content holding a `'`: with no escapes it can only be
+/// delimited by `"`, so it is already spelled one way on both sides and is
+/// re-emitted as it stands. Rewriting it to `'` regardless would turn
+/// `"a'b"` into `'a'b'`, which denotes `a` — a different value, and one
+/// another link may legitimately carry.
+///
 /// Scope is deliberately narrow:
 ///
 /// - Only `{{…}}`. A `{%…%}` tag has statement syntax where a space can
@@ -199,8 +213,9 @@ fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
     if !bytes.windows(2).any(|w| w == b"{{") {
         return Cow::Borrowed(url);
     }
-    // Byte-oriented, but UTF-8 safe: only ASCII whitespace is dropped,
-    // and no byte of a multi-byte sequence is ASCII.
+    // Byte-oriented, but UTF-8 safe: only ASCII whitespace is dropped and
+    // only an ASCII quote is rewritten, and no byte of a multi-byte
+    // sequence is ASCII.
     let mut out: Vec<u8> = Vec::with_capacity(url.len());
     let mut i = 0;
     while i < bytes.len() {
@@ -218,20 +233,34 @@ fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
         };
         let interior = &bytes[i + "{{".len()..end - "}}".len()];
         out.extend_from_slice(b"{{");
-        let mut quote: Option<u8> = None;
         let mut j = 0;
         while j < interior.len() {
             let byte = interior[j];
-            if let Some(open) = quote {
-                if byte == open {
-                    quote = None;
-                }
-                out.push(byte);
-                j += 1;
-            } else if byte == b'\'' || byte == b'"' {
-                quote = Some(byte);
-                out.push(byte);
-                j += 1;
+            if byte == b'\'' || byte == b'"' {
+                let start = j + 1;
+                let Some(close) = interior[start..].iter().position(|&b| b == byte) else {
+                    // Unterminated quote: the rest of the tag is kept
+                    // verbatim, delimiter included — its extent is unknown,
+                    // so there is nothing to re-emit a canonical form of.
+                    out.extend_from_slice(&interior[j..]);
+                    break;
+                };
+                let content = &interior[start..start + close];
+                // The content is the value and is copied verbatim; the
+                // delimiter is spelling, and the two sides may differ on
+                // it (#88). `'` is the canonical kind — it is what
+                // `templatize` writes — except for a content holding a
+                // `'`, which without escapes can only ever be delimited
+                // by `"` and so is already spelled one way on both sides.
+                let delim = if content.contains(&b'\'') {
+                    b'"'
+                } else {
+                    b'\''
+                };
+                out.push(delim);
+                out.extend_from_slice(content);
+                out.push(delim);
+                j = start + close + 1;
             } else if interior[j..].starts_with(b"${") {
                 let start = j + "${".len();
                 let Some(close) = interior[start..].iter().position(|&b| b == b'}') else {
@@ -259,7 +288,7 @@ fn strip_liquid_tag_whitespace(url: &str) -> Cow<'_, str> {
         out.extend_from_slice(b"}}");
         i = end;
     }
-    Cow::Owned(String::from_utf8(out).expect("only ASCII whitespace was dropped"))
+    Cow::Owned(String::from_utf8(out).expect("only ASCII bytes were dropped or rewritten"))
 }
 
 /// If a Liquid output tag opens at `i`, the index just past its `}}`.
@@ -950,7 +979,9 @@ mod tests {
             "https://x.com/{{sep|default:' - '}}/a"
         );
         // Double quotes delimit just the same, and a quote of the other
-        // kind inside is ordinary text.
+        // kind inside is ordinary text. A content holding a `'` keeps its
+        // `"` delimiters: with no escapes that is the only way to write
+        // it, so both sides already agree on the spelling.
         assert_eq!(
             normalize_url(r#"https://x.com/{{ sep | default: " it's here " }}"#),
             r#"https://x.com/{{sep|default:" it's here "}}"#
@@ -960,6 +991,46 @@ mod tests {
         assert_eq!(
             normalize_url("https://x.com/{{ sep | default: ' oops }}/a"),
             "https://x.com/{{sep|default:' oops }}/a"
+        );
+    }
+
+    #[test]
+    fn normalize_folds_quote_style_on_an_unrelated_filter_argument() {
+        // The delimiter is spelling, not value (#88). A dashboard flipping
+        // `'sale'` to `"sale"` on a filter this repo does not manage used
+        // to change the anchor key, and the link lost its live lid to a
+        // generated slug.
+        assert_eq!(
+            normalize_url("https://x.com/{{segment|default:'sale'}}/p"),
+            normalize_url(r#"https://x.com/{{ segment | default: "sale" }}/p"#)
+        );
+        // `'` is the canonical kind, so a `"`-spelled argument is what
+        // moves.
+        assert_eq!(
+            normalize_url(r#"https://x.com/{{ segment | default: "sale" }}/p"#),
+            "https://x.com/{{segment|default:'sale'}}/p"
+        );
+        // Folding the delimiter must not fold the content with it: the
+        // spaces inside still separate two different links.
+        assert_ne!(
+            normalize_url(r#"https://x.com/{{ sep | default: " - " }}/a"#),
+            normalize_url("https://x.com/{{ sep | default: '-' }}/a")
+        );
+        assert_eq!(
+            normalize_url(r#"https://x.com/{{ sep | default: " - " }}/a"#),
+            "https://x.com/{{sep|default:' - '}}/a"
+        );
+        // A content that holds a `'` cannot be re-delimited — `'a'b'`
+        // would denote `a` — so it stays `"`-quoted and stays distinct
+        // from the link whose argument really is `a`.
+        assert_ne!(
+            normalize_url(r#"https://x.com/{{ sep | default: "a'b" }}/p"#),
+            normalize_url("https://x.com/{{ sep | default: 'a' }}/p")
+        );
+        // A `"` inside is ordinary text and does not block the fold.
+        assert_eq!(
+            normalize_url(r#"https://x.com/{{ sep | default: 'a"b' }}/p"#),
+            r#"https://x.com/{{sep|default:'a"b'}}/p"#
         );
     }
 

--- a/src/values/correlation.rs
+++ b/src/values/correlation.rs
@@ -152,8 +152,12 @@ pub fn normalize_url(url: &str) -> Anchor {
 /// exception is a content holding a `'`: with no escapes it can only be
 /// delimited by `"`, so it is already spelled one way on both sides and is
 /// re-emitted as it stands. Rewriting it to `'` regardless would turn
-/// `"a'b"` into `'a'b'`, which denotes `a` — a different value, and one
-/// another link may legitimately carry.
+/// `"a'b"` into `'a'b'`, whose leading literal is `a` and whose `b'` is
+/// trailing junk — a key that transcribes no value anyone wrote. Note the
+/// hazard is *not* a collision with the link whose argument really is `a`:
+/// that keys as `'a'`, and the trailing `b'` keeps the two apart. Keeping
+/// the `"` is the conservative choice — the key stays a faithful
+/// transcription of the only spelling the value has.
 ///
 /// Scope is deliberately narrow:
 ///
@@ -171,10 +175,15 @@ pub fn normalize_url(url: &str) -> Anchor {
 ///   spacing, so `{{ u | append: '}}' }}` still keys differently from
 ///   `{{u|append:'}}'}}`. Both sides missed before this pass too, so it
 ///   is an uncovered case, not a regression.
-/// - Literal `{{…}}` text inside a `{% raw %}` block is despaced like
-///   any other tag. Reaching that needs a raw block *and* a literal
-///   space inside a URL, so the pass does not carry the cost of tracking
-///   raw spans.
+/// - Literal `{{…}}` text inside a `{% raw %}` block is despaced — and,
+///   since #88, re-delimited — like any other tag. Inside `raw` those
+///   bytes are the rendered output, so unlike everywhere else the two
+///   spellings really are two different URLs, and the pass merges them.
+///   It already did so on whitespace, which is the wider axis of the two;
+///   the delimiter adds one more to a region that was never distinguished
+///   in the first place. Reaching it needs a raw block *and* a Liquid-
+///   shaped literal inside a URL, so the pass still does not carry the
+///   cost of tracking raw spans.
 ///
 /// A quoted string is not the only literal region inside a tag, so
 /// `${…}` is treated as a second one. Braze addresses a personalization
@@ -1020,17 +1029,21 @@ mod tests {
             normalize_url(r#"https://x.com/{{ sep | default: " - " }}/a"#),
             "https://x.com/{{sep|default:' - '}}/a"
         );
-        // A content that holds a `'` cannot be re-delimited: `'a'b'` would
-        // denote `a`. It stays `"`-quoted — which is also the only way
-        // Liquid can spell it, so both sides already agree — and so stays
-        // distinct from the link whose argument really is `a`.
+        // A content that holds a `'` keeps its `"` delimiters: with no
+        // escapes that is the only way Liquid can spell it, so both sides
+        // already agree, and re-delimiting would emit `'a'b'` — a byte
+        // sequence that denotes `a` followed by trailing junk rather than
+        // the value that was written.
+        //
+        // Pinned by value, not by inequality. An `assert_ne!` against the
+        // link whose argument really is `a` would hold under *every*
+        // implementation of this function — content is copied verbatim in
+        // all of them, so `'a'b'` and `'a'` can never be equal — and so
+        // would say nothing about the exception. Only the exact expected
+        // key fails when the exception is dropped.
         assert_eq!(
             normalize_url(r#"https://x.com/{{ sep | default: "a'b" }}/p"#),
             r#"https://x.com/{{sep|default:"a'b"}}/p"#
-        );
-        assert_ne!(
-            normalize_url(r#"https://x.com/{{ sep | default: "a'b" }}/p"#),
-            normalize_url("https://x.com/{{ sep | default: 'a' }}/p")
         );
         // A `"` inside is ordinary text and does not block the fold.
         assert_eq!(

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -359,6 +359,30 @@ fn respelling_never_merges_two_distinct_links() {
                 "{{sep|default:'-'}}{{x| lid: 'liveaaaaaaaa2'}}",
             ],
         ),
+        // #88, the over-normalizing direction of the delimiter fold, which
+        // the positive half cannot see. Canonicalizing the *kind* of quote
+        // is safe only while the quote bytes themselves stay in the key:
+        // drop them instead, and a string literal keys the same as a Liquid
+        // *variable* of that name — two links that render differently.
+        //
+        // The fold's other guard, the `'`-in-content exception, has no row
+        // here on purpose. Re-delimiting `"a'b"` yields `'a'b'`, which does
+        // NOT collide with the link whose argument is `a` (that keys as
+        // `'a'`; the trailing `b'` keeps them apart) — only with a
+        // *malformed* `{{sep|default:'a'b'}}`, and a malformed tag takes the
+        // unterminated-quote path, whose key is spacing-sensitive by design.
+        // So it is pinned by value in `correlation`'s unit half instead.
+        (
+            "https://x.com/{{segment|default:'a'}}{{x|lid:'liveaaaaaaaa1'}} \
+             https://x.com/{{segment|default:a}}{{x|lid:'liveaaaaaaaa2'}}",
+            "https://x.com/{{ segment | default: a }}{{ x | lid: 'liveaaaaaaaa2' }} \
+             https://x.com/{{ segment | default: 'a' }}{{ x | lid: 'liveaaaaaaaa1' }}",
+            FieldKind::EmailPlainBody,
+            &[
+                "{{segment|default:'a'}}{{x| lid: 'liveaaaaaaaa1'}}",
+                "{{segment|default:a}}{{x| lid: 'liveaaaaaaaa2'}}",
+            ],
+        ),
         // Whitespace *between* the bytes of a `${NAME}` is part of the name.
         (
             "https://x.com/{{custom_attribute.${first name}}}{{x|lid:'liveaaaaaaaa1'}} \

--- a/src/values/roundtrip.rs
+++ b/src/values/roundtrip.rs
@@ -301,6 +301,14 @@ fn survives_every_respelling_the_dashboard_can_introduce() {
             r#"<a href="https://x.com/sale">{{x | lid: "liveaaaaaaaa1"}}</a>"#,
             FieldKind::ContentBlock,
         ),
+        // #88: quote style on a filter argument this repo does not
+        // manage. Semantically identical in Liquid, and the one axis the
+        // despacing pass used to leave byte-distinct.
+        (
+            "https://x.com/{{segment|default:'sale'}}{{x|lid:'liveaaaaaaaa1'}}",
+            r#"https://x.com/{{ segment | default: "sale" }}{{ x | lid: 'liveaaaaaaaa1' }}"#,
+            FieldKind::EmailPlainBody,
+        ),
         // The include respaced. `templatize` rebuilds it canonically, so
         // the key has to be derived from the name rather than the bytes.
         (


### PR DESCRIPTION
Closes #88.

## The bug

`{{ segment | default: 'sale' }}` and `{{ segment | default: "sale" }}` denote
the same string in Liquid. `strip_liquid_tag_whitespace` copied a quoted region
verbatim — **delimiter included** — so the two spellings stayed byte-distinct in
the anchor key. A dashboard-side quote flip on a filter this tool does not manage
made the two sides key the link differently, the lookup missed, and a generated
slug was written over a live `lid`.

Verified by execution on the pre-fix tree, using the issue's repro:

```
errors    = []
gated     = true
warnings  = ["lid: URL anchor '…' not found in remote body — using fallback value
              'segment_default_sale_x' (new link; Braze will reassign on first
              dashboard save)"]
fallbacks = [LidFallback { anchor: Some("…"), value: "segment_default_sale_x" }]
```

So this was **recorded, not silent**: the warning fired and `fallback_gated` was
set, meaning `diff` exits `8` and `apply` refuses without `--allow-fallback`. The
loss needed a run carrying that flag — but the warning calls the link "new" and
says Braze will reassign, which invites exactly that.

## The fix

Quoted regions are re-emitted with a canonical delimiter; **the contents stay
byte-for-byte verbatim.**

Content normalization is off the table and stays off. The spaces in
`{{ sep | default: ' - ' }}` are the value — merging that anchor with `'-'`'s
would let `resolve_lid_batch`'s FIFO hand each link the other's live identifier,
which is strictly worse than the miss being fixed. That reasoning is the doc at
`correlation.rs`, and this PR extends it rather than weakening it: only the
delimiter moves.

**Canonical delimiter: `'`** — what `templatize` writes — **except for a value
containing a `'`.** Liquid has no string escapes, so such a value can only ever
be written with `"`; both sides therefore already agree on its spelling, and
re-quoting it would turn `"a'b"` into `'a'b'` — a key that transcribes no value
anyone wrote. That case is pinned by an `assert_eq!` on the expected key. (It is
*not* a collision with the link whose argument really is `a`: that keys as `'a'`,
and the trailing `b'` keeps the two apart.)

An unterminated quote still keeps the rest of its tag verbatim, unchanged.

## Relation to #79

Per your comment on the issue: this is not a fifth regex widening. Liquid has
exactly **two** quote characters, so this axis is closed and enumerable, unlike
the open set of Liquid spellings that #68 / #70 / #73 / #77 approximated.
Re-measuring lid fallback counts on a real project, and reconsidering #79 if
non-zero, stays as planned after this lands.

## Tests

- `roundtrip::survives_every_respelling_the_dashboard_can_introduce` — a new row
  with the issue's exact strings. **Confirmed to fail on the pre-fix tree** (the
  source change was stashed and the row went red), so it is a real guard.
- `correlation::normalize_folds_quote_style_on_an_unrelated_filter_argument` —
  the fold itself, plus the two things it must not do: fold contents (`" - "` vs
  `'-'` stay distinct) and re-delimit a `'`-holding value.
- #86's existing row — quote style on the *managed value itself* — still passes;
  `lid_filter_re` and `cb_id_filter_re` both accept either quote, and everything
  reaching them is now `'`.
- `cargo test --all`: **662 pass / 0 fail** (661 before; +1 test, +2 table rows).
  `cargo clippy --all-targets --all-features` and `cargo fmt --check` clean.

Not merging — waiting on your review.

---

## /review-loop での修正

4 レンズ + cross-vendor (Codex gpt-6-astra) をこの diff に当てた結果。**製品コードは 1 バイトも変えていない** — 入ったのはテストの追加と、根拠の誤りの訂正のみ。

**must-fix 1件（修正済み）**

- negative テーブル `respelling_never_merges_two_distinct_links` に #88 軸の行がなかった。この fold の次の自然な単純化は「区切り文字を落とす」ことで、そうすると `{{segment|default:'a'}}`（文字列）と `{{segment|default:a}}`（Liquid **変数**）が同一キーに潰れ、FIFO が live lid を入れ替える。unquoted なフィルタ引数を使うテストはツリー内に 1 つもなかった。行を追加し、mutation（区切り文字を落とす実装）で red になることを確認済み。

**根拠の誤りの訂正（挙動不変）**

- `assert_ne!("a'b" ≠ 'a')` は**どんな実装でも落ちない**空アサーションだった（内容は常に verbatim なので `'a'b'` と `'a'` は決して等しくならない）。削除し、生きたガードが `assert_eq!` の方であることを明記。
- 同じ推論が doc コメントと CHANGELOG にも入っていた。`"a'b"` の再デリミットが危険なのは「`a` のリンクと衝突するから」ではない（衝突しない）。例外の実利は、その値が持ちうる唯一の綴りをキーが忠実に転写し続けること。
- `{% raw %}` 内: raw のリテラルは描画結果そのものなので 2 つの綴りは本当に別 URL で、この fold はそこをマージする。ただし**空白パスが既にマージしていた**領域への 1 軸追加であり、健全な領域を壊してはいない。scope リストに明記（raw span 追跡は引き続き見送り）。

**doc の追随**

- `docs/per-env-values.md` は #77 / #85 では更新されたが #88 では更新されておらず、引用符付き引数を「バイト単位の identity」と説明したままだった。オペレータがダッシュボードのクォート反転を今も lid 喪失と読み、不要な手作業を計画しうる。区切り文字の fold と、綴りに依存する残余（unclosed `{{` / 引用符内の `}}`）を追記。
- CHANGELOG の「there is no next spelling behind this one」も同様に緩和。

**検証したが指摘ではなかったもの**

- HTML `href` 経路: 属性区切りと Liquid 区切りが同時に反転する現実的な形は **live lid を保持**することを実行で確認。属性内で Liquid のクォートだけが単独で動くことは HTML 上ありえないため、plaintext 行がこの軸の正しい検証手段。
- `Anchor` は比較キー専用で、plan file にも JSON 出力にも POST 値にも載らない（`slug_core` が両クォートを `_` に潰すため fallback slug も不変）。

**残る blind spot**: 実アプリ実行なし（読解 + 単体/結合テストのみ）。4 レンズは**同一モデルの別視点**であって独立レビュアーではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed formatting of quoted arguments in Liquid output tags.
  - Quote styles are now normalized without changing the values they contain.
  - Prevented formatting changes from altering link anchor keys or replacing live `lid` values.
  - Preserved whitespace within quoted values and correctly handled values containing apostrophes.

- **Documentation**
  - Added a changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->