### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
-## [Unreleased]
+## [0.21.0] — 2026-09-11
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
`Cargo.toml` / `Cargo.lock` `0.20.0` → `0.21.0`, and the CHANGELOG's
`[Unreleased]` heading becomes `[0.21.0] — 2026-09-11`. No other
changes — same three-file shape as #98.

## Why minor, not patch

This release ships **plan file version 2**, which reached `main` in #102
but has never been in a published build. A v1 plan is rejected with
"regenerate with `diff --plan-out`". That is the breaking change.

Two changes settle that shape:

- **`apply --plan` verifies remote preconditions** rather than only the
  op shape (#100)
- **`scope` records the Braze endpoint** the plan was generated against
  (#106) — `scope.environment` is a config label, not an identity

## What else is in it

- `apply --max-plan-age <DURATION>` expires a plan on a **new exit code
  9** (#104), before the first API call
- `diff --plan-out` writes the plan atomically, and writes *through*
  destinations a rename would destroy — device nodes, FIFOs, sockets,
  symlinks (#105)
- Three Liquid `lid` fixes: quote style on an unrelated filter argument
  no longer costs a link its live `lid` (#88); a live `lid` is no longer
  overwritten by a generated slug, and a `lid` in a non-anchor element's
  body now resolves (#87, #84); the fallback gate now counts live `lid`
  values the anchor scan never paired

## On #106, which closed without the whoami part

The v0.21.0 milestone is empty because #106 was closed after the
remaining investigation came back negative: no Braze REST endpoint
reports which workspace an API key belongs to, so there is no identifier
to record in `PlanScope`. Braze's own MCP server exposes `get_workspaces`
with its REST endpoint listed as `N/A`, reachable only through an OAuth
user token.

The consequence is already documented in the CHANGELOG entry and in
`src/diff/plan.rs`: a key swap on one endpoint is still not detected —
the plan records where it looked, not whose data it saw. #113 tracks the
detection recipe for when that changes.

## Verification

- `cargo test --all` — 662 pass / 0 fail
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.21.0 is now available.
  * Updated the release date to September 11, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->