### PR TITLE
config: reject unknown keys under environments.<env>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ versions follow [semver](https://semver.org/). Per IMPLEMENTATION.md
 changes; v1.0 freezes the public surface (CLI flags, config schema,
 file formats, JSON output, exit codes) for the full v1.x line.
 
+## [Unreleased]
+
+### Changed
+
+- **`environments.<env>` now rejects unknown keys (#121).** It was the
+  one config block that did not: #49 removed the check so configs still
+  carrying the by-then-deleted `values_file` key would keep loading.
+  That shim outlived its reason and left `docs/configuration.md`
+  §Strictness false — a typo under an environment was silently ignored
+  while the same typo anywhere else failed with a line number. A config
+  that still has `values_file` now fails at load (exit 3) with a pointer
+  to the line; delete the key.
+
 ## [0.22.0] — 2026-09-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ file formats, JSON output, exit codes) for the full v1.x line.
   That shim outlived its reason and left `docs/configuration.md`
   §Strictness false — a typo under an environment was silently ignored
   while the same typo anywhere else failed with a line number. A config
-  that still has `values_file` now fails at load (exit 3) with a pointer
-  to the line; delete the key.
+  that still has `values_file` now fails at load with a pointer to the
+  line, the way every other stray key does; delete the key.
 
 ## [0.22.0] — 2026-09-13
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,7 +241,8 @@ The map lives on the resource block rather than under
 `environments.<env>` deliberately: the resource block has always
 rejected unknown keys, so a `braze-sync` older than this key refuses
 the whole file instead of silently applying to the block you excluded
-(`environments.<env>` only became strict in the release after).
+(`environments.<env>` accepted stray keys until v0.22.0, so a binary
+that old ignores — rather than refuses — a key placed there).
 
 ### `naming` (optional)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,7 +241,7 @@ The map lives on the resource block rather than under
 `environments.<env>` deliberately: the resource block has always
 rejected unknown keys, so a `braze-sync` older than this key refuses
 the whole file instead of silently applying to the block you excluded
-(`environments.<env>` accepted stray keys until v0.22.0, so a binary
+(`environments.<env>` accepted stray keys through v0.22.0, so a binary
 that old ignores — rather than refuses — a key placed there).
 
 ### `naming` (optional)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,9 +238,10 @@ this the same way the other commands do — it needs no API key either
 way.
 
 The map lives on the resource block rather than under
-`environments.<env>` deliberately: the resource block rejects unknown
-keys, so a `braze-sync` older than this key refuses the whole file
-instead of silently applying to the block you excluded.
+`environments.<env>` deliberately: the resource block has always
+rejected unknown keys, so a `braze-sync` older than this key refuses
+the whole file instead of silently applying to the block you excluded
+(`environments.<env>` only became strict in the release after).
 
 ### `naming` (optional)
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -423,6 +423,31 @@ environments:
     }
 
     #[test]
+    fn rejects_unknown_key_under_environment() {
+        // The one struct that was permissive (#49 kept it so for the
+        // removed `values_file` key). A stray key here would otherwise
+        // be the only place in the config file a typo is ignored.
+        let yaml = r#"
+version: 1
+default_environment: dev
+environments:
+  dev:
+    api_endpoint: https://rest.fra-02.braze.eu
+    api_key_env: BRAZE_DEV_API_KEY
+    values_file: values/dev.yaml
+"#;
+        let f = write_config(yaml);
+        let err = ConfigFile::load(f.path()).unwrap_err();
+        match err {
+            Error::YamlParse { source, .. } => {
+                let msg = source.to_string();
+                assert!(msg.contains("values_file"), "msg: {msg}");
+            }
+            other => panic!("expected YamlParse error, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn accepts_exclude_patterns_on_resource_config() {
         let yaml = r#"
 version: 1

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -30,6 +30,7 @@ pub struct ConfigFile {
 pub struct Defaults {}
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EnvironmentConfig {
     pub api_endpoint: Url,
     pub api_key_env: String,
@@ -96,8 +97,9 @@ pub struct ResourceConfig {
     /// top-level `environments` map (an undeclared name is a config
     /// error). Lives here rather than under `environments.<name>` so a
     /// binary that predates the key rejects the file outright instead
-    /// of silently syncing what the user asked it not to touch — this
-    /// struct is `deny_unknown_fields`, `EnvironmentConfig` is not.
+    /// of silently syncing what the user asked it not to touch —
+    /// `EnvironmentConfig` was still permissive when this shipped
+    /// (v0.22.0; closed in #121).
     #[serde(default)]
     pub environments: BTreeMap<String, ResourceEnvironmentConfig>,
     /// Apply-time ordering policy. Currently consulted only by


### PR DESCRIPTION
Fixes #121

## What

`EnvironmentConfig` gets `#[serde(deny_unknown_fields)]` back. It was the one config struct without it: #49 dropped the check so configs still carrying the by-then-removed `environments.<env>.values_file` key would keep loading. That key has been gone for many releases; the shim outlived its reason and left `docs/configuration.md` §Strictness ("at every level") false.

## Effect

- A typo under an environment now fails at load with a line pointer, like a typo anywhere else in the file. Before, it was silently ignored — including a misplaced `api_key: …` sitting unnoticed in the file.
- A config that still has `values_file` now fails at load; delete the key. No shim, per the project's no-backward-compat policy.
- The two places #120 wrote "the resource block is strict, `environments.<env>` is not" (a doc comment on `ResourceConfig.environments`, and `docs/configuration.md` §exclude_patterns) now say when that stopped being true.

Every struct in `src/config/schema.rs` is now `deny_unknown_fields` (`ApplyOrder` is a unit-variant enum, which already rejects unknown values). The `init` scaffold, every test fixture, and every docs example emit only `api_endpoint` / `api_key_env` under an environment.

## Tests

`cargo test --all`: **708 passed / 0 failed** (707 on main; +1). clippy / fmt clean.

- `rejects_unknown_key_under_environment`: the MINIMAL fixture plus `values_file` → `YamlParse` whose message names the key. Fails at base (load succeeds, `unwrap_err` panics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration entries under `environments.<env>` now reject unknown keys instead of silently ignoring them.
  - Invalid configurations identify the unrecognized key and its location, making errors easier to resolve.
  - Configurations containing the removed `values_file` setting now fail during loading.

- **Documentation**
  - Clarified how environment-specific settings behave with older versions, including their handling of unrecognized keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->