### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
-## [Unreleased]
+## [0.22.0] — 2026-09-13
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "braze-sync"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "braze-sync"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"


### PR DESCRIPTION
`Cargo.toml` / `Cargo.lock` `0.21.0` → `0.22.0`, and the CHANGELOG's
`[Unreleased]` heading becomes `[0.22.0] — 2026-09-13`. No other
changes — same three-file shape as #114.

## Why minor, not patch

Two additions to the public surface:

- **Per-environment `exclude_patterns`** (#116) —
  `resources.<kind>.environments.<env>.exclude_patterns`, appended to
  the kind-level list for the active environment. Placed on the
  resource block so a v0.21.0 binary refuses a config that uses it
  rather than syncing the block it was told to skip.
- **`export --prune`** (#117) — restores the old "rebuild the registry
  from Braze alone" on request, now that the default keeps entries the
  workspace did not return.

Two behaviour changes worth knowing when upgrading, neither a contract
break:

- `validate --env <undeclared>` now exits 3; it used to ignore `--env`
  and run against `default_environment`.
- `export`'s `custom_attribute` stderr line reads
  `refreshed N from Braze, kept M registry-only entries`; the old
  `exported N attribute(s)` wording is gone. `--format` is inert for
  `export`, so this is its only output surface.

## What else is in it

- **`diff --fail-on-drift` no longer exits 2 for drift a correct setup
  produces** (#115): a Custom Attribute in the registry that Braze does
  not have is report-only. JSON gains `drift_tier` on every entry plus
  `summary.gating_drift` / `report_only_drift`, additive under
  `version: 1`.
- **`export` no longer deletes registry entries** the queried
  workspace did not return (#117, #118); an unparseable registry now
  fails `export` instead of being overwritten; duplicate names collapse
  to one entry the way `diff` already treats them, named on stderr.

## Checks

`cargo test --all` at this tip: 707 passed / 0 failed. Tag `v0.22.0`
after merge triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.22.0.
  * Updated the project’s release metadata and changelog to reflect the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->