### PR TITLE
config: scope exclude_patterns to one environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,8 +131,9 @@ file formats, JSON output, exit codes) for the full v1.x line.
   block it was told to leave alone. `validate` now honors `--env`,
   which it parsed and ignored before — so `validate --env <undeclared>`
   is now the config error every other command already made it, where
-  it used to run against `default_environment` and pass. Nothing here adds an include/allowlist —
-  a resource is either matched by a pattern or managed.
+  it used to run against `default_environment` and pass. Nothing here
+  adds an include/allowlist — a resource is either matched by a pattern
+  or managed.
 - **`export --prune`.** Restores the previous rebuild for the case where
   it is what you mean: drop every Custom Attribute registry entry the
   queried workspace does not return, and report how many. It affects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,8 +129,9 @@ file formats, JSON output, exit codes) for the full v1.x line.
   keys) rather than under `environments.<env>` (which does not), so an
   older binary refuses a config that uses it instead of applying to the
   block it was told to leave alone. `validate` now honors `--env`,
-  which it parsed and ignored before; with no per-environment patterns
-  its behaviour is unchanged. Nothing here adds an include/allowlist —
+  which it parsed and ignored before — so `validate --env <undeclared>`
+  is now the config error every other command already made it, where
+  it used to run against `default_environment` and pass. Nothing here adds an include/allowlist —
   a resource is either matched by a pattern or managed.
 - **`export --prune`.** Restores the previous rebuild for the case where
   it is what you mean: drop every Custom Attribute registry entry the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,23 @@ file formats, JSON output, exit codes) for the full v1.x line.
 
 ### Added
 
+- **Per-environment `exclude_patterns` (#116).** A resource block now
+  takes `environments.<env>.exclude_patterns`, appended to the kind-level
+  list when `<env>` is the active environment (`--env`, else
+  `default_environment`). It exists for the case where one workspace's
+  copy of a resource cannot be synced and the other's can — a content
+  block authored with the drag-and-drop editor, which Braze refuses to
+  update through the API — without un-managing the namesake in every
+  other environment, which is what a kind-level pattern did. `<env>`
+  must be declared under the top-level `environments` map; every
+  environment's patterns are compiled at load, not only the active
+  one's. The key lives on the resource block (which rejects unknown
+  keys) rather than under `environments.<env>` (which does not), so an
+  older binary refuses a config that uses it instead of applying to the
+  block it was told to leave alone. `validate` now honors `--env`,
+  which it parsed and ignored before; with no per-environment patterns
+  its behaviour is unchanged. Nothing here adds an include/allowlist —
+  a resource is either matched by a pattern or managed.
 - **`export --prune`.** Restores the previous rebuild for the case where
   it is what you mean: drop every Custom Attribute registry entry the
   queried workspace does not return, and report how many. It affects

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,8 @@ optional — omitted entries fall back to the defaults shown below. To
 skip a resource entirely in a workspace, set `enabled: false`.
 
 Every resource sub-block also accepts an optional
