### PR TITLE
diff: stop exiting 2 for drift a correct setup produces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ### Fixed
 
-- **`diff --fail-on-drift` no longer exits 2 for drift nobody can
-  resolve (#115).** The gate counted every diff whose `has_changes()`
+- **`diff --fail-on-drift` no longer exits 2 for drift a correct setup
+  produces (#115).** The gate counted every diff whose `has_changes()`
   was true, with no notion of whether the difference could be acted on.
   One state cannot: a Custom Attribute in the Git registry that Braze
   does not have. Braze has no create endpoint for Custom Attributes —
@@ -30,11 +30,13 @@ file formats, JSON output, exit codes) for the full v1.x line.
   code changed.
 
   **What this costs, stated plainly.** A pipeline that relied on exit 2
-  to catch a typo in the registry goes green after upgrading. The row is
-  still printed and still in the JSON, but the signal moved from the
-  exit code to the output — and braze-sync cannot tell a typo from an
-  attribute awaiting traffic, which is exactly why it stopped failing
-  the build over the question. No exit code was added; the set stays
+  to catch a typo in the registry goes green after upgrading — and so
+  does one that relied on it to catch an attribute somebody removed on
+  the Braze side, which lands in the same state. The row is still
+  printed and still in the JSON, but the signal moved from the exit
+  code to the output. braze-sync cannot tell a typo, a dashboard-side
+  removal, and an attribute awaiting traffic apart, which is exactly
+  why it stopped failing the build over the question. No exit code was added; the set stays
   frozen (README §Exit codes). What narrowed is which differences
   qualify for `2`.
 
@@ -42,10 +44,12 @@ file formats, JSON output, exit codes) for the full v1.x line.
   Orphaned Content Blocks and Email Templates (no DELETE endpoint),
   Custom Attributes missing from the registry, descriptions that
   disagree, and both Tag states all still exit 2 — each is resolved by
-  a human in the dashboard or in Git. The test is not "can braze-sync
-  write it" but "can anybody resolve it", which is why the existing
-  `is_actionable()` predicate — which answers the first question, and
-  excludes orphans and all Tag drift — was not reused for the gate.
+  a human in the dashboard or in Git, and none of them is what a
+  healthy setup looks like. The test is not "can braze-sync write it"
+  but "does a correct configuration produce this", which is why the
+  existing `is_actionable()` predicate — which answers the first
+  question, and excludes orphans and all Tag drift — was not reused for
+  the gate.
 
   To make the split legible rather than implicit: `--format json` now
   carries `drift_tier` (`gating` / `report_only` / `none`) on every
@@ -102,7 +106,7 @@ file formats, JSON output, exit codes) for the full v1.x line.
   `PresentInGitOnly`, which counts toward `changed_count()`, so it
   appears in the table and in `--format json` on every run where it
   previously vanished — but only because `export` had deleted it. It no
-  longer exits 2; see the drift-severity entry below, which landed in
+  longer exits 2; see the drift-severity entry above, which landed in
   the same release. To drop such entries from the listing as well, use
   `custom_attribute.exclude_patterns`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,16 @@ file formats, JSON output, exit codes) for the full v1.x line.
   **What this costs, stated plainly.** A pipeline that relied on exit 2
   to catch a typo in the registry goes green after upgrading — and so
   does one that relied on it to catch an attribute somebody removed on
-  the Braze side, which lands in the same state. The row is still
-  printed and still in the JSON, but the signal moved from the exit
-  code to the output. braze-sync cannot tell a typo, a dashboard-side
-  removal, and an attribute awaiting traffic apart, which is exactly
-  why it stopped failing the build over the question. No exit code was added; the set stays
-  frozen (README §Exit codes). What narrowed is which differences
-  qualify for `2`.
+  the Braze side, which lands in the same state — as does a
+  `/custom_attributes` response that came back short without erroring
+  (a `2xx` with an empty or missing `attributes` list, or a dropped
+  `Link: rel="next"` header). The row is still printed and still in
+  the JSON, but the signal moved from the exit code to the output.
+  braze-sync cannot tell a typo, a dashboard-side removal, a short
+  response, and an attribute awaiting traffic apart, which is exactly
+  why it stopped failing the build over the question. No exit code was
+  added; the set stays frozen (README §Exit codes). What narrowed is
+  which differences qualify for `2`.
 
   Nothing else was reclassified, including drift `apply` cannot write.
   Orphaned Content Blocks and Email Templates (no DELETE endpoint),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,58 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ### Fixed
 