-`exclude_patterns: [<regex>, …]` list; see
+`exclude_patterns: [<regex>, …]` list and an optional `environments`
+map that scopes further patterns to one environment; see
 [§ exclude_patterns](#exclude_patterns) below.
 
 #### `catalog_schema`
@@ -95,6 +96,7 @@ Every resource sub-block also accepts an optional
 | `enabled` | bool | `true` |
 | `path` | path | `catalogs/` |
 | `exclude_patterns` | list of regex strings | `[]` |
+| `environments.<env>.exclude_patterns` | list of regex strings | `[]` |
 
 Directory holding one `<catalog>/schema.yaml` per catalog.
 
@@ -105,6 +107,7 @@ Directory holding one `<catalog>/schema.yaml` per catalog.
 | `enabled` | bool | `true` |
 | `path` | path | `content_blocks/` |
 | `exclude_patterns` | list of regex strings | `[]` |
+| `environments.<env>.exclude_patterns` | list of regex strings | `[]` |
 
 Directory of `<name>.liquid` files.
 
@@ -115,6 +118,7 @@ Directory of `<name>.liquid` files.
 | `enabled` | bool | `true` |
 | `path` | path | `email_templates/` |
 | `exclude_patterns` | list of regex strings | `[]` |
+| `environments.<env>.exclude_patterns` | list of regex strings | `[]` |
 
 Directory holding one `<template>/` subdirectory per email template, each
 containing `template.yaml`, `body.html`, and `body.txt`.
@@ -126,6 +130,7 @@ containing `template.yaml`, `body.html`, and `body.txt`.
 | `enabled` | bool | `true` |
 | `path` | path | `custom_attributes/registry.yaml` |
 | `exclude_patterns` | list of regex strings | `[]` |
+| `environments.<env>.exclude_patterns` | list of regex strings | `[]` |
 
 A single-file registry — see [registry-mode.md](registry-mode.md).
 
@@ -136,6 +141,7 @@ A single-file registry — see [registry-mode.md](registry-mode.md).
 | `enabled` | bool | `false` |
 | `path` | path | `tags/registry.yaml` |
 | `exclude_patterns` | list of regex strings | `[]` |
+| `environments.<env>.exclude_patterns` | list of regex strings | `[]` |
 
 A single-file registry of workspace tags. **Opt-in:** omitting
 `resources.tag` from your config leaves tag tracking off so existing
@@ -195,6 +201,46 @@ custom_attribute:
     - "^(hoge|hack)$"   # developer leftovers
     - "^test_"          # anything prefixed test_
 ```
+
+#### Scoping a pattern to one environment
+
+`exclude_patterns` on the resource block applies to every environment.
+To exclude a name in one environment only, put the pattern under
+`environments.<env>.exclude_patterns` on the same resource block; the
+active environment's list (picked by `--env`, else
+`default_environment`) is appended to the kind-level list, and a name
+matching either is excluded. The other environments keep managing the
+name.
+
+```yaml
+content_block:
+  path: content_blocks/
+  exclude_patterns:
+    - "^test_"          # every environment
+  environments:
+    prod:
+      exclude_patterns:
+        - "^footer$"    # prod only
+```
+
+The case this exists for: Braze refuses API updates to content blocks
+authored with the drag-and-drop editor (`HTTP 400: DND Content blocks
+are not allowed to be updated from the API`). Whether a block is DND is
+a property of one workspace's copy, so `prod`'s `footer` may need
+excluding while `dev`'s `footer` — ordinary HTML — should stay
+drift-checked. A kind-level `^footer$` would un-manage both.
+
+`<env>` must be a key of the top-level `environments` map; an
+undeclared name is a config error (exit `3`). Every environment's
+patterns are compiled at load, not just the active one's, so a bad
+regex under `prod` fails a `dev` run too. `validate` honors `--env` for
+this the same way the other commands do — it needs no API key either
+way.
+
+The map lives on the resource block rather than under
+`environments.<env>` deliberately: the resource block rejects unknown
+keys, so a `braze-sync` older than this key refuses the whole file
+instead of silently applying to the block you excluded.
 
 ### `naming` (optional)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -141,7 +141,7 @@ pub async fn run() -> i32 {
     // it as a pre-merge check. All other commands fall through to the
     // env-resolution stage below.
     if let Command::Validate(args) = &cli.command {
-        return finish(validate::run(args, &cfg, &config_dir).await);
+        return finish(validate::run(args, &cfg, cli.env.as_deref(), &config_dir).await);
     }
 
     // Templatize is local-only too — dispatch alongside validate

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -33,8 +33,19 @@ struct ValidationIssue {
     message: String,
 }
 
-pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> anyhow::Result<()> {
+pub async fn run(
+    args: &ValidateArgs,
+    cfg: &ConfigFile,
+    env_override: Option<&str>,
+    config_dir: &Path,
+) -> anyhow::Result<()> {
     let kinds = selected_kinds(args.resource, &cfg.resources);
+    // Same environment pick as every other command (`--env`, else
+    // `default_environment`) so per-environment excludes skip the same
+    // names here that `diff`/`apply` would skip — without resolving the
+    // API key, which validate must keep not needing.
+    let env_name = cfg.environment_name(env_override)?;
+    let mut excludes_by_kind = cfg.excludes_for_environment(&env_name)?;
 
     let mut issues: Vec<ValidationIssue> = Vec::new();
 
@@ -42,7 +53,7 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
         match kind {
             ResourceKind::CatalogSchema => {
                 let catalogs_root = config_dir.join(&cfg.resources.catalog_schema.path);
-                let excludes = compile_kind_excludes(cfg, kind)?;
+                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
                 validate_catalog_schemas(
                     &catalogs_root,
                     cfg.naming.catalog_name_pattern.as_deref(),
@@ -52,7 +63,7 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
             }
             ResourceKind::ContentBlock => {
                 let content_blocks_root = config_dir.join(&cfg.resources.content_block.path);
-                let excludes = compile_kind_excludes(cfg, kind)?;
+                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
                 validate_content_blocks(
                     &content_blocks_root,
                     cfg.naming.content_block_name_pattern.as_deref(),
@@ -62,12 +73,12 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
             }
             ResourceKind::EmailTemplate => {
                 let email_templates_root = config_dir.join(&cfg.resources.email_template.path);
-                let excludes = compile_kind_excludes(cfg, kind)?;
+                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
                 validate_email_templates(&email_templates_root, &excludes, &mut issues)?;
             }
             ResourceKind::CustomAttribute => {
                 let registry_path = config_dir.join(&cfg.resources.custom_attribute.path);
-                let excludes = compile_kind_excludes(cfg, kind)?;
+                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
                 validate_custom_attributes(
                     &registry_path,
                     cfg.naming.custom_attribute_name_pattern.as_deref(),
@@ -77,7 +88,7 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
             }
             ResourceKind::Tag => {
                 let registry_path = config_dir.join(&cfg.resources.tag.path);
-                let excludes = compile_kind_excludes(cfg, kind)?;
+                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
                 validate_tags(
                     cfg,
                     config_dir,
@@ -101,13 +112,6 @@ pub async fn run(args: &ValidateArgs, cfg: &ConfigFile, config_dir: &Path) -> an
     }
 
     Err(Error::Config(format!("{} validation issue(s) found", issues.len())).into())
-}
-
-fn compile_kind_excludes(cfg: &ConfigFile, kind: ResourceKind) -> anyhow::Result<Vec<Regex>> {
-    Ok(crate::config::compile_exclude_patterns(
-        &cfg.resources.for_kind(kind).exclude_patterns,
-        kind.as_str(),
-    )?)
 }
 
 /// Try to open a resource root directory. Returns `None` (and pushes an

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -53,7 +53,9 @@ pub async fn run(
         match kind {
             ResourceKind::CatalogSchema => {
                 let catalogs_root = config_dir.join(&cfg.resources.catalog_schema.path);
-                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
+                let excludes = excludes_by_kind
+                    .remove(&kind)
+                    .expect("excludes_for_environment inserts every kind");
                 validate_catalog_schemas(
                     &catalogs_root,
                     cfg.naming.catalog_name_pattern.as_deref(),
@@ -63,7 +65,9 @@ pub async fn run(
             }
             ResourceKind::ContentBlock => {
                 let content_blocks_root = config_dir.join(&cfg.resources.content_block.path);
-                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
+                let excludes = excludes_by_kind
+                    .remove(&kind)
+                    .expect("excludes_for_environment inserts every kind");
                 validate_content_blocks(
                     &content_blocks_root,
                     cfg.naming.content_block_name_pattern.as_deref(),
@@ -73,12 +77,16 @@ pub async fn run(
             }
             ResourceKind::EmailTemplate => {
                 let email_templates_root = config_dir.join(&cfg.resources.email_template.path);
-                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
+                let excludes = excludes_by_kind
+                    .remove(&kind)
+                    .expect("excludes_for_environment inserts every kind");
                 validate_email_templates(&email_templates_root, &excludes, &mut issues)?;
             }
             ResourceKind::CustomAttribute => {
                 let registry_path = config_dir.join(&cfg.resources.custom_attribute.path);
-                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
+                let excludes = excludes_by_kind
+                    .remove(&kind)
+                    .expect("excludes_for_environment inserts every kind");
                 validate_custom_attributes(
                     &registry_path,
                     cfg.naming.custom_attribute_name_pattern.as_deref(),
@@ -88,7 +96,9 @@ pub async fn run(
             }
             ResourceKind::Tag => {
                 let registry_path = config_dir.join(&cfg.resources.tag.path);
-                let excludes = excludes_by_kind.remove(&kind).unwrap_or_default();
+                let excludes = excludes_by_kind
+                    .remove(&kind)
+                    .expect("excludes_for_environment inserts every kind");
                 validate_tags(
                     cfg,
                     config_dir,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -528,8 +528,10 @@ resources:
         let f = write_config(TWO_ENVS_WITH_SCOPED_EXCLUDE);
         let cfg = ConfigFile::load(f.path()).unwrap();
         assert_eq!(cfg.environment_name(None).unwrap(), "a");
-        let ex = cfg.excludes_for_environment("b").unwrap();
-        assert!(!is_excluded("foo", &ex[&ResourceKind::ContentBlock]));
+        let a = cfg.excludes_for_environment("a").unwrap();
+        assert!(is_excluded("foo", &a[&ResourceKind::ContentBlock]));
+        let b = cfg.excludes_for_environment("b").unwrap();
+        assert!(!is_excluded("foo", &b[&ResourceKind::ContentBlock]));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,7 @@ pub mod schema;
 
 pub use schema::{
     ApplyOrder, ConfigFile, Defaults, EnvironmentConfig, NamingConfig, ResourceConfig,
-    ResourcesConfig,
+    ResourceEnvironmentConfig, ResourcesConfig,
 };
 
 use crate::error::{Error, Result};
@@ -41,7 +41,8 @@ pub struct ResolvedConfig {
     pub api_key: SecretString,
     pub resources: ResourcesConfig,
     pub naming: NamingConfig,
-    /// Compiled `exclude_patterns` per resource kind. Populated by
+    /// Compiled `exclude_patterns` per resource kind — the kind-level
+    /// list plus the active environment's. Populated by
     /// [`ConfigFile::resolve_with`] so callers can look up a `&[Regex]`
     /// without recompiling on every invocation.
     pub excludes: HashMap<ResourceKind, Vec<Regex>>,
@@ -142,12 +143,68 @@ impl ConfigFile {
             }
         }
         // Compile every resource's exclude_patterns at load time so
-        // malformed regexes fail fast instead of at first use.
+        // malformed regexes fail fast instead of at first use — the
+        // per-environment lists too, not just the active environment's,
+        // so a typo in `prod`'s list is caught by a `dev` run.
         for kind in ResourceKind::all() {
             let rc = self.resources.for_kind(*kind);
             compile_exclude_patterns(&rc.exclude_patterns, kind.as_str())?;
+            for (env_name, env_rc) in &rc.environments {
+                if !self.environments.contains_key(env_name) {
+                    return Err(Error::Config(format!(
+                        "resources.{}.environments.{env_name}: not declared in the \
+                         top-level environments map",
+                        kind.as_str()
+                    )));
+                }
+                compile_exclude_patterns(
+                    &env_rc.exclude_patterns,
+                    &format!("{}.environments.{env_name}", kind.as_str()),
+                )?;
+            }
         }
         Ok(())
+    }
+
+    /// The environment a run targets: `env_override` (the `--env` flag)
+    /// when given, else `default_environment`. Errors on an undeclared
+    /// name so the caller never has to special-case it.
+    pub fn environment_name(&self, env_override: Option<&str>) -> Result<String> {
+        let env_name = env_override
+            .map(str::to_string)
+            .unwrap_or_else(|| self.default_environment.clone());
+        if !self.environments.contains_key(&env_name) {
+            let known: Vec<&str> = self.environments.keys().map(String::as_str).collect();
+            return Err(Error::Config(format!(
+                "unknown environment '{}'; declared: [{}]",
+                env_name,
+                known.join(", ")
+            )));
+        }
+        Ok(env_name)
+    }
+
+    /// Compiled exclude patterns per kind for `env_name`: the kind-level
+    /// list followed by that environment's own. Shared by
+    /// [`Self::resolve_with`] and `validate`, which runs before
+    /// environment resolution because it needs no API key.
+    pub fn excludes_for_environment(
+        &self,
+        env_name: &str,
+    ) -> Result<HashMap<ResourceKind, Vec<Regex>>> {
+        let mut excludes = HashMap::new();
+        for kind in ResourceKind::all() {
+            let rc = self.resources.for_kind(*kind);
+            let mut patterns = compile_exclude_patterns(&rc.exclude_patterns, kind.as_str())?;
+            if let Some(env_rc) = rc.environments.get(env_name) {
+                patterns.extend(compile_exclude_patterns(
+                    &env_rc.exclude_patterns,
+                    &format!("{}.environments.{env_name}", kind.as_str()),
+                )?);
+            }
+            excludes.insert(*kind, patterns);
+        }
+        Ok(excludes)
     }
 
     /// Resolve to a [`ResolvedConfig`] using the real process environment.
@@ -162,18 +219,8 @@ impl ConfigFile {
         env_override: Option<&str>,
         env_lookup: impl Fn(&str) -> Option<String>,
     ) -> Result<ResolvedConfig> {
-        let env_name = env_override
-            .map(str::to_string)
-            .unwrap_or_else(|| self.default_environment.clone());
-
-        if !self.environments.contains_key(&env_name) {
-            let known: Vec<&str> = self.environments.keys().map(String::as_str).collect();
-            return Err(Error::Config(format!(
-                "unknown environment '{}'; declared: [{}]",
-                env_name,
-                known.join(", ")
-            )));
-        }
+        let env_name = self.environment_name(env_override)?;
+        let excludes = self.excludes_for_environment(&env_name)?;
         let env_cfg = self
             .environments
             .remove(&env_name)
@@ -186,15 +233,6 @@ impl ConfigFile {
                 "environment variable '{}' is set but empty",
                 env_cfg.api_key_env
             )));
-        }
-
-        let mut excludes: HashMap<ResourceKind, Vec<Regex>> = HashMap::new();
-        for kind in ResourceKind::all() {
-            let rc = self.resources.for_kind(*kind);
-            excludes.insert(
-                *kind,
-                compile_exclude_patterns(&rc.exclude_patterns, kind.as_str())?,
-            );
         }
 
         Ok(ResolvedConfig {
@@ -434,6 +472,149 @@ resources:
             }
             other => panic!("expected Config error, got {other:?}"),
         }
+    }
+
+    const TWO_ENVS_WITH_SCOPED_EXCLUDE: &str = r#"
+version: 1
+default_environment: a
+environments:
+  a:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_A_API_KEY
+  b:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_B_API_KEY
+resources:
+  content_block:
+    path: content_blocks/
+    exclude_patterns:
+      - "^shared_"
+    environments:
+      a:
+        exclude_patterns:
+          - "^foo$"
+"#;
+
+    #[test]
+    fn per_environment_excludes_add_to_kind_level_for_the_active_environment_only() {
+        let f = write_config(TWO_ENVS_WITH_SCOPED_EXCLUDE);
+        let lookup = |_: &str| Some("k".to_string());
+
+        let a = ConfigFile::load(f.path())
+            .unwrap()
+            .resolve_with(Some("a"), lookup)
+            .unwrap();
+        let a_ex = a.excludes_for(ResourceKind::ContentBlock);
+        assert!(is_excluded("foo", a_ex));
+        assert!(is_excluded("shared_x", a_ex));
+        assert!(!is_excluded("bar", a_ex));
+
+        let b = ConfigFile::load(f.path())
+            .unwrap()
+            .resolve_with(Some("b"), lookup)
+            .unwrap();
+        let b_ex = b.excludes_for(ResourceKind::ContentBlock);
+        assert!(!is_excluded("foo", b_ex), "b's foo must stay managed");
+        assert!(
+            is_excluded("shared_x", b_ex),
+            "kind-level list applies everywhere"
+        );
+    }
+
+    #[test]
+    fn excludes_for_environment_needs_no_api_key() {
+        // `validate` runs before env resolution; the same pick must be
+        // reachable from the unresolved file.
+        let f = write_config(TWO_ENVS_WITH_SCOPED_EXCLUDE);
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        assert_eq!(cfg.environment_name(None).unwrap(), "a");
+        let ex = cfg.excludes_for_environment("b").unwrap();
+        assert!(!is_excluded("foo", &ex[&ResourceKind::ContentBlock]));
+    }
+
+    #[test]
+    fn rejects_per_environment_exclude_for_undeclared_environment() {
+        let yaml = r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_DEV_API_KEY
+resources:
+  content_block:
+    path: content_blocks/
+    environments:
+      prod:
+        exclude_patterns: ["^foo$"]
+"#;
+        let f = write_config(yaml);
+        let err = ConfigFile::load(f.path()).unwrap_err();
+        match err {
+            Error::Config(msg) => {
+                assert!(
+                    msg.contains("resources.content_block.environments.prod"),
+                    "msg: {msg}"
+                );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_per_environment_exclude_at_load_even_when_inactive() {
+        // `b` is not the default environment; a `dev`-side run must
+        // still refuse the file rather than let prod discover the typo.
+        let yaml = r#"
+version: 1
+default_environment: a
+environments:
+  a:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_A_API_KEY
+  b:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_B_API_KEY
+resources:
+  content_block:
+    path: content_blocks/
+    environments:
+      b:
+        exclude_patterns: ["("]
+"#;
+        let f = write_config(yaml);
+        let err = ConfigFile::load(f.path()).unwrap_err();
+        match err {
+            Error::Config(msg) => {
+                assert!(
+                    msg.contains("content_block.environments.b.exclude_patterns[0]"),
+                    "msg: {msg}"
+                );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_key_under_resource_environment() {
+        // Fail-closed is the reason the key lives under the resource.
+        let yaml = r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_DEV_API_KEY
+resources:
+  content_block:
+    path: content_blocks/
+    environments:
+      dev:
+        include_patterns: ["^foo$"]
+"#;
+        let f = write_config(yaml);
+        let err = ConfigFile::load(f.path()).unwrap_err();
+        assert!(matches!(err, Error::YamlParse { .. }), "got: {err:?}");
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -152,8 +152,8 @@ impl ConfigFile {
             for (env_name, env_rc) in &rc.environments {
                 if !self.environments.contains_key(env_name) {
                     return Err(Error::Config(format!(
-                        "resources.{}.environments.{env_name}: not declared in the \
-                         top-level environments map",
+                        "{}.environments.{env_name}: not declared in the top-level \
+                         environments map",
                         kind.as_str()
                     )));
                 }
@@ -553,7 +553,7 @@ resources:
         match err {
             Error::Config(msg) => {
                 assert!(
-                    msg.contains("resources.content_block.environments.prod"),
+                    msg.contains("content_block.environments.prod: not declared"),
                     "msg: {msg}"
                 );
             }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -92,6 +92,14 @@ pub struct ResourceConfig {
     /// don't produce noise. See `docs/configuration.md §exclude_patterns`.
     #[serde(default)]
     pub exclude_patterns: Vec<String>,
+    /// Per-environment overrides, keyed by a name declared under the
+    /// top-level `environments` map (an undeclared name is a config
+    /// error). Lives here rather than under `environments.<name>` so a
+    /// binary that predates the key rejects the file outright instead
+    /// of silently syncing what the user asked it not to touch — this
+    /// struct is `deny_unknown_fields`, `EnvironmentConfig` is not.
+    #[serde(default)]
+    pub environments: BTreeMap<String, ResourceEnvironmentConfig>,
     /// Apply-time ordering policy. Currently consulted only by
     /// `content_block` apply, which uses `Dependency` to topologically
     /// sort `{{content_blocks.${other}}}` references so a referrer is
@@ -101,6 +109,21 @@ pub struct ResourceConfig {
     /// it on other resource kinds is accepted but inert.
     #[serde(default)]
     pub apply_order: ApplyOrder,
+}
+
+/// Environment-scoped part of a [`ResourceConfig`]. Only exclusion is
+/// scoped today: a resource can exist under the same name in two
+/// workspaces and be syncable in one but not the other (a content block
+/// authored with the drag-and-drop editor cannot be updated through the
+/// API, and DND-ness is a property of one workspace's copy).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceEnvironmentConfig {
+    /// Added to the kind-level `exclude_patterns` when this environment
+    /// is the active one. Same regex dialect and semantics; a name
+    /// matching either list is excluded.
+    #[serde(default)]
+    pub exclude_patterns: Vec<String>,
 }
 
 /// Apply-time ordering policy. `Dependency` topo-sorts content_blocks
@@ -125,6 +148,7 @@ fn default_catalog_schema() -> ResourceConfig {
         enabled: true,
         path: PathBuf::from("catalogs/"),
         exclude_patterns: Vec::new(),
+        environments: BTreeMap::new(),
         apply_order: ApplyOrder::Dependency,
     }
 }
@@ -134,6 +158,7 @@ fn default_content_block() -> ResourceConfig {
         enabled: true,
         path: PathBuf::from("content_blocks/"),
         exclude_patterns: Vec::new(),
+        environments: BTreeMap::new(),
         apply_order: ApplyOrder::Dependency,
     }
 }
@@ -143,6 +168,7 @@ fn default_email_template() -> ResourceConfig {
         enabled: true,
         path: PathBuf::from("email_templates/"),
         exclude_patterns: Vec::new(),
+        environments: BTreeMap::new(),
         apply_order: ApplyOrder::Dependency,
     }
 }
@@ -152,6 +178,7 @@ fn default_custom_attribute() -> ResourceConfig {
         enabled: true,
         path: PathBuf::from("custom_attributes/registry.yaml"),
         exclude_patterns: Vec::new(),
+        environments: BTreeMap::new(),
         apply_order: ApplyOrder::Dependency,
     }
 }
@@ -163,6 +190,7 @@ fn default_tag() -> ResourceConfig {
         enabled: false,
         path: PathBuf::from("tags/registry.yaml"),
         exclude_patterns: Vec::new(),
+        environments: BTreeMap::new(),
         apply_order: ApplyOrder::Dependency,
     }
 }

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -10,8 +10,8 @@ mod common;
 
 use assert_cmd::Command;
 use common::{
-    write_config, write_local_content_block, write_local_custom_attribute_registry,
-    write_local_email_template, write_local_schema,
+    write_config, write_config_with_env_scoped_cb_exclude, write_local_content_block,
+    write_local_custom_attribute_registry, write_local_email_template, write_local_schema,
 };
 use serde_json::json;
 use wiremock::matchers::{method, path, query_param};
@@ -256,6 +256,56 @@ async fn diff_content_block_added_when_remote_missing() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("Content Block: fresh"), "stdout: {stdout}");
     assert!(stdout.contains("+ new content block"), "stdout: {stdout}");
+}
+
+/// A name excluded in environment `a` only is skipped there and still
+/// diffed in `b` — the same local file, the same remote, only `--env`
+/// differs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diff_content_block_environment_scoped_exclude_skips_one_environment_only() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/content_blocks/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"content_blocks": []})))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config_with_env_scoped_cb_exclude(tmp.path(), &server.uri(), "^foo$");
+    write_local_content_block(tmp.path(), "foo", "Hello\n");
+
+    let run = |env: &'static str| {
+        let config_path = config_path.clone();
+        tokio::task::spawn_blocking(move || {
+            Command::cargo_bin("braze-sync")
+                .unwrap()
+                .env("BRAZE_API_KEY", "test-key")
+                .args(["--config", config_path.to_str().unwrap(), "--env", env])
+                .args(["diff", "--resource", "content_block", "--fail-on-drift"])
+                .output()
+                .unwrap()
+        })
+    };
+
+    let a = run("a").await.unwrap();
+    assert!(
+        a.status.success(),
+        "a: {}",
+        String::from_utf8_lossy(&a.stderr)
+    );
+    let a_out = String::from_utf8(a.stdout).unwrap();
+    assert!(!a_out.contains("Content Block: foo"), "a stdout: {a_out}");
+
+    let b = run("b").await.unwrap();
+    assert_eq!(
+        b.status.code(),
+        Some(2),
+        "b: {}",
+        String::from_utf8_lossy(&b.stderr)
+    );
+    let b_out = String::from_utf8(b.stdout).unwrap();
+    assert!(b_out.contains("Content Block: foo"), "b stdout: {b_out}");
+    assert!(b_out.contains("+ new content block"), "b stdout: {b_out}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/cli_validate.rs
+++ b/tests/cli_validate.rs
@@ -193,6 +193,28 @@ naming:
     );
 }
 
+/// `--env` used to be parsed and ignored by `validate`; an undeclared
+/// name is now the same config error the other commands give.
+#[test]
+fn validate_rejects_undeclared_env() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = write_config(tmp.path(), Default::default());
+
+    let output = Command::cargo_bin("braze-sync")
+        .unwrap()
+        .args(["--config", config_path.to_str().unwrap(), "--env", "zzz"])
+        .args(["validate"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown environment 'zzz'"),
+        "stderr: {stderr}"
+    );
+}
+
 // =====================================================================
 // Content Block (v0.2.0)
 // =====================================================================

--- a/tests/cli_validate.rs
+++ b/tests/cli_validate.rs
@@ -135,6 +135,64 @@ fn validate_reports_naming_pattern_violation() {
     assert!(stderr.contains("catalog_name_pattern"), "stderr: {stderr}");
 }
 
+/// `validate` picks the environment the way every other command does
+/// (`--env`, else `default_environment`), so an exclude scoped to one
+/// environment silences a naming violation there and nowhere else.
+#[test]
+fn validate_honors_env_flag_for_environment_scoped_excludes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("braze-sync.config.yaml");
+    std::fs::write(
+        &config_path,
+        "version: 1
+default_environment: a
+environments:
+  a:
+    api_endpoint: http://127.0.0.1:1
+    api_key_env: BRAZE_VALIDATE_TEST_NOT_SET
+  b:
+    api_endpoint: http://127.0.0.1:1
+    api_key_env: BRAZE_VALIDATE_TEST_NOT_SET
+resources:
+  content_block:
+    path: content_blocks/
+    environments:
+      a:
+        exclude_patterns: ['^BadName$']
+naming:
+  content_block_name_pattern: '^[a-z][a-z0-9_]*$'
+",
+    )
+    .unwrap();
+    write_local_content_block(tmp.path(), "BadName", "Hello\n");
+
+    let run = |env: &str| {
+        Command::cargo_bin("braze-sync")
+            .unwrap()
+            .env_remove("BRAZE_VALIDATE_TEST_NOT_SET")
+            .args(["--config", config_path.to_str().unwrap(), "--env", env])
+            .args(["validate", "--resource", "content_block"])
+            .output()
+            .unwrap()
+    };
+
+    let a = run("a");
+    assert!(
+        a.status.success(),
+        "a stderr: {}",
+        String::from_utf8_lossy(&a.stderr)
+    );
+
+    let b = run("b");
+    assert_eq!(b.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&b.stderr);
+    assert!(stderr.contains("BadName"), "b stderr: {stderr}");
+    assert!(
+        stderr.contains("content_block_name_pattern"),
+        "b stderr: {stderr}"
+    );
+}
+
 // =====================================================================
 // Content Block (v0.2.0)
 // =====================================================================

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -140,6 +140,39 @@ resources:
     config_path
 }
 
+/// Write a config with two environments, `a` and `b`, that both point
+/// at `server_uri`, plus a `content_block` exclude scoped to `a` only.
+/// The two environments share one mock so a test can show the same
+/// name being skipped in one and managed in the other.
+pub fn write_config_with_env_scoped_cb_exclude(
+    dir: &Path,
+    server_uri: &str,
+    pattern: &str,
+) -> PathBuf {
+    let config_path = dir.join("braze-sync.config.yaml");
+    let yaml = format!(
+        "version: 1
+default_environment: a
+environments:
+  a:
+    api_endpoint: {server_uri}
+    api_key_env: BRAZE_API_KEY
+  b:
+    api_endpoint: {server_uri}
+    api_key_env: BRAZE_API_KEY
+resources:
+  content_block:
+    path: content_blocks/
+    environments:
+      a:
+        exclude_patterns:
+          - '{pattern}'
+"
+    );
+    fs::write(&config_path, yaml).unwrap();
+    config_path
+}
+
 /// Write a local tag registry to `<dir>/tags/registry.yaml`.
 pub fn write_local_tag_registry(dir: &Path, yaml_body: &str) {
     let t_dir = dir.join("tags");


### PR DESCRIPTION
Fixes #116

## What

A resource block now takes `environments.<env>.exclude_patterns`, appended to the kind-level `exclude_patterns` when `<env>` is the active environment (`--env`, else `default_environment`):

```yaml
resources:
  content_block:
    path: content_blocks/
    exclude_patterns: ["^test_"]     # every environment
    environments:
      prod:
        exclude_patterns: ["^footer$"]   # prod only
```

Braze refuses API updates to drag-and-drop content blocks, and DND-ness belongs to one workspace's copy. A kind-level `^footer$` un-managed the namesake in every environment — including from `diff`, so a dashboard edit to the HTML copy went unnoticed. Now only the environment that names it skips it.

## Decisions

- **Key lives on the resource block, not under `environments.<env>`.** `ResourceConfig` is `deny_unknown_fields`, `EnvironmentConfig` is not (dropped in #49 for the `values_file` upgrade path). An older binary therefore refuses a config that uses the key instead of silently applying to the block it was told to leave alone. The docs §Strictness inaccuracy this exposes is out of scope here (separate issue).
- **`validate` honors `--env`**, which it parsed and ignored before. It still runs before env resolution and needs no API key: exclude construction moved to `ConfigFile::environment_name` / `excludes_for_environment`, shared with `resolve_with`. `validate --env <undeclared>` is now the config error every other command already gave.
- **Union semantics**: kind-level list always applies; the active environment's list is added. No include/allowlist.
- **Undeclared `<env>` under a resource is a load error**, and every environment's patterns compile at load — a bad regex under `prod` fails a `dev` run.
- v0.x tolerates schema additions (freeze is at v1.0); the placement argument above is the real constraint.

## Tests

`cargo test --all`: **707 passed / 0 failed** (699 on main; +8). clippy / fmt clean.

- config: per-env union for the active env only; `excludes_for_environment` reachable without an API key; undeclared env rejected; invalid regex under an *inactive* env rejected at load; unknown key under `environments.<env>` rejected
- `diff`: same local file, same mock, `--env a` skips `foo` (exit 0 under `--fail-on-drift`), `--env b` reports it (exit 2)
- `validate`: `--env a` silences a naming violation, `--env b` reports it (exit 3); `--env zzz` exits 3

## Docs

`docs/configuration.md` gains the field in every resource table and a "Scoping a pattern to one environment" section; CHANGELOG under `[Unreleased] / Added`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added environment-specific exclusion patterns for resource configurations.
  - Validation and diff operations now apply exclusions based on the selected environment.
  - Invalid or undeclared environments are reported clearly during validation.
- **Documentation**
  - Added configuration guidance and examples for environment-scoped exclusions.
- **Tests**
  - Added coverage for environment-specific exclusions and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->