+- **`diff --fail-on-drift` no longer exits 2 for drift nobody can
+  resolve (#115).** The gate counted every diff whose `has_changes()`
+  was true, with no notion of whether the difference could be acted on.
+  One state cannot: a Custom Attribute in the Git registry that Braze
+  does not have. Braze has no create endpoint for Custom Attributes —
+  an attribute materializes on the first `/users/track` call carrying
+  it — so a registry describing more than one workspace contains such
+  entries by construction. `apply` has no call to make and `export`
+  clears them only by deleting the entry another workspace depends on
+  (#117), which means the daily drift check
+  [integration.md](docs/integration.md) recommends was red every day.
+  In one deployment 82 of 86 changed entries were this class, so the
+  genuine drift in the other 4 was invisible in practice.
+
+  Such entries are now **listed and not counted**. They stay in the
+  table, in `--format json`, and in `changed_count()`; only the exit
+  code changed.
+
+  **What this costs, stated plainly.** A pipeline that relied on exit 2
+  to catch a typo in the registry goes green after upgrading. The row is
+  still printed and still in the JSON, but the signal moved from the
+  exit code to the output — and braze-sync cannot tell a typo from an
+  attribute awaiting traffic, which is exactly why it stopped failing
+  the build over the question. No exit code was added; the set stays
+  frozen (README §Exit codes). What narrowed is which differences
+  qualify for `2`.
+
+  Nothing else was reclassified, including drift `apply` cannot write.
+  Orphaned Content Blocks and Email Templates (no DELETE endpoint),
+  Custom Attributes missing from the registry, descriptions that
+  disagree, and both Tag states all still exit 2 — each is resolved by
+  a human in the dashboard or in Git. The test is not "can braze-sync
+  write it" but "can anybody resolve it", which is why the existing
+  `is_actionable()` predicate — which answers the first question, and
+  excludes orphans and all Tag drift — was not reused for the gate.
+
+  To make the split legible rather than implicit: `--format json` now
+  carries `drift_tier` (`gating` / `report_only` / `none`) on every
+  entry of every kind, plus `summary.gating_drift` and
+  `summary.report_only_drift`. Both are additive; the schema stays
+  `version: 1`. `[.diffs[] | select(.drift_tier == "gating")] | length`
+  reproduces the gate exactly, without reimplementing the per-kind
+  table.
+
+- **`PresentInGitOnly` no longer reads as "likely a typo" (#115).** The
+  hint assumed the registry mirrors exactly one workspace. It does not
+  have to, and under a shared registry the entry is usually correct —
+  it simply has no traffic in this workspace yet. The line now hedges
+  the way `docs/registry-mode.md` already did, because the CLI
+  genuinely cannot tell the two apart. Same assumption as #106 / #113:
+  an environment name is not a workspace identity.
+
 - **`export` no longer deletes Custom Attribute registry entries the
   queried workspace does not have (#117).** `export --resource
   custom_attribute` rebuilt `registry.yaml` from the Braze response
@@ -46,14 +98,12 @@ file formats, JSON output, exit codes) for the full v1.x line.
   is visible in the file and in `diff`, and a deleted entry is visible
   nowhere.
 
-  The direct cost is that **`diff --fail-on-drift` now stays red.** A
-  kept entry is `PresentInGitOnly`, which counts toward
-  `changed_count()`, so the gate exits 2 — and `apply` cannot clear it,
-  because there is no create-attribute endpoint. That gate went green
-  before this change only because `export` had deleted the entry; the
-  red is existing disagreement stopping being papered over by data
-  loss, not new information. Until kind-aware drift severity lands
-  (#115), the way to keep such a gate green is
+  The direct cost is that a kept entry stays **listed** as drift. It is
+  `PresentInGitOnly`, which counts toward `changed_count()`, so it
+  appears in the table and in `--format json` on every run where it
+  previously vanished — but only because `export` had deleted it. It no
+  longer exits 2; see the drift-severity entry below, which landed in
+  the same release. To drop such entries from the listing as well, use
   `custom_attribute.exclude_patterns`.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ across all v1.x releases.
 |:---:|:---|
 | `0` | Success |
 | `1` | General error |
-| `2` | Drift detected (`diff --fail-on-drift`) |
+| `2` | Drift detected (`diff --fail-on-drift`). Counts drift somebody can resolve; drift no command and no dashboard action can clear is listed but not counted — see [integration.md](docs/integration.md#what-counts-as-drift-for-exit-2) |
 | `3` | Config / argument error (or `validate` issues) |
 | `4` | Authentication failed (invalid API key) |
 | `5` | Rate limit retries exhausted |

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ across all v1.x releases.
 |:---:|:---|
 | `0` | Success |
 | `1` | General error |
-| `2` | Drift detected (`diff --fail-on-drift`). Counts drift somebody can resolve; drift no command and no dashboard action can clear is listed but not counted — see [integration.md](docs/integration.md#what-counts-as-drift-for-exit-2) |
+| `2` | Drift detected (`diff --fail-on-drift`). Drift a correct setup produces — a Custom Attribute awaiting traffic in this workspace — is listed but not counted; see [integration.md](docs/integration.md#what-counts-as-drift-for-exit-2) |
 | `3` | Config / argument error (or `validate` issues) |
 | `4` | Authentication failed (invalid API key) |
 | `5` | Rate limit retries exhausted |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -90,9 +90,17 @@ setup looks like. "braze-sync cannot write it" is not the test.
 
 The cost is stated plainly: a registry typo, or an attribute somebody
 removed on the Braze side, lands in the same state and goes green too.
-braze-sync cannot tell them apart, which is exactly why it stopped
-failing the build over the question — the row is still printed, so the
-signal moved from the exit code to the output.
+So does a `/custom_attributes` fetch that came back short without
+erroring — a `2xx` whose body is empty or lacks `attributes`, or a
+first page whose `Link: rel="next"` header a proxy dropped — because
+every entry the response is missing looks the same as one awaiting
+traffic. (A non-`2xx` response still fails the run: `401` exits `4`,
+anything else exits `1`.) braze-sync cannot tell any of these apart,
+which is exactly why it stopped failing the build over the question —
+the row is still printed, so the signal moved from the exit code to
+the output. A run where *every* registry entry is report-only and the
+summary shows nothing in sync is worth a second look before you trust
+the green.
 
 Nothing is hidden either way. Report-only differences appear in the
 table with a count of how many were not charged against the gate, and

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -66,8 +66,10 @@ Exit-code contract:
 
 ### What counts as drift for exit `2`
 
-`--fail-on-drift` does not count every difference it prints. It counts
-the ones somebody can resolve.
+`--fail-on-drift` does not count every difference it prints. It skips
+the one state a *correct* setup produces — where the output of a
+healthy configuration and of a mistake are the same, so failing the
+build over it says nothing.
 
 The exception today is a Custom Attribute present in the Git registry
 but not in Braze. There is no create endpoint for Custom Attributes —
@@ -83,8 +85,14 @@ Everything else still fails the build, including drift `apply` cannot
 write: an orphaned Content Block or Email Template (a human archives it
 in the dashboard), a Custom Attribute in Braze but missing from the
 registry (`export` resolves it), a description that disagrees (a human
-edits one side), and both Tag states. "braze-sync cannot write it" is
-not the test — "nobody can resolve it" is.
+edits one side), and both Tag states. None of those is what a healthy
+setup looks like. "braze-sync cannot write it" is not the test.
+
+The cost is stated plainly: a registry typo, or an attribute somebody
+removed on the Braze side, lands in the same state and goes green too.
+braze-sync cannot tell them apart, which is exactly why it stopped
+failing the build over the question — the row is still printed, so the
+signal moved from the exit code to the output.
 
 Nothing is hidden either way. Report-only differences appear in the
 table with a count of how many were not charged against the gate, and
@@ -175,7 +183,9 @@ jq '.summary' diff.json
 #   "changed": 5,
 #   "in_sync": 1,
 #   "destructive": 1,
-#   "orphan": 1
+#   "orphan": 1,
+#   "gating_drift": 4,
+#   "report_only_drift": 1
 # }
 ```
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -55,7 +55,7 @@ Exit-code contract:
 |:---:|:---|:---|
 | `0` | In sync | Pass |
 | `1` | Generic failure (I/O, parse, unmapped error) | Fail the build |
-| `2` | Drift detected | Fail the build |
+| `2` | Drift detected — see [what counts as drift](#what-counts-as-drift-for-exit-2) | Fail the build |
 | `3` | `validate` caught a local issue | Fail the build |
 | `4` | API key is invalid | Fail & page the operator |
 | `5` | Rate limit retries exhausted | Retry the job |
@@ -63,6 +63,40 @@ Exit-code contract:
 | `7` | Plan/apply mismatch (`apply --plan`): the op set differs, the remote moved since the plan, or the plan's scope — environment or endpoint — no longer matches | Fail the build; regenerate the plan and re-review |
 | `8` | Fallback gate: unmatched placeholder + unconsumed remote lid value (see `apply --allow-fallback`). Unlike code `2`, this fires unconditionally — plain `diff` has no opt-in flag for it | Fail the build / block merge |
 | `9` | Plan outside its validity window (`apply --max-plan-age`) — the approval expired, or the plan's `generated_at` is too far in the future | Regenerate the plan and re-approve; do not retry the same plan |
+
+### What counts as drift for exit `2`
+
+`--fail-on-drift` does not count every difference it prints. It counts
+the ones somebody can resolve.
+
+The exception today is a Custom Attribute present in the Git registry
+but not in Braze. There is no create endpoint for Custom Attributes —
+an attribute materializes in a workspace on the first `/users/track`
+call carrying it — so when one registry describes more than one
+workspace, every attribute that has not yet seen traffic in the
+workspace you are diffing against is reported here. No `apply` clears
+it, and `export` only clears it by deleting the entry the other
+workspace depends on. Counting it would leave the scheduled job below
+red every day, which hides the genuine drift sitting next to it.
+
+Everything else still fails the build, including drift `apply` cannot
+write: an orphaned Content Block or Email Template (a human archives it
+in the dashboard), a Custom Attribute in Braze but missing from the
+registry (`export` resolves it), a description that disagrees (a human
+edits one side), and both Tag states. "braze-sync cannot write it" is
+not the test — "nobody can resolve it" is.
+
+Nothing is hidden either way. Report-only differences appear in the
+table with a count of how many were not charged against the gate, and
+in `--format json` every entry carries a `drift_tier` of `gating`,
+`report_only`, or `none`, with `summary.gating_drift` and
+`summary.report_only_drift` alongside `summary.changed`. To reproduce
+the gate exactly:
+
+```bash
+braze-sync diff --env prod --format json \
+  | jq '[.diffs[] | select(.drift_tier == "gating")] | length'
+```
 
 ## Apply on merge
 
@@ -225,3 +259,7 @@ too; otherwise they stay in the step log.
 Even with PR-level drift checks, schedule a daily `diff --fail-on-drift`
 against production. Dashboard edits are the dominant source of drift in
 practice, and they bypass every PR-gated check you install.
+
+A daily job is only useful while a red result still means something, so
+check [what counts as drift](#what-counts-as-drift-for-exit-2) if yours
+is red every morning.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -94,8 +94,9 @@ So does a `/custom_attributes` fetch that came back short without
 erroring — a `2xx` whose body is empty or lacks `attributes`, or a
 first page whose `Link: rel="next"` header a proxy dropped — because
 every entry the response is missing looks the same as one awaiting
-traffic. (A non-`2xx` response still fails the run: `401` exits `4`,
-anything else exits `1`.) braze-sync cannot tell any of these apart,
+traffic. (A non-`2xx` response still fails the run with its own code
+from the table above: `4`, `5`, or `1`.) braze-sync cannot tell any of
+these apart,
 which is exactly why it stopped failing the build over the question —
 the row is still printed, so the signal moved from the exit code to
 the output. A run where *every* registry entry is report-only and the

--- a/docs/orphan-tracking.md
+++ b/docs/orphan-tracking.md
@@ -44,14 +44,17 @@ individual diff entry and in the `summary.orphan` count:
 ```json
 {
   "version": 1,
-  "summary": { "changed": 2, "in_sync": 4, "destructive": 0, "orphan": 2 },
+  "summary": {
+    "changed": 2, "in_sync": 4, "destructive": 0, "orphan": 2,
+    "gating_drift": 2, "report_only_drift": 0
+  },
   "diffs": [
     {
-      "kind": "content_block", "op": "unchanged",
+      "kind": "content_block", "op": "unchanged", "drift_tier": "gating",
       "name": "legacy_promo", "orphan": true
     },
     {
-      "kind": "email_template", "op": "unchanged",
+      "kind": "email_template", "op": "unchanged", "drift_tier": "gating",
       "name": "old_welcome", "orphan": true,
       "subject_changed": false, "metadata_changed": false
     }

--- a/docs/registry-mode.md
+++ b/docs/registry-mode.md
@@ -113,6 +113,8 @@ pretends to be more powerful than it is.
    A nightly `diff --fail-on-drift` (see
    [integration.md](integration.md)) will flag new attributes as
    `UnregisteredInGit` so someone opens a PR with a description.
+   Entries the workspace has not seen yet (`PresentInGitOnly`) are
+   listed by the same run but do not fail it.
 
 4. **Deprecate deliberately**. When an attribute is truly retired, mark
    it `deprecated: true` in the registry and run `apply --confirm`.

--- a/docs/registry-mode.md
+++ b/docs/registry-mode.md
@@ -76,7 +76,7 @@ Fields:
 |:---|:---|:---|
 | `Unchanged` | Identical in Git and Braze | None |
 | `UnregisteredInGit` | Exists in Braze, missing from the registry | Report; prompts a follow-up `export` |
-| `PresentInGitOnly` | In the registry, not in Braze | Warning — a typo in the registry, or an attribute that has seen no `/users/track` traffic in *this* workspace. Which one it is depends on whether the registry covers more than one workspace; the CLI cannot tell |
+| `PresentInGitOnly` | In the registry, not in Braze | Warning — a typo in the registry, or an attribute that has seen no `/users/track` traffic in *this* workspace. Which one it is depends on whether the registry covers more than one workspace; the CLI cannot tell. Listed, but does not raise exit `2` |
 | `DeprecationToggled` | `deprecated` differs between Git and Braze | **Writes** — this is the only mutation `braze-sync` performs for Custom Attributes |
 | `MetadataOnly` | Only `description` differs | Report; no API call (Braze has no description endpoint) |
 
@@ -155,29 +155,31 @@ Two consequences worth knowing:
   falling back to a full rewrite would delete the whole registry over a
   one-character YAML slip.
 
-### This keeps `diff --fail-on-drift` red
+### This keeps the entry listed as drift, but not as a failure
 
 Worth stating plainly, because it is the direct cost of the change: a
-kept entry is drift. `diff` classifies it `PresentInGitOnly`, which
-counts toward `changed_count()`, so `diff --fail-on-drift` exits **2** —
-and `apply` cannot clear it, because Braze has no create-attribute
-endpoint. The daily drift check recommended in
-[integration.md](integration.md) therefore stays red for as long as the
-entry stays in the registry.
+kept entry is drift. `diff` classifies it `PresentInGitOnly` and counts
+it toward `changed_count()`, so it appears in the table and in
+`--format json` every run. Before this change it disappeared from both
+— but only because `export` had deleted it. The listing is not new
+information appearing; it is existing disagreement stopping being
+papered over by data loss.
 
-Before this change that gate went green, but only because `export` had
-deleted the entry. The red is not new information appearing; it is
-existing disagreement stopping being papered over by data loss.
+It does **not** exit `2`. `PresentInGitOnly` is report-only: Braze has
+no create-attribute endpoint, so `apply` has no call to make, and
+`export` can only clear the entry by deleting the one another workspace
+depends on. Nobody can resolve it, so the daily drift check recommended
+in [integration.md](integration.md) stays green — while still printing
+the row. See
+[what counts as drift](integration.md#what-counts-as-drift-for-exit-2).
 
-Three ways out, in rough order of preference:
+If you would rather the entries not be listed at all, two ways out:
 
 1. Add the names to `custom_attribute.exclude_patterns` — the intended
-   mechanism for "managed out of band". They stay in the file and stop
-   counting as drift.
+   mechanism for "managed out of band". They stop being compared at
+   all, so they leave the listing as well as the gate.
 2. `export --prune` against the workspace that is the whole truth for
    the registry, if one is.
-3. Wait for kind-aware drift severity, so drift no command can resolve
-   stops raising exit 2 (uny/braze-sync#115).
 
 ### `export --prune`
 

--- a/docs/registry-mode.md
+++ b/docs/registry-mode.md
@@ -170,9 +170,10 @@ papered over by data loss.
 It does **not** exit `2`. `PresentInGitOnly` is report-only: Braze has
 no create-attribute endpoint, so `apply` has no call to make, and
 `export` can only clear the entry by deleting the one another workspace
-depends on. Nobody can resolve it, so the daily drift check recommended
-in [integration.md](integration.md) stays green — while still printing
-the row. See
+depends on. Nobody can resolve it, so it does not, by itself, fail the
+daily drift check recommended in [integration.md](integration.md) —
+the row is still printed, and any gating drift next to it still exits
+`2`. See
 [what counts as drift](integration.md#what-counts-as-drift-for-exit-2).
 
 If you would rather the entries not be listed at all, two ways out:

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -180,11 +180,14 @@ pub async fn run(
         return Err(Error::FallbackGated { count: gated_count }.into());
     }
 
-    if args.fail_on_drift && summary.changed_count() > 0 {
-        return Err(Error::DriftDetected {
-            count: summary.changed_count(),
+    // Gates on the gating tier, not on `changed_count()`: drift that no
+    // action by anyone can clear stays in the listing above but must not
+    // hold a scheduled CI job red forever. See `diff::DriftTier`.
+    if args.fail_on_drift {
+        let gating = summary.gating_drift_count();
+        if gating > 0 {
+            return Err(Error::DriftDetected { count: gating }.into());
         }
-        .into());
     }
 
     Ok(())

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -1,8 +1,9 @@
 //! `braze-sync diff` — show drift between local files and Braze.
 //!
 //! Plan output goes to stdout (so `braze-sync diff > drift.txt` is
-//! clean); warnings go to stderr. With `--fail-on-drift`, any drift
-//! exits 2 so CI can gate on a clean tree.
+//! clean); warnings go to stderr. With `--fail-on-drift`, drift on the
+//! gating tier exits 2 so CI can gate on a clean tree; see
+//! `diff::DriftTier` for what is listed but not counted.
 
 use crate::braze::error::BrazeApiError;
 use crate::braze::BrazeClient;
@@ -46,7 +47,10 @@ pub struct DiffArgs {
     #[arg(long, requires = "resource")]
     pub name: Option<String>,
 
-    /// Exit with code 2 if any drift is detected. Intended for CI gates.
+    /// Exit with code 2 if drift somebody must act on is detected.
+    /// Intended for CI gates. Drift a correct setup produces (a Custom
+    /// Attribute awaiting traffic in this workspace) is listed but not
+    /// counted.
     #[arg(long)]
     pub fail_on_drift: bool,
 
@@ -180,9 +184,9 @@ pub async fn run(
         return Err(Error::FallbackGated { count: gated_count }.into());
     }
 
-    // Gates on the gating tier, not on `changed_count()`: drift that no
-    // action by anyone can clear stays in the listing above but must not
-    // hold a scheduled CI job red forever. See `diff::DriftTier`.
+    // Gates on the gating tier, not on `changed_count()`: drift a correct
+    // setup produces stays in the listing above but must not hold a
+    // scheduled CI job red forever. See `diff::DriftTier`.
     if args.fail_on_drift {
         let gating = summary.gating_drift_count();
         if gating > 0 {

--- a/src/diff/custom_attribute.rs
+++ b/src/diff/custom_attribute.rs
@@ -19,7 +19,9 @@ pub struct CustomAttributeDiff {
 pub enum CustomAttributeOp {
     /// Present in Braze but missing from local registry. Action: prompt `export`.
     UnregisteredInGit,
-    /// Present in local registry but not in Braze. Often a typo.
+    /// Present in local registry but not in Braze: a typo, or an
+    /// attribute this workspace has not seen `/users/track` traffic
+    /// for yet. See [`CustomAttributeDiff::drift_tier`].
     PresentInGitOnly,
     /// `deprecated` flag changed. The only mutation `apply` actually performs.
     DeprecationToggled {

--- a/src/diff/custom_attribute.rs
+++ b/src/diff/custom_attribute.rs
@@ -48,6 +48,39 @@ impl CustomAttributeDiff {
     pub fn is_actionable(&self) -> bool {
         matches!(self.op, CustomAttributeOp::DeprecationToggled { .. })
     }
+
+    /// Which drift tier this diff falls in for `diff --fail-on-drift`.
+    ///
+    /// `PresentInGitOnly` is the one state a *correct* setup produces
+    /// and nobody can clear. A Custom Attribute materializes in a
+    /// workspace on the first `/users/track` call carrying it, and
+    /// there is no create endpoint — so when one registry describes
+    /// more than one workspace, every attribute that has not yet seen
+    /// traffic in *this* workspace is reported here. `apply` has no
+    /// call to make, and `export` can only clear it by deleting the
+    /// entry the other workspace depends on. Under a daily scheduled
+    /// drift check that is a job that is red forever, which hides the
+    /// genuine drift sitting next to it.
+    ///
+    /// Every other state gates:
+    ///
+    /// - `UnregisteredInGit` — the registry is incomplete. `export`
+    ///   resolves it; the whole point of the registry is that the list
+    ///   is complete, so an omission is drift a human must close.
+    /// - `MetadataOnly` — descriptions genuinely disagree. braze-sync
+    ///   has no endpoint for them, but a human editing either the
+    ///   dashboard or the registry does, so this is not unresolvable.
+    /// - `DeprecationToggled` — `apply` writes it.
+    pub fn drift_tier(&self) -> crate::diff::DriftTier {
+        use crate::diff::DriftTier;
+        match self.op {
+            CustomAttributeOp::Unchanged => DriftTier::None,
+            CustomAttributeOp::PresentInGitOnly => DriftTier::ReportOnly,
+            CustomAttributeOp::UnregisteredInGit
+            | CustomAttributeOp::MetadataOnly
+            | CustomAttributeOp::DeprecationToggled { .. } => DriftTier::Gating,
+        }
+    }
 }
 
 /// Compare a local registry against a remote (Braze) attribute set and
@@ -425,5 +458,57 @@ mod tests {
         let remote = vec![attr("x", false, Some("desc"))];
         let diffs = diff(Some(&registry), &remote);
         assert!(diffs[0].hints.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // drift tiers (#115)
+    // -----------------------------------------------------------------
+
+    fn tier_of(op: CustomAttributeOp) -> crate::diff::DriftTier {
+        CustomAttributeDiff {
+            name: "x".into(),
+            op,
+            hints: vec![],
+        }
+        .drift_tier()
+    }
+
+    /// The whole point of #115: an attribute declared in a registry that
+    /// covers more than one workspace is not drift anyone can close.
+    #[test]
+    fn present_in_git_only_is_report_only() {
+        assert_eq!(
+            tier_of(CustomAttributeOp::PresentInGitOnly),
+            crate::diff::DriftTier::ReportOnly
+        );
+    }
+
+    /// The states that must keep gating. `UnregisteredInGit` and
+    /// `MetadataOnly` are equally unwritable by `apply`, so "braze-sync
+    /// cannot write it" must not be what decides the tier.
+    #[test]
+    fn every_other_changed_state_gates() {
+        for op in [
+            CustomAttributeOp::UnregisteredInGit,
+            CustomAttributeOp::MetadataOnly,
+            CustomAttributeOp::DeprecationToggled {
+                from: false,
+                to: true,
+            },
+        ] {
+            assert_eq!(
+                tier_of(op.clone()),
+                crate::diff::DriftTier::Gating,
+                "{op:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unchanged_is_not_drift() {
+        assert_eq!(
+            tier_of(CustomAttributeOp::Unchanged),
+            crate::diff::DriftTier::None
+        );
     }
 }

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -84,16 +84,18 @@ impl<T> DiffOp<T> {
 /// and all Tag drift, both of which a CI gate must keep failing on.
 ///
 /// The rule for [`DriftTier::ReportOnly`] is deliberately narrow: a
-/// state qualifies only when a *correct* configuration produces it, so
-/// that no action by anyone would clear it. "braze-sync cannot write
+/// state qualifies only when a *correct* configuration produces it —
+/// when the same output is what a healthy setup looks like, failing
+/// the build over it carries no information. "braze-sync cannot write
 /// it" is not sufficient — most unwritable drift still means a human
 /// must go do something, in the Braze dashboard or in Git.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DriftTier {
     /// No change. Not drift at all.
     None,
-    /// Real disagreement, but one a correct setup produces and nobody
-    /// can resolve. Listed in every output; does not raise exit 2.
+    /// Real disagreement, but one a correct setup produces — so it
+    /// cannot be told apart from a mistake by looking. Listed in every
+    /// output; does not raise exit 2.
     ReportOnly,
     /// Drift a human must act on. Raises exit 2 under `--fail-on-drift`.
     Gating,
@@ -248,9 +250,9 @@ impl DiffSummary {
     }
 
     /// Count of diffs that raise exit 2 under `--fail-on-drift`. A
-    /// subset of [`Self::changed_count`]: the difference is drift no
-    /// action by anyone can clear, which stays in every listing but
-    /// must not keep a scheduled CI job permanently red.
+    /// subset of [`Self::changed_count`]: the difference is drift a
+    /// correct setup produces, which stays in every listing but must
+    /// not keep a scheduled CI job permanently red.
     pub fn gating_drift_count(&self) -> usize {
         self.diffs
             .iter()
@@ -339,7 +341,5 @@ mod drift_tier_tests {
         assert_eq!(summary.gating_drift_count(), 1);
         assert_eq!(summary.report_only_drift_count(), 1);
         assert_eq!(summary.in_sync_count(), 1);
-        // The ledger stays whole: nothing is dropped from the listing.
-        assert_eq!(summary.diffs.len(), 3);
     }
 }

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -77,6 +77,28 @@ impl<T> DiffOp<T> {
     }
 }
 
+/// How a changed diff is treated by `diff --fail-on-drift`.
+///
+/// Separate from [`ResourceDiff::is_actionable`], which answers a
+/// different question — "can `apply` push this?" — and excludes orphans
+/// and all Tag drift, both of which a CI gate must keep failing on.
+///
+/// The rule for [`DriftTier::ReportOnly`] is deliberately narrow: a
+/// state qualifies only when a *correct* configuration produces it, so
+/// that no action by anyone would clear it. "braze-sync cannot write
+/// it" is not sufficient — most unwritable drift still means a human
+/// must go do something, in the Braze dashboard or in Git.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriftTier {
+    /// No change. Not drift at all.
+    None,
+    /// Real disagreement, but one a correct setup produces and nobody
+    /// can resolve. Listed in every output; does not raise exit 2.
+    ReportOnly,
+    /// Drift a human must act on. Raises exit 2 under `--fail-on-drift`.
+    Gating,
+}
+
 /// Per-resource-kind diff result.
 #[derive(Debug, Clone)]
 pub enum ResourceDiff {
@@ -168,6 +190,33 @@ impl ResourceDiff {
             _ => false,
         }
     }
+
+    /// Which drift tier this diff falls in. See [`DriftTier`] for the
+    /// rule; the per-kind reasoning is below.
+    pub fn drift_tier(&self) -> DriftTier {
+        if !self.has_changes() {
+            return DriftTier::None;
+        }
+        match self {
+            // The only kind with a report-only state; see
+            // `CustomAttributeDiff::drift_tier`.
+            Self::CustomAttribute(d) => d.drift_tier(),
+            // Orphans: Braze exposes no DELETE, but the resolution is a
+            // human archiving the resource in the dashboard (or
+            // deleting the local file). Somebody must act, so this
+            // gates.
+            //
+            // Tags: `ReferencedButUnregistered` blocks `apply`
+            // pre-flight outright, and `RegisteredButUnreferenced` is a
+            // registry entry whose last user is gone. Both are resolved
+            // entirely in Git plus the dashboard — nothing about them
+            // is unresolvable, so both gate.
+            //
+            // Catalog Schema / Content Block / Email Template: `apply`
+            // writes these directly.
+            _ => DriftTier::Gating,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -196,5 +245,101 @@ impl DiffSummary {
 
     pub fn in_sync_count(&self) -> usize {
         self.diffs.iter().filter(|d| !d.has_changes()).count()
+    }
+
+    /// Count of diffs that raise exit 2 under `--fail-on-drift`. A
+    /// subset of [`Self::changed_count`]: the difference is drift no
+    /// action by anyone can clear, which stays in every listing but
+    /// must not keep a scheduled CI job permanently red.
+    pub fn gating_drift_count(&self) -> usize {
+        self.diffs
+            .iter()
+            .filter(|d| d.drift_tier() == DriftTier::Gating)
+            .count()
+    }
+
+    /// Count of changed diffs that are listed but do not raise exit 2.
+    pub fn report_only_drift_count(&self) -> usize {
+        self.diffs
+            .iter()
+            .filter(|d| d.drift_tier() == DriftTier::ReportOnly)
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod drift_tier_tests {
+    use super::*;
+
+    fn orphan_content_block() -> ResourceDiff {
+        ResourceDiff::ContentBlock(content_block::ContentBlockDiff {
+            name: "legacy_banner".into(),
+            op: DiffOp::Unchanged,
+            text_diff: None,
+            orphan: true,
+        })
+    }
+
+    fn tag(op: tag::TagOp) -> ResourceDiff {
+        ResourceDiff::Tag(tag::TagDiff {
+            name: "promo".into(),
+            op,
+            hints: vec![],
+        })
+    }
+
+    /// An orphan cannot be written by `apply` — Braze exposes no DELETE
+    /// — but archiving it in the dashboard resolves it, so it must keep
+    /// raising exit 2. This is the case that makes `is_actionable()`
+    /// (which excludes orphans) the wrong predicate for the gate.
+    #[test]
+    fn orphans_gate_even_though_apply_cannot_write_them() {
+        let d = orphan_content_block();
+        assert!(!d.is_actionable());
+        assert_eq!(d.drift_tier(), DriftTier::Gating);
+    }
+
+    /// Braze has no tag-mutation API at all, yet both Tag states are
+    /// resolved entirely in Git plus the dashboard. `is_actionable()`
+    /// returns false for every Tag diff; the gate must not follow it.
+    #[test]
+    fn both_tag_states_gate() {
+        for op in [
+            tag::TagOp::ReferencedButUnregistered,
+            tag::TagOp::RegisteredButUnreferenced,
+        ] {
+            let d = tag(op);
+            assert!(!d.is_actionable());
+            assert_eq!(d.drift_tier(), DriftTier::Gating);
+        }
+    }
+
+    #[test]
+    fn unchanged_tag_is_not_drift() {
+        assert_eq!(tag(tag::TagOp::Unchanged).drift_tier(), DriftTier::None);
+    }
+
+    #[test]
+    fn counts_split_changed_into_the_two_tiers() {
+        let report_only = ResourceDiff::CustomAttribute(custom_attribute::CustomAttributeDiff {
+            name: "trial_started_at".into(),
+            op: custom_attribute::CustomAttributeOp::PresentInGitOnly,
+            hints: vec![],
+        });
+        let in_sync = ResourceDiff::ContentBlock(content_block::ContentBlockDiff {
+            name: "promo".into(),
+            op: DiffOp::Unchanged,
+            text_diff: None,
+            orphan: false,
+        });
+        let summary = DiffSummary {
+            diffs: vec![report_only, orphan_content_block(), in_sync],
+        };
+        assert_eq!(summary.changed_count(), 2);
+        assert_eq!(summary.gating_drift_count(), 1);
+        assert_eq!(summary.report_only_drift_count(), 1);
+        assert_eq!(summary.in_sync_count(), 1);
+        // The ledger stays whole: nothing is dropped from the listing.
+        assert_eq!(summary.diffs.len(), 3);
     }
 }

--- a/src/format/fixtures.rs
+++ b/src/format/fixtures.rs
@@ -282,3 +282,25 @@ pub fn custom_attribute_unchanged_with_hint() -> DiffSummary {
         diffs: vec![ResourceDiff::CustomAttribute(ca)],
     }
 }
+
+/// A `PresentInGitOnly` custom attribute next to a genuinely gating
+/// one. Pins the ledger contract from #115: both render, both appear in
+/// `--format json`, and only the second raises exit 2.
+pub fn mixed_drift_tiers() -> DiffSummary {
+    let report_only = CustomAttributeDiff {
+        name: "trial_started_at".into(),
+        op: CustomAttributeOp::PresentInGitOnly,
+        hints: vec![],
+    };
+    let gating = CustomAttributeDiff {
+        name: "plan_tier".into(),
+        op: CustomAttributeOp::UnregisteredInGit,
+        hints: vec![],
+    };
+    DiffSummary {
+        diffs: vec![
+            ResourceDiff::CustomAttribute(report_only),
+            ResourceDiff::CustomAttribute(gating),
+        ],
+    }
+}

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -17,7 +17,7 @@ use crate::diff::custom_attribute::{CustomAttributeDiff, CustomAttributeOp};
 use crate::diff::email_template::EmailTemplateDiff;
 use crate::diff::tag::{TagDiff, TagOp};
 use crate::diff::TextDiffSummary;
-use crate::diff::{DiffOp, DiffSummary, ResourceDiff};
+use crate::diff::{DiffOp, DiffSummary, DriftTier, ResourceDiff};
 use crate::resource::CatalogField;
 use serde::Serialize;
 
@@ -49,6 +49,10 @@ struct JsonSummary {
     in_sync: usize,
     destructive: usize,
     orphan: usize,
+    /// Subset of `changed` that raises exit 2 under `--fail-on-drift`.
+    gating_drift: usize,
+    /// Subset of `changed` that is listed but never raises exit 2.
+    report_only_drift: usize,
 }
 
 #[derive(Serialize)]
@@ -57,11 +61,13 @@ enum JsonDiffEntry {
     CatalogSchema {
         name: String,
         op: JsonOp,
+        drift_tier: JsonDriftTier,
         field_diffs: Vec<JsonFieldDiff>,
     },
     ContentBlock {
         name: String,
         op: JsonOp,
+        drift_tier: JsonDriftTier,
         orphan: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         text_diff: Option<JsonTextDiff>,
@@ -69,6 +75,7 @@ enum JsonDiffEntry {
     EmailTemplate {
         name: String,
         op: JsonOp,
+        drift_tier: JsonDriftTier,
         subject_changed: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         body_html_diff: Option<JsonTextDiff>,
@@ -81,6 +88,7 @@ enum JsonDiffEntry {
         name: String,
         #[serde(flatten)]
         change: JsonCustomAttributeChange,
+        drift_tier: JsonDriftTier,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         hints: Vec<String>,
     },
@@ -88,9 +96,32 @@ enum JsonDiffEntry {
         name: String,
         #[serde(flatten)]
         change: JsonTagChange,
+        drift_tier: JsonDriftTier,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         hints: Vec<String>,
     },
+}
+
+/// How `--fail-on-drift` treats this entry. Present on every entry of
+/// every kind so a consumer can filter without reproducing the per-kind
+/// table: `.diffs[] | select(.drift_tier == "gating")` is exactly the
+/// set that produced exit 2.
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum JsonDriftTier {
+    None,
+    ReportOnly,
+    Gating,
+}
+
+impl From<DriftTier> for JsonDriftTier {
+    fn from(t: DriftTier) -> Self {
+        match t {
+            DriftTier::None => Self::None,
+            DriftTier::ReportOnly => Self::ReportOnly,
+            DriftTier::Gating => Self::Gating,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -154,6 +185,8 @@ impl From<&DiffSummary> for JsonRoot {
                 in_sync: s.in_sync_count(),
                 destructive: s.destructive_count(),
                 orphan: s.orphan_count(),
+                gating_drift: s.gating_drift_count(),
+                report_only_drift: s.report_only_drift_count(),
             },
             diffs: s.diffs.iter().map(JsonDiffEntry::from).collect(),
         }
@@ -162,38 +195,44 @@ impl From<&DiffSummary> for JsonRoot {
 
 impl From<&ResourceDiff> for JsonDiffEntry {
     fn from(d: &ResourceDiff) -> Self {
+        // The tier lives on `ResourceDiff`, not on the per-kind diffs,
+        // so it is resolved here and threaded into each constructor.
+        let tier = d.drift_tier().into();
         match d {
-            ResourceDiff::CatalogSchema(c) => Self::from_catalog_schema(c),
-            ResourceDiff::ContentBlock(c) => Self::from_content_block(c),
-            ResourceDiff::EmailTemplate(c) => Self::from_email_template(c),
-            ResourceDiff::CustomAttribute(c) => Self::from_custom_attribute(c),
-            ResourceDiff::Tag(c) => Self::from_tag(c),
+            ResourceDiff::CatalogSchema(c) => Self::from_catalog_schema(c, tier),
+            ResourceDiff::ContentBlock(c) => Self::from_content_block(c, tier),
+            ResourceDiff::EmailTemplate(c) => Self::from_email_template(c, tier),
+            ResourceDiff::CustomAttribute(c) => Self::from_custom_attribute(c, tier),
+            ResourceDiff::Tag(c) => Self::from_tag(c, tier),
         }
     }
 }
 
 impl JsonDiffEntry {
-    fn from_catalog_schema(c: &CatalogSchemaDiff) -> Self {
+    fn from_catalog_schema(c: &CatalogSchemaDiff, drift_tier: JsonDriftTier) -> Self {
         Self::CatalogSchema {
             name: c.name.clone(),
             op: top_op(&c.op),
+            drift_tier,
             field_diffs: c.field_diffs.iter().filter_map(json_field_diff).collect(),
         }
     }
 
-    fn from_content_block(c: &ContentBlockDiff) -> Self {
+    fn from_content_block(c: &ContentBlockDiff, drift_tier: JsonDriftTier) -> Self {
         Self::ContentBlock {
             name: c.name.clone(),
             op: top_op(&c.op),
+            drift_tier,
             orphan: c.orphan,
             text_diff: c.text_diff.as_ref().map(json_text_diff),
         }
     }
 
-    fn from_email_template(c: &EmailTemplateDiff) -> Self {
+    fn from_email_template(c: &EmailTemplateDiff, drift_tier: JsonDriftTier) -> Self {
         Self::EmailTemplate {
             name: c.name.clone(),
             op: top_op(&c.op),
+            drift_tier,
             subject_changed: c.subject_changed,
             body_html_diff: c.body_html_diff.as_ref().map(json_text_diff),
             body_plaintext_diff: c.body_plaintext_diff.as_ref().map(json_text_diff),
@@ -202,18 +241,20 @@ impl JsonDiffEntry {
         }
     }
 
-    fn from_custom_attribute(c: &CustomAttributeDiff) -> Self {
+    fn from_custom_attribute(c: &CustomAttributeDiff, drift_tier: JsonDriftTier) -> Self {
         Self::CustomAttribute {
             name: c.name.clone(),
             change: json_custom_attribute_change(&c.op),
+            drift_tier,
             hints: c.hints.clone(),
         }
     }
 
-    fn from_tag(c: &TagDiff) -> Self {
+    fn from_tag(c: &TagDiff, drift_tier: JsonDriftTier) -> Self {
         Self::Tag {
             name: c.name.clone(),
             change: json_tag_change(&c.op),
+            drift_tier,
             hints: c.hints.clone(),
         }
     }

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -102,10 +102,11 @@ enum JsonDiffEntry {
     },
 }
 
-/// How `--fail-on-drift` treats this entry. Present on every entry of
-/// every kind so a consumer can filter without reproducing the per-kind
-/// table: `.diffs[] | select(.drift_tier == "gating")` is exactly the
-/// set that produced exit 2.
+/// How `diff --fail-on-drift` treats this entry. Present on every
+/// entry of every kind so a consumer can filter without reproducing the
+/// per-kind table: under that flag, `.diffs[] | select(.drift_tier ==
+/// "gating")` is exactly the set that produced exit 2. (`apply --format
+/// json` emits the same field; `apply` never exits 2 on it.)
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 enum JsonDriftTier {
@@ -195,8 +196,8 @@ impl From<&DiffSummary> for JsonRoot {
 
 impl From<&ResourceDiff> for JsonDiffEntry {
     fn from(d: &ResourceDiff) -> Self {
-        // The tier lives on `ResourceDiff`, not on the per-kind diffs,
-        // so it is resolved here and threaded into each constructor.
+        // `ResourceDiff::drift_tier` owns the per-kind dispatch, so
+        // resolve the tier once here and thread it into each constructor.
         let tier = d.drift_tier().into();
         match d {
             ResourceDiff::CatalogSchema(c) => Self::from_catalog_schema(c, tier),

--- a/src/format/snapshot_tests.rs
+++ b/src/format/snapshot_tests.rs
@@ -163,3 +163,17 @@ fn custom_attribute_unchanged_with_hint_table() {
 fn custom_attribute_unchanged_with_hint_json() {
     insta::assert_snapshot!(JsonFormatter.format(&fixtures::custom_attribute_unchanged_with_hint()));
 }
+
+// =====================================================================
+// drift tiers (#115): report-only drift is listed but does not gate
+// =====================================================================
+
+#[test]
+fn mixed_drift_tiers_table() {
+    insta::assert_snapshot!(TableFormatter::default().format(&fixtures::mixed_drift_tiers()));
+}
+
+#[test]
+fn mixed_drift_tiers_json() {
+    insta::assert_snapshot!(JsonFormatter.format(&fixtures::mixed_drift_tiers()));
+}

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__all_kinds_mixed_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__all_kinds_mixed_json.snap
@@ -8,13 +8,16 @@ expression: "JsonFormatter.format(&fixtures::all_kinds_mixed())"
     "changed": 4,
     "in_sync": 0,
     "destructive": 0,
-    "orphan": 0
+    "orphan": 0,
+    "gating_drift": 4,
+    "report_only_drift": 0
   },
   "diffs": [
     {
       "kind": "catalog_schema",
       "name": "cardiology",
       "op": "modified",
+      "drift_tier": "gating",
       "field_diffs": [
         {
           "op": "added",
@@ -29,6 +32,7 @@ expression: "JsonFormatter.format(&fixtures::all_kinds_mixed())"
       "kind": "content_block",
       "name": "promo",
       "op": "modified",
+      "drift_tier": "gating",
       "orphan": false,
       "text_diff": {
         "additions": 5,
@@ -39,6 +43,7 @@ expression: "JsonFormatter.format(&fixtures::all_kinds_mixed())"
       "kind": "email_template",
       "name": "welcome",
       "op": "unchanged",
+      "drift_tier": "gating",
       "subject_changed": true,
       "body_html_diff": {
         "additions": 20,
@@ -52,7 +57,8 @@ expression: "JsonFormatter.format(&fixtures::all_kinds_mixed())"
       "name": "marketing_segment",
       "op": "deprecation_toggled",
       "from": false,
-      "to": true
+      "to": true,
+      "drift_tier": "gating"
     }
   ]
 }

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__catalog_schema_field_diffs_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__catalog_schema_field_diffs_json.snap
@@ -8,13 +8,16 @@ expression: "JsonFormatter.format(&fixtures::catalog_schema_with_mixed_field_dif
     "changed": 1,
     "in_sync": 0,
     "destructive": 1,
-    "orphan": 0
+    "orphan": 0,
+    "gating_drift": 1,
+    "report_only_drift": 0
   },
   "diffs": [
     {
       "kind": "catalog_schema",
       "name": "cardiology",
       "op": "modified",
+      "drift_tier": "gating",
       "field_diffs": [
         {
           "op": "modified",

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__catalog_schema_unchanged_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__catalog_schema_unchanged_json.snap
@@ -8,13 +8,16 @@ expression: "JsonFormatter.format(&fixtures::catalog_schema_unchanged())"
     "changed": 0,
     "in_sync": 1,
     "destructive": 0,
-    "orphan": 0
+    "orphan": 0,
+    "gating_drift": 0,
+    "report_only_drift": 0
   },
   "diffs": [
     {
       "kind": "catalog_schema",
       "name": "stable",
       "op": "unchanged",
+      "drift_tier": "none",
       "field_diffs": []
     }
   ]

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_added_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_added_json.snap
@@ -8,13 +8,16 @@ expression: "JsonFormatter.format(&fixtures::content_block_added())"
     "changed": 1,
     "in_sync": 0,
     "destructive": 0,
-    "orphan": 0
+    "orphan": 0,
+    "gating_drift": 1,
+    "report_only_drift": 0
   },
   "diffs": [
     {
       "kind": "content_block",
       "name": "fresh_promo",
       "op": "added",
+      "drift_tier": "gating",
       "orphan": false
     }
   ]

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_body_modified_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_body_modified_json.snap
@@ -8,13 +8,16 @@ expression: "JsonFormatter.format(&fixtures::content_block_body_modified())"
     "changed": 1,
     "in_sync": 0,
     "destructive": 0,
-    "orphan": 0
+    "orphan": 0,
+    "gating_drift": 1,
+    "report_only_drift": 0
   },
   "diffs": [
     {
       "kind": "content_block",
       "name": "promo",
       "op": "modified",
+      "drift_tier": "gating",
       "orphan": false,
       "text_diff": {
         "additions": 1,

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_orphan_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__content_block_orphan_json.snap
@@ -8,13 +8,16 @@ expression: "JsonFormatter.format(&fixtures::content_block_orphan())"
     "changed": 1,
     "in_sync": 0,
     "destructive": 0,
-    "orphan": 1
+    "orphan": 1,
+    "gating_drift": 1,
+    "report_only_drift": 0
   },
   "diffs": [
     {
       "kind": "content_block",
       "name": "legacy_promo",
       "op": "unchanged",
+      "drift_tier": "gating",
       "orphan": true
     }
   ]

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__custom_attribute_unchanged_with_hint_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__custom_attribute_unchanged_with_hint_json.snap
@@ -8,13 +8,16 @@ expression: "JsonFormatter.format(&fixtures::custom_attribute_unchanged_with_hin
     "changed": 0,
     "in_sync": 1,
     "destructive": 0,
-    "orphan": 0
+    "orphan": 0,
+    "gating_drift": 0,
+    "report_only_drift": 0
   },
   "diffs": [
     {
       "kind": "custom_attribute",
       "name": "visit_count",
       "op": "unchanged",
+      "drift_tier": "none",
       "hints": [
         "type mismatch: local number vs Braze string (run export to update)"
       ]

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__empty_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__empty_json.snap
@@ -8,7 +8,9 @@ expression: "JsonFormatter.format(&fixtures::empty())"
     "changed": 0,
     "in_sync": 0,
     "destructive": 0,
-    "orphan": 0
+    "orphan": 0,
+    "gating_drift": 0,
+    "report_only_drift": 0
   },
   "diffs": []
 }

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mixed_drift_tiers_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mixed_drift_tiers_json.snap
@@ -1,0 +1,29 @@
+---
+source: src/format/snapshot_tests.rs
+expression: "JsonFormatter.format(&fixtures::mixed_drift_tiers())"
+---
+{
+  "version": 1,
+  "summary": {
+    "changed": 2,
+    "in_sync": 0,
+    "destructive": 0,
+    "orphan": 0,
+    "gating_drift": 1,
+    "report_only_drift": 1
+  },
+  "diffs": [
+    {
+      "kind": "custom_attribute",
+      "name": "trial_started_at",
+      "op": "present_in_git_only",
+      "drift_tier": "report_only"
+    },
+    {
+      "kind": "custom_attribute",
+      "name": "plan_tier",
+      "op": "unregistered_in_git",
+      "drift_tier": "gating"
+    }
+  ]
+}

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mixed_drift_tiers_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mixed_drift_tiers_table.snap
@@ -10,4 +10,4 @@ expression: "TableFormatter::default().format(&fixtures::mixed_drift_tiers())"
 
 Summary: 2 changed, 0 in sync, 0 orphan, 0 destructive
 
-ℹ 1 change(s) reported only — not counted by --fail-on-drift. Nothing braze-sync or the Braze dashboard can do resolves them.
+ℹ 1 change(s) reported only — not counted by --fail-on-drift. A correct multi-workspace registry produces them, and the CLI cannot tell those from a typo.

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mixed_drift_tiers_table.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mixed_drift_tiers_table.snap
@@ -1,0 +1,13 @@
+---
+source: src/format/snapshot_tests.rs
+expression: "TableFormatter::default().format(&fixtures::mixed_drift_tiers())"
+---
+🏷  Custom Attribute: trial_started_at
+   ⚠ in Git registry but not in Braze (a typo, or no /users/track traffic in this workspace yet)
+
+🏷  Custom Attribute: plan_tier
+   ⚠ exists in Braze but not in Git registry (run export)
+
+Summary: 2 changed, 0 in sync, 0 orphan, 0 destructive
+
+ℹ 1 change(s) reported only — not counted by --fail-on-drift. Nothing braze-sync or the Braze dashboard can do resolves them.

--- a/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_json.snap
+++ b/src/format/snapshots/braze_sync__format__snapshot_tests__mostly_in_sync_json.snap
@@ -8,25 +8,30 @@ expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
     "changed": 2,
     "in_sync": 6,
     "destructive": 0,
-    "orphan": 1
+    "orphan": 1,
+    "gating_drift": 2,
+    "report_only_drift": 0
   },
   "diffs": [
     {
       "kind": "catalog_schema",
       "name": "stable",
       "op": "unchanged",
+      "drift_tier": "none",
       "field_diffs": []
     },
     {
       "kind": "content_block",
       "name": "footer",
       "op": "unchanged",
+      "drift_tier": "none",
       "orphan": false
     },
     {
       "kind": "content_block",
       "name": "promo",
       "op": "modified",
+      "drift_tier": "gating",
       "orphan": false,
       "text_diff": {
         "additions": 5,
@@ -37,6 +42,7 @@ expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
       "kind": "email_template",
       "name": "receipt",
       "op": "unchanged",
+      "drift_tier": "none",
       "subject_changed": false,
       "metadata_changed": false,
       "orphan": false
@@ -45,6 +51,7 @@ expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
       "kind": "email_template",
       "name": "legacy_welcome",
       "op": "unchanged",
+      "drift_tier": "gating",
       "subject_changed": false,
       "metadata_changed": false,
       "orphan": true
@@ -53,6 +60,7 @@ expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
       "kind": "custom_attribute",
       "name": "visit_count",
       "op": "unchanged",
+      "drift_tier": "none",
       "hints": [
         "type mismatch: local number vs Braze string (run export to update)"
       ]
@@ -60,12 +68,14 @@ expression: "JsonFormatter.format(&fixtures::mostly_in_sync_with_one_change())"
     {
       "kind": "tag",
       "name": "transactional",
-      "op": "unchanged"
+      "op": "unchanged",
+      "drift_tier": "none"
     },
     {
       "kind": "tag",
       "name": "seasonal",
       "op": "unchanged",
+      "drift_tier": "none",
       "hints": [
         "registered in two environments with different casing"
       ]

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -41,17 +41,16 @@ pub fn render(summary: &DiffSummary, only_drift: bool) -> String {
         summary.destructive_count(),
     );
 
-    // Report-only drift is real disagreement that no braze-sync command
-    // and no dashboard action can clear, so `--fail-on-drift` does not
-    // count it. Say so here: otherwise "N changed" next to exit 0 reads
-    // as a bug.
+    // Report-only drift is real disagreement that a correct setup can
+    // produce, so `--fail-on-drift` does not count it. Say so here:
+    // otherwise "N changed" next to exit 0 reads as a bug.
     let report_only = summary.report_only_drift_count();
     if report_only > 0 {
         let _ = writeln!(
             out,
             "\nℹ {report_only} change(s) reported only — not counted by \
-             --fail-on-drift. Nothing braze-sync or the Braze dashboard \
-             can do resolves them.",
+             --fail-on-drift. A correct multi-workspace registry produces \
+             them, and the CLI cannot tell those from a typo.",
         );
     }
 

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -41,6 +41,20 @@ pub fn render(summary: &DiffSummary, only_drift: bool) -> String {
         summary.destructive_count(),
     );
 
+    // Report-only drift is real disagreement that no braze-sync command
+    // and no dashboard action can clear, so `--fail-on-drift` does not
+    // count it. Say so here: otherwise "N changed" next to exit 0 reads
+    // as a bug.
+    let report_only = summary.report_only_drift_count();
+    if report_only > 0 {
+        let _ = writeln!(
+            out,
+            "\nℹ {report_only} change(s) reported only — not counted by \
+             --fail-on-drift. Nothing braze-sync or the Braze dashboard \
+             can do resolves them.",
+        );
+    }
+
     // Always-on orphan report. Braze exposes no DELETE for content blocks
     // or email templates, so braze-sync cannot prune them; surface them as
     // a read-only signal instead of mutating remote state.
@@ -207,7 +221,17 @@ fn render_custom_attribute(out: &mut String, d: &CustomAttributeDiff) {
             out.push_str("   ⚠ exists in Braze but not in Git registry (run export)\n");
         }
         CustomAttributeOp::PresentInGitOnly => {
-            out.push_str("   ⚠ in Git registry but not in Braze (likely a typo)\n");
+            // "likely a typo" assumed the registry mirrors exactly one
+            // workspace. It does not have to: an attribute materializes
+            // on the first `/users/track` call carrying it, so a
+            // registry covering more than one workspace legitimately
+            // describes attributes this one has not seen yet. Hedged
+            // the same way docs/registry-mode.md already is — the CLI
+            // genuinely cannot tell the two apart.
+            out.push_str(
+                "   ⚠ in Git registry but not in Braze \
+                 (a typo, or no /users/track traffic in this workspace yet)\n",
+            );
         }
         CustomAttributeOp::MetadataOnly => {
             out.push_str("   ~ metadata-only change (no API to apply)\n");

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -1306,3 +1306,44 @@ async fn present_in_git_only_hint_does_not_assume_a_single_workspace() {
     );
     assert!(!stdout.contains("likely a typo"), "stdout: {stdout}");
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn only_drift_keeps_report_only_rows_and_trailer() {
+    // `--only-drift` hides in-sync blocks. A report-only row is drift —
+    // it must survive the filter, and so must the trailer that explains
+    // why it did not exit 2.
+    let server = drift_tier_server(json!([])).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_custom_attribute_registry(tmp.path(), LOCAL_REGISTRY);
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "diff",
+                "--resource",
+                "custom_attribute",
+                "--only-drift",
+                "--fail-on-drift",
+                "--no-color",
+            ])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(output.status.code(), Some(0), "expected exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("Custom Attribute: no_traffic_here"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("1 change(s) reported only"),
+        "stdout: {stdout}"
+    );
+}

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -1124,3 +1124,185 @@ async fn diff_only_drift_does_not_affect_json_output() {
     assert_eq!(parsed["diffs"].as_array().unwrap().len(), 1);
     assert_eq!(parsed["summary"]["in_sync"], 1);
 }
+
+// =====================================================================
+// drift tiers under --fail-on-drift (#115)
+//
+// A registry describing more than one Braze workspace legitimately
+// contains attributes this workspace has not seen traffic for. Those
+// must stay in every listing but must not hold a scheduled CI job red,
+// because nothing anyone can run resolves them.
+// =====================================================================
+
+/// Shared setup: one registry entry Braze does not return
+/// (`PresentInGitOnly`), plus `extra` attributes returned by Braze.
+async fn drift_tier_server(extra: serde_json::Value) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/custom_attributes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "attributes": extra
+        })))
+        .mount(&server)
+        .await;
+    server
+}
+
+const LOCAL_REGISTRY: &str = "attributes:\n  - name: no_traffic_here\n    type: string\n";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fail_on_drift_ignores_report_only_drift_but_still_lists_it() {
+    // Braze returns nothing, so the single registry entry is
+    // PresentInGitOnly — the one state no command can clear.
+    let server = drift_tier_server(json!([])).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_custom_attribute_registry(tmp.path(), LOCAL_REGISTRY);
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "diff",
+                "--resource",
+                "custom_attribute",
+                "--fail-on-drift",
+                "--no-color",
+            ])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(output.status.code(), Some(0), "expected exit 0");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // The ledger is the point: suppressing the row would trade a false
+    // alarm for a blind spot.
+    assert!(
+        stdout.contains("Custom Attribute: no_traffic_here"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("1 changed"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("1 change(s) reported only"),
+        "stdout: {stdout}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fail_on_drift_still_exits_two_for_gating_drift() {
+    // `other` is in Braze but not in the registry: UnregisteredInGit,
+    // which `export` resolves, so it keeps gating.
+    let server = drift_tier_server(json!([{"name": "other", "data_type": "string"}])).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_custom_attribute_registry(tmp.path(), LOCAL_REGISTRY);
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args([
+                "diff",
+                "--resource",
+                "custom_attribute",
+                "--fail-on-drift",
+                "--no-color",
+            ])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "expected exit 2");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Mixed run: both rows listed, but only the gating one is counted.
+    assert!(stdout.contains("2 changed"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Custom Attribute: no_traffic_here"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Custom Attribute: other"),
+        "stdout: {stdout}"
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("Drift detected in 1 resource(s)"),
+        "count must be the gating subset, not the total; stderr: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn json_output_carries_the_drift_tier() {
+    let server = drift_tier_server(json!([{"name": "other", "data_type": "string"}])).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_custom_attribute_registry(tmp.path(), LOCAL_REGISTRY);
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "custom_attribute", "--format", "json"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(v["summary"]["changed"], 2);
+    assert_eq!(v["summary"]["gating_drift"], 1);
+    assert_eq!(v["summary"]["report_only_drift"], 1);
+
+    // A consumer must be able to reproduce the gate without
+    // reimplementing the per-kind table.
+    let tier_of = |name: &str| -> String {
+        v["diffs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|d| d["name"] == name)
+            .unwrap_or_else(|| panic!("{name} missing from JSON: {stdout}"))["drift_tier"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+    assert_eq!(tier_of("no_traffic_here"), "report_only");
+    assert_eq!(tier_of("other"), "gating");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn present_in_git_only_hint_does_not_assume_a_single_workspace() {
+    let server = drift_tier_server(json!([])).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), &server.uri());
+    write_local_custom_attribute_registry(tmp.path(), LOCAL_REGISTRY);
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env("BRAZE_API_KEY", "test-key")
+            .args(["--config", config_path.to_str().unwrap()])
+            .args(["diff", "--resource", "custom_attribute", "--no-color"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("no /users/track traffic in this workspace yet"),
+        "stdout: {stdout}"
+    );
+    assert!(!stdout.contains("likely a typo"), "stdout: {stdout}");
+}


### PR DESCRIPTION
## Summary

`diff --fail-on-drift` gated on `changed_count()`, so it exited 2 for every difference it could print — including the one state a correct setup produces and that no command can clear: a Custom Attribute declared in the Git registry that Braze does not have. There is no create endpoint for Custom Attributes (one materializes on the first `/users/track` call carrying it), so a registry describing more than one workspace holds such entries by construction, and the scheduled drift check `docs/integration.md` recommends was red every day.

This PR introduces `DriftTier { None, ReportOnly, Gating }` on `ResourceDiff` and gates on the gating tier.

| state | exit 2? | why |
|---|---|---|
| `custom_attribute` `PresentInGitOnly` | **no** | a correct multi-workspace registry produces it; the CLI cannot tell it from a typo |
| `custom_attribute` `UnregisteredInGit` | yes | registry incomplete; `export` resolves it |
| `custom_attribute` `MetadataOnly` | yes | descriptions genuinely disagree; a human edits one side |
| `custom_attribute` `DeprecationToggled` | yes | `apply` writes it |
| orphan (`content_block` / `email_template`) | yes | no DELETE endpoint, but a human archives it in the dashboard |
| Tag `ReferencedButUnregistered` / `RegisteredButUnreferenced` | yes | resolved entirely in Git + dashboard |
| everything else | yes | `apply` writes it |

The criterion is "does a correct configuration produce this output", not "can braze-sync write it" — which is also why `is_actionable()` was not reused as the gate: it answers the second question and excludes orphans and all Tag drift, both of which CI must keep failing on.

## What does not change

- The ledger. Report-only rows stay in the table, in `--format json`, and in `changed_count()`. The table gains a one-line note when any exist, so `N changed` next to exit 0 does not read as a bug.
- The exit-code set. No new code; only what qualifies for `2` narrowed.
- `apply`. It already used `actionable_count()`; untouched.

## What does change, stated plainly

- A pipeline that relied on exit 2 to catch a registry typo — or an attribute somebody removed on the Braze side, or a `/custom_attributes` response that came back short without erroring — goes green after upgrading. All land in `PresentInGitOnly`, and braze-sync cannot tell them from an attribute awaiting traffic. The row is still printed; the signal moved from the exit code to the output.
- `DriftDetected.count` is now the gating subset, so the number matches what the error claims.
- `--format json` gains `drift_tier` (`gating` / `report_only` / `none`) on every entry of every kind, plus `summary.gating_drift` and `summary.report_only_drift`. Additive; schema stays `version: 1`. `[.diffs[] | select(.drift_tier == "gating")] | length` reproduces the gate without reimplementing the table.
- `likely a typo` → `(a typo, or no /users/track traffic in this workspace yet)`, matching the hedge `docs/registry-mode.md` already made. Same assumption as #106 / #113: an environment name is not a workspace identity.

## Docs

`README.md` §Exit codes, `docs/integration.md` (new section "What counts as drift for exit 2", JSON sample), `docs/registry-mode.md` (the "Three ways out" section #117 added now describes the landed behaviour), `docs/orphan-tracking.md` (JSON sample), `CHANGELOG.md` (this entry, and the #117 entry's forward reference).

## Tests

`cargo test --all`: **699 passed, 0 failed** (685 on `main`, +14): 3 unit on `CustomAttributeDiff::drift_tier`, 4 unit on `ResourceDiff::drift_tier` / the summary counts (incl. orphan and both Tag states asserted `!is_actionable() && Gating` so neither predicate can be rewritten in terms of the other), 2 snapshot (table + JSON, mixed tiers), 5 CLI integration (report-only → exit 0 with the row listed; gating → exit 2 with count = gating subset; JSON carries the tier; hint wording; `--only-drift` keeps the report-only row and the trailer). Ten existing JSON snapshots updated for the additive fields.

Mutation check: five deliberate breaks (gate on `changed_count`; `MetadataOnly` → report-only; orphans → report-only; count = total; revert the hint) each made the intended test fail.

clippy and fmt clean.

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `diff --fail-on-drift` now distinguishes gating drift from report-only drift.
  * Report-only drift remains visible but no longer causes exit code 2.
  * JSON output now includes drift tiers and separate gating/report-only counts.
  * Custom attributes absent from Braze include clearer guidance about missing traffic.

* **Documentation**
  * Updated README and integration, registry, and orphan-tracking documentation to explain drift tiers, CI behavior, and revised output.

* **Bug Fixes**
  * Corrected messaging that previously implied all Git-only attributes were likely typos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